### PR TITLE
Implement GetOrganisationById query handler

### DIFF
--- a/src/Herit.Api/Controllers/OrganisationController.cs
+++ b/src/Herit.Api/Controllers/OrganisationController.cs
@@ -4,6 +4,7 @@ using Herit.Application.Features.Organisation.Commands.DeleteOrganisation;
 using Herit.Application.Features.Organisation.Commands.UpdateDepartment;
 using Herit.Application.Features.Organisation.Commands.UpdateOrganisation;
 using Herit.Application.Features.Organisation.Queries.GetDepartmentById;
+using Herit.Application.Features.Organisation.Queries.GetOrganisationById;
 using Herit.Application.Features.Organisation.Queries.ListDepartments;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
@@ -17,6 +18,13 @@ public class OrganisationController : ControllerBase
     private readonly IMediator _mediator;
 
     public OrganisationController(IMediator mediator) => _mediator = mediator;
+
+    [HttpGet("{id:guid}")]
+    public async Task<IActionResult> GetOrganisationById(Guid id, CancellationToken ct)
+    {
+        var result = await _mediator.Send(new GetOrganisationByIdQuery(id), ct);
+        return result is null ? NotFound() : Ok(result);
+    }
 
     [HttpPut("{id:guid}")]
     public async Task<IActionResult> UpdateOrganisation(Guid id, [FromBody] UpdateOrganisationCommand command, CancellationToken ct)

--- a/src/Herit.Application/Features/Organisation/Queries/GetOrganisationById/GetOrganisationByIdQuery.cs
+++ b/src/Herit.Application/Features/Organisation/Queries/GetOrganisationById/GetOrganisationByIdQuery.cs
@@ -1,0 +1,19 @@
+using Herit.Application.Interfaces;
+using MediatR;
+
+namespace Herit.Application.Features.Organisation.Queries.GetOrganisationById;
+
+public record GetOrganisationByIdQuery(Guid Id) : IRequest<Herit.Domain.Entities.Organisation?>;
+
+public class GetOrganisationByIdQueryHandler : IRequestHandler<GetOrganisationByIdQuery, Herit.Domain.Entities.Organisation?>
+{
+    private readonly IOrganisationRepository _repository;
+
+    public GetOrganisationByIdQueryHandler(IOrganisationRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public Task<Herit.Domain.Entities.Organisation?> Handle(GetOrganisationByIdQuery request, CancellationToken cancellationToken)
+        => _repository.GetByIdAsync(request.Id, cancellationToken);
+}

--- a/tests/Herit.Application.Tests/Features/Organisation/Queries/GetOrganisationByIdQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Organisation/Queries/GetOrganisationByIdQueryHandlerTests.cs
@@ -1,0 +1,42 @@
+using Herit.Application.Features.Organisation.Queries.GetOrganisationById;
+using Herit.Application.Interfaces;
+using NSubstitute;
+using OrganisationEntity = Herit.Domain.Entities.Organisation;
+
+namespace Herit.Application.Tests.Features.Organisation.Queries;
+
+public class GetOrganisationByIdQueryHandlerTests
+{
+    private readonly IOrganisationRepository _repository = Substitute.For<IOrganisationRepository>();
+    private readonly GetOrganisationByIdQueryHandler _handler;
+
+    public GetOrganisationByIdQueryHandlerTests()
+    {
+        _handler = new GetOrganisationByIdQueryHandler(_repository);
+    }
+
+    [Fact]
+    public async Task Handle_WithExistingId_ReturnsOrganisation()
+    {
+        var id = Guid.NewGuid();
+        var organisation = OrganisationEntity.Create(id, "Ministry of Finance");
+        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(organisation);
+
+        var result = await _handler.Handle(new GetOrganisationByIdQuery(id), CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(id, result.Id);
+        Assert.Equal("Ministry of Finance", result.Name);
+    }
+
+    [Fact]
+    public async Task Handle_WithNonExistentId_ReturnsNull()
+    {
+        var id = Guid.NewGuid();
+        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((OrganisationEntity?)null);
+
+        var result = await _handler.Handle(new GetOrganisationByIdQuery(id), CancellationToken.None);
+
+        Assert.Null(result);
+    }
+}


### PR DESCRIPTION
## Description

Implements `GetOrganisationByIdQuery` and `GetOrganisationByIdQueryHandler` to fetch a single organisation by ID via the repository. Adds a `GET /api/v1/organisation/{id}` endpoint that returns `200 OK` with the entity or `404 Not Found`.

## Linked Issue

Closes #7

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Two unit tests cover the handler: existing ID returns the entity, non-existent ID returns null. All 59 tests pass.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)