### PR TITLE
Integration tests for OrganisationRepository

### DIFF
--- a/tests/Herit.Infrastructure.Tests/Repositories/OrganisationRepositoryTests.cs
+++ b/tests/Herit.Infrastructure.Tests/Repositories/OrganisationRepositoryTests.cs
@@ -101,4 +101,47 @@ public class OrganisationRepositoryTests : IDisposable
 
         Assert.Null(exception);
     }
+
+    [Fact]
+    public async Task ListAsync_WhenEmpty_ReturnsEmptyCollection()
+    {
+        var result = await _repository.ListAsync();
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task AddAsync_WithParentId_PersistsParentId()
+    {
+        var parentId = Guid.NewGuid();
+        var parent = Organisation.Create(parentId, "Parent Org");
+        await _repository.AddAsync(parent);
+
+        var childId = Guid.NewGuid();
+        var child = Organisation.Create(childId, "Child Org", parentId);
+        await _repository.AddAsync(child);
+
+        var persisted = await _repository.GetByIdAsync(childId);
+        Assert.NotNull(persisted);
+        Assert.Equal(parentId, persisted.ParentId);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_PreservesParentId()
+    {
+        var parentId = Guid.NewGuid();
+        await _repository.AddAsync(Organisation.Create(parentId, "Parent"));
+
+        var childId = Guid.NewGuid();
+        var child = Organisation.Create(childId, "Child", parentId);
+        await _repository.AddAsync(child);
+
+        child.Update("Renamed Child");
+        await _repository.UpdateAsync(child);
+
+        var persisted = await _repository.GetByIdAsync(childId);
+        Assert.NotNull(persisted);
+        Assert.Equal("Renamed Child", persisted.Name);
+        Assert.Equal(parentId, persisted.ParentId);
+    }
 }


### PR DESCRIPTION
## Description

Extends the existing `OrganisationRepositoryTests` with three additional integration tests that were missing:

- `ListAsync_WhenEmpty_ReturnsEmptyCollection` — verifies baseline empty-DB behaviour.
- `AddAsync_WithParentId_PersistsParentId` — confirms child organisations retain their `ParentId` after persistence.
- `UpdateAsync_PreservesParentId` — confirms `ParentId` is not lost when an organisation is renamed.

## Linked Issue

Closes #9

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Chore / refactor

## Testing Notes

`dotnet test` — 11 infrastructure integration tests pass (up from 8), 64 total.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)