### PR TITLE
Implement OrganisationRepository

### DIFF
--- a/src/Herit.Infrastructure/Repositories/OrganisationRepository.cs
+++ b/src/Herit.Infrastructure/Repositories/OrganisationRepository.cs
@@ -1,6 +1,7 @@
 using Herit.Application.Interfaces;
 using Herit.Domain.Entities;
 using Herit.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
 
 namespace Herit.Infrastructure.Repositories;
 
@@ -14,17 +15,35 @@ public class OrganisationRepository : IOrganisationRepository
     }
 
     public Task<Organisation?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
-        => throw new NotImplementedException();
+        => _context.Organisations.FindAsync([id], cancellationToken).AsTask();
 
-    public Task<IEnumerable<Organisation>> ListAsync(CancellationToken cancellationToken = default)
-        => throw new NotImplementedException();
+    public async Task<IEnumerable<Organisation>> ListAsync(CancellationToken cancellationToken = default)
+        => await _context.Organisations.ToListAsync(cancellationToken);
 
-    public Task AddAsync(Organisation organisation, CancellationToken cancellationToken = default)
-        => throw new NotImplementedException();
+    public async Task AddAsync(Organisation organisation, CancellationToken cancellationToken = default)
+    {
+        await _context.Organisations.AddAsync(organisation, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
 
-    public Task UpdateAsync(Organisation organisation, CancellationToken cancellationToken = default)
-        => throw new NotImplementedException();
+    public async Task UpdateAsync(Organisation organisation, CancellationToken cancellationToken = default)
+    {
+        var tracked = _context.ChangeTracker.Entries<Organisation>()
+            .FirstOrDefault(e => e.Entity.Id == organisation.Id);
+        if (tracked is not null)
+            tracked.State = EntityState.Detached;
 
-    public Task DeleteAsync(Guid id, CancellationToken cancellationToken = default)
-        => throw new NotImplementedException();
+        _context.Organisations.Update(organisation);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task DeleteAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var organisation = await _context.Organisations.FindAsync([id], cancellationToken);
+        if (organisation is not null)
+        {
+            _context.Organisations.Remove(organisation);
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+    }
 }

--- a/tests/Herit.Infrastructure.Tests/Herit.Infrastructure.Tests.csproj
+++ b/tests/Herit.Infrastructure.Tests/Herit.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/tests/Herit.Infrastructure.Tests/Repositories/OrganisationRepositoryTests.cs
+++ b/tests/Herit.Infrastructure.Tests/Repositories/OrganisationRepositoryTests.cs
@@ -1,0 +1,104 @@
+using Herit.Domain.Entities;
+using Herit.Infrastructure.Persistence;
+using Herit.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Herit.Infrastructure.Tests.Repositories;
+
+public class OrganisationRepositoryTests : IDisposable
+{
+    private readonly HeritDbContext _context;
+    private readonly OrganisationRepository _repository;
+
+    public OrganisationRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<HeritDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _context = new HeritDbContext(options);
+        _repository = new OrganisationRepository(_context);
+    }
+
+    public void Dispose() => _context.Dispose();
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsOrganisation_WhenExists()
+    {
+        var id = Guid.NewGuid();
+        var org = Organisation.Create(id, "Acme");
+        await _repository.AddAsync(org);
+
+        var result = await _repository.GetByIdAsync(id);
+
+        Assert.NotNull(result);
+        Assert.Equal(id, result.Id);
+        Assert.Equal("Acme", result.Name);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsNull_WhenNotExists()
+    {
+        var result = await _repository.GetByIdAsync(Guid.NewGuid());
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ListAsync_ReturnsAllOrganisations()
+    {
+        await _repository.AddAsync(Organisation.Create(Guid.NewGuid(), "Org A"));
+        await _repository.AddAsync(Organisation.Create(Guid.NewGuid(), "Org B"));
+
+        var result = await _repository.ListAsync();
+
+        Assert.Equal(2, result.Count());
+    }
+
+    [Fact]
+    public async Task AddAsync_PersistsOrganisation()
+    {
+        var id = Guid.NewGuid();
+        var org = Organisation.Create(id, "New Org");
+
+        await _repository.AddAsync(org);
+
+        var persisted = await _context.Organisations.FindAsync(id);
+        Assert.NotNull(persisted);
+        Assert.Equal("New Org", persisted.Name);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_PersistsChanges()
+    {
+        var id = Guid.NewGuid();
+        var org = Organisation.Create(id, "Original");
+        await _repository.AddAsync(org);
+
+        var updated = Organisation.Create(id, "Updated");
+        await _repository.UpdateAsync(updated);
+
+        var persisted = await _context.Organisations.FindAsync(id);
+        Assert.NotNull(persisted);
+        Assert.Equal("Updated", persisted.Name);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_RemovesOrganisation_WhenExists()
+    {
+        var id = Guid.NewGuid();
+        await _repository.AddAsync(Organisation.Create(id, "To Delete"));
+
+        await _repository.DeleteAsync(id);
+
+        var persisted = await _context.Organisations.FindAsync(id);
+        Assert.Null(persisted);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_DoesNotThrow_WhenNotExists()
+    {
+        var exception = await Record.ExceptionAsync(() => _repository.DeleteAsync(Guid.NewGuid()));
+
+        Assert.Null(exception);
+    }
+}


### PR DESCRIPTION
## Description

Implements all methods of `IOrganisationRepository` in `Herit.Infrastructure/Repositories/OrganisationRepository.cs` using EF Core against `HeritDbContext`. Also adds `OrganisationRepositoryTests` covering all five operations using the EF Core InMemory provider.

## Linked Issue

Closes #3

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

7 new xUnit tests exercise `GetByIdAsync`, `ListAsync`, `AddAsync`, `UpdateAsync`, and `DeleteAsync` (including the not-found edge cases). All pass against the InMemory EF provider.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/implement-organisation-repository`)