### PR TITLE
Implement ListOrganisations query handler

### DIFF
--- a/src/Herit.Api/Controllers/OrganisationController.cs
+++ b/src/Herit.Api/Controllers/OrganisationController.cs
@@ -6,6 +6,7 @@ using Herit.Application.Features.Organisation.Commands.UpdateOrganisation;
 using Herit.Application.Features.Organisation.Queries.GetDepartmentById;
 using Herit.Application.Features.Organisation.Queries.GetOrganisationById;
 using Herit.Application.Features.Organisation.Queries.ListDepartments;
+using Herit.Application.Features.Organisation.Queries.ListOrganisations;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
@@ -18,6 +19,10 @@ public class OrganisationController : ControllerBase
     private readonly IMediator _mediator;
 
     public OrganisationController(IMediator mediator) => _mediator = mediator;
+
+    [HttpGet]
+    public async Task<IActionResult> ListOrganisations(CancellationToken ct)
+        => Ok(await _mediator.Send(new ListOrganisationsQuery(), ct));
 
     [HttpGet("{id:guid}")]
     public async Task<IActionResult> GetOrganisationById(Guid id, CancellationToken ct)

--- a/src/Herit.Application/Features/Organisation/Queries/ListOrganisations/ListOrganisationsQuery.cs
+++ b/src/Herit.Application/Features/Organisation/Queries/ListOrganisations/ListOrganisationsQuery.cs
@@ -1,0 +1,19 @@
+using Herit.Application.Interfaces;
+using MediatR;
+
+namespace Herit.Application.Features.Organisation.Queries.ListOrganisations;
+
+public record ListOrganisationsQuery() : IRequest<IEnumerable<Herit.Domain.Entities.Organisation>>;
+
+public class ListOrganisationsQueryHandler : IRequestHandler<ListOrganisationsQuery, IEnumerable<Herit.Domain.Entities.Organisation>>
+{
+    private readonly IOrganisationRepository _repository;
+
+    public ListOrganisationsQueryHandler(IOrganisationRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public Task<IEnumerable<Herit.Domain.Entities.Organisation>> Handle(ListOrganisationsQuery request, CancellationToken cancellationToken)
+        => _repository.ListAsync(cancellationToken);
+}

--- a/tests/Herit.Application.Tests/Features/Organisation/Queries/ListOrganisationsQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Organisation/Queries/ListOrganisationsQueryHandlerTests.cs
@@ -1,0 +1,42 @@
+using Herit.Application.Features.Organisation.Queries.ListOrganisations;
+using Herit.Application.Interfaces;
+using NSubstitute;
+using OrganisationEntity = Herit.Domain.Entities.Organisation;
+
+namespace Herit.Application.Tests.Features.Organisation.Queries;
+
+public class ListOrganisationsQueryHandlerTests
+{
+    private readonly IOrganisationRepository _repository = Substitute.For<IOrganisationRepository>();
+    private readonly ListOrganisationsQueryHandler _handler;
+
+    public ListOrganisationsQueryHandlerTests()
+    {
+        _handler = new ListOrganisationsQueryHandler(_repository);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsAllOrganisations()
+    {
+        var organisations = new[]
+        {
+            OrganisationEntity.Create(Guid.NewGuid(), "Ministry of Finance"),
+            OrganisationEntity.Create(Guid.NewGuid(), "Ministry of Health")
+        };
+        _repository.ListAsync(Arg.Any<CancellationToken>()).Returns(organisations.AsEnumerable());
+
+        var result = await _handler.Handle(new ListOrganisationsQuery(), CancellationToken.None);
+
+        Assert.Equal(2, result.Count());
+    }
+
+    [Fact]
+    public async Task Handle_WhenEmpty_ReturnsEmptyCollection()
+    {
+        _repository.ListAsync(Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<OrganisationEntity>());
+
+        var result = await _handler.Handle(new ListOrganisationsQuery(), CancellationToken.None);
+
+        Assert.Empty(result);
+    }
+}


### PR DESCRIPTION
## Description

Implements `ListOrganisationsQuery` and `ListOrganisationsQueryHandler` to retrieve all organisations from the repository. Adds a `GET /api/v1/organisation` endpoint to the controller.

## Linked Issue

Closes #8

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Two unit tests cover the handler: returns all organisations and returns an empty collection when none exist. All 61 tests pass.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)