### PR TITLE
Implement DeleteOrganisation command handler

### DIFF
--- a/src/Herit.Api/Controllers/OrganisationController.cs
+++ b/src/Herit.Api/Controllers/OrganisationController.cs
@@ -1,5 +1,6 @@
 using Herit.Application.Features.Organisation.Commands.CreateDepartment;
 using Herit.Application.Features.Organisation.Commands.DeleteDepartment;
+using Herit.Application.Features.Organisation.Commands.DeleteOrganisation;
 using Herit.Application.Features.Organisation.Commands.UpdateDepartment;
 using Herit.Application.Features.Organisation.Commands.UpdateOrganisation;
 using Herit.Application.Features.Organisation.Queries.GetDepartmentById;
@@ -21,6 +22,13 @@ public class OrganisationController : ControllerBase
     public async Task<IActionResult> UpdateOrganisation(Guid id, [FromBody] UpdateOrganisationCommand command, CancellationToken ct)
     {
         await _mediator.Send(command with { Id = id }, ct);
+        return NoContent();
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> DeleteOrganisation(Guid id, CancellationToken ct)
+    {
+        await _mediator.Send(new DeleteOrganisationCommand(id), ct);
         return NoContent();
     }
 

--- a/src/Herit.Application/Features/Organisation/Commands/DeleteOrganisation/DeleteOrganisationCommand.cs
+++ b/src/Herit.Application/Features/Organisation/Commands/DeleteOrganisation/DeleteOrganisationCommand.cs
@@ -1,0 +1,26 @@
+using Herit.Application.Interfaces;
+using MediatR;
+
+namespace Herit.Application.Features.Organisation.Commands.DeleteOrganisation;
+
+public record DeleteOrganisationCommand(Guid Id) : IRequest<Unit>;
+
+public class DeleteOrganisationCommandHandler : IRequestHandler<DeleteOrganisationCommand, Unit>
+{
+    private readonly IOrganisationRepository _repository;
+
+    public DeleteOrganisationCommandHandler(IOrganisationRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<Unit> Handle(DeleteOrganisationCommand request, CancellationToken cancellationToken)
+    {
+        var organisation = await _repository.GetByIdAsync(request.Id, cancellationToken);
+        if (organisation is null)
+            throw new InvalidOperationException($"Organisation '{request.Id}' does not exist.");
+
+        await _repository.DeleteAsync(request.Id, cancellationToken);
+        return Unit.Value;
+    }
+}

--- a/tests/Herit.Application.Tests/Features/Organisation/Commands/DeleteOrganisationCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Organisation/Commands/DeleteOrganisationCommandHandlerTests.cs
@@ -1,0 +1,43 @@
+using Herit.Application.Features.Organisation.Commands.DeleteOrganisation;
+using Herit.Application.Interfaces;
+using NSubstitute;
+using OrganisationEntity = Herit.Domain.Entities.Organisation;
+
+namespace Herit.Application.Tests.Features.Organisation.Commands;
+
+public class DeleteOrganisationCommandHandlerTests
+{
+    private readonly IOrganisationRepository _repository = Substitute.For<IOrganisationRepository>();
+    private readonly DeleteOrganisationCommandHandler _handler;
+
+    public DeleteOrganisationCommandHandlerTests()
+    {
+        _handler = new DeleteOrganisationCommandHandler(_repository);
+    }
+
+    [Fact]
+    public async Task Handle_WithExistingOrganisation_DeletesAndReturnsUnit()
+    {
+        var id = Guid.NewGuid();
+        var organisation = OrganisationEntity.Create(id, "Ministry of Finance");
+        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(organisation);
+
+        var command = new DeleteOrganisationCommand(id);
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.Equal(MediatR.Unit.Value, result);
+        await _repository.Received(1).DeleteAsync(id, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WithNonExistentOrganisation_ThrowsInvalidOperationException()
+    {
+        var id = Guid.NewGuid();
+        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((OrganisationEntity?)null);
+
+        var command = new DeleteOrganisationCommand(id);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await _repository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Description

Implements `DeleteOrganisationCommand` and `DeleteOrganisationCommandHandler` to delete an organisation by ID, guarding against non-existent IDs with an `InvalidOperationException`. Adds a `DELETE /api/v1/organisation/{id}` endpoint to the controller.

## Linked Issue

Closes #6

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Two unit tests cover the handler: successful deletion and deletion of a non-existent organisation (expects `InvalidOperationException`). All 57 tests pass.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)