### PR TITLE
Implement UpdateOrganisation command handler

### DIFF
--- a/src/Herit.Api/Controllers/OrganisationController.cs
+++ b/src/Herit.Api/Controllers/OrganisationController.cs
@@ -1,6 +1,7 @@
 using Herit.Application.Features.Organisation.Commands.CreateDepartment;
 using Herit.Application.Features.Organisation.Commands.DeleteDepartment;
 using Herit.Application.Features.Organisation.Commands.UpdateDepartment;
+using Herit.Application.Features.Organisation.Commands.UpdateOrganisation;
 using Herit.Application.Features.Organisation.Queries.GetDepartmentById;
 using Herit.Application.Features.Organisation.Queries.ListDepartments;
 using MediatR;
@@ -15,6 +16,13 @@ public class OrganisationController : ControllerBase
     private readonly IMediator _mediator;
 
     public OrganisationController(IMediator mediator) => _mediator = mediator;
+
+    [HttpPut("{id:guid}")]
+    public async Task<IActionResult> UpdateOrganisation(Guid id, [FromBody] UpdateOrganisationCommand command, CancellationToken ct)
+    {
+        await _mediator.Send(command with { Id = id }, ct);
+        return NoContent();
+    }
 
     [HttpGet("departments")]
     public async Task<IActionResult> ListDepartments(CancellationToken ct)

--- a/src/Herit.Application/Features/Organisation/Commands/UpdateOrganisation/UpdateOrganisationCommand.cs
+++ b/src/Herit.Application/Features/Organisation/Commands/UpdateOrganisation/UpdateOrganisationCommand.cs
@@ -1,0 +1,27 @@
+using Herit.Application.Interfaces;
+using MediatR;
+
+namespace Herit.Application.Features.Organisation.Commands.UpdateOrganisation;
+
+public record UpdateOrganisationCommand(Guid Id, string Name) : IRequest<Unit>;
+
+public class UpdateOrganisationCommandHandler : IRequestHandler<UpdateOrganisationCommand, Unit>
+{
+    private readonly IOrganisationRepository _repository;
+
+    public UpdateOrganisationCommandHandler(IOrganisationRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<Unit> Handle(UpdateOrganisationCommand request, CancellationToken cancellationToken)
+    {
+        var organisation = await _repository.GetByIdAsync(request.Id, cancellationToken);
+        if (organisation is null)
+            throw new InvalidOperationException($"Organisation '{request.Id}' does not exist.");
+
+        organisation.Update(request.Name);
+        await _repository.UpdateAsync(organisation, cancellationToken);
+        return Unit.Value;
+    }
+}

--- a/src/Herit.Domain/Entities/Organisation.cs
+++ b/src/Herit.Domain/Entities/Organisation.cs
@@ -17,4 +17,9 @@ public class Organisation
             ParentId = parentId
         };
     }
+
+    public void Update(string name)
+    {
+        Name = name;
+    }
 }

--- a/tests/Herit.Application.Tests/Features/Organisation/Commands/UpdateOrganisationCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Organisation/Commands/UpdateOrganisationCommandHandlerTests.cs
@@ -1,0 +1,44 @@
+using Herit.Application.Features.Organisation.Commands.UpdateOrganisation;
+using Herit.Application.Interfaces;
+using NSubstitute;
+using OrganisationEntity = Herit.Domain.Entities.Organisation;
+
+namespace Herit.Application.Tests.Features.Organisation.Commands;
+
+public class UpdateOrganisationCommandHandlerTests
+{
+    private readonly IOrganisationRepository _repository = Substitute.For<IOrganisationRepository>();
+    private readonly UpdateOrganisationCommandHandler _handler;
+
+    public UpdateOrganisationCommandHandlerTests()
+    {
+        _handler = new UpdateOrganisationCommandHandler(_repository);
+    }
+
+    [Fact]
+    public async Task Handle_WithExistingOrganisation_UpdatesNameAndReturnsUnit()
+    {
+        var id = Guid.NewGuid();
+        var organisation = OrganisationEntity.Create(id, "Old Name");
+        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(organisation);
+
+        var command = new UpdateOrganisationCommand(id, "New Name");
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.Equal(MediatR.Unit.Value, result);
+        Assert.Equal("New Name", organisation.Name);
+        await _repository.Received(1).UpdateAsync(organisation, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WithNonExistentOrganisation_ThrowsInvalidOperationException()
+    {
+        var id = Guid.NewGuid();
+        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((OrganisationEntity?)null);
+
+        var command = new UpdateOrganisationCommand(id, "New Name");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await _repository.DidNotReceive().UpdateAsync(Arg.Any<OrganisationEntity>(), Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Description

Implements the `UpdateOrganisationCommand` and `UpdateOrganisationCommandHandler` to update an organisation's name. Adds an `Update` method to the `Organisation` domain entity, exposes a `PUT /api/v1/organisation/{id}` endpoint in the controller, and covers the handler with unit tests.

## Linked Issue

Closes #5

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Two unit tests cover the handler: one for a successful update and one for a non-existent organisation (expects `InvalidOperationException`). All 55 tests pass.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)