### PR TITLE
Unit tests for Organisation command handlers

### DIFF
--- a/tests/Herit.Application.Tests/Features/Organisation/Commands/CreateOrganisationCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Organisation/Commands/CreateOrganisationCommandHandlerTests.cs
@@ -56,4 +56,13 @@ public class CreateOrganisationCommandHandlerTests
         await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
         await _repository.DidNotReceive().AddAsync(Arg.Any<OrganisationEntity>(), Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task Handle_CalledTwice_ReturnsDifferentIds()
+    {
+        var id1 = await _handler.Handle(new CreateOrganisationCommand("Org A"), CancellationToken.None);
+        var id2 = await _handler.Handle(new CreateOrganisationCommand("Org B"), CancellationToken.None);
+
+        Assert.NotEqual(id1, id2);
+    }
 }

--- a/tests/Herit.Application.Tests/Features/Organisation/Commands/DeleteOrganisationCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Organisation/Commands/DeleteOrganisationCommandHandlerTests.cs
@@ -40,4 +40,16 @@ public class DeleteOrganisationCommandHandlerTests
         await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
         await _repository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task Handle_DeletesUsingCommandId()
+    {
+        var id = Guid.NewGuid();
+        var organisation = OrganisationEntity.Create(id, "Ministry of Finance");
+        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(organisation);
+
+        await _handler.Handle(new DeleteOrganisationCommand(id), CancellationToken.None);
+
+        await _repository.Received(1).DeleteAsync(id, Arg.Any<CancellationToken>());
+    }
 }

--- a/tests/Herit.Application.Tests/Features/Organisation/Commands/UpdateOrganisationCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Organisation/Commands/UpdateOrganisationCommandHandlerTests.cs
@@ -41,4 +41,16 @@ public class UpdateOrganisationCommandHandlerTests
         await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
         await _repository.DidNotReceive().UpdateAsync(Arg.Any<OrganisationEntity>(), Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task Handle_LooksUpOrganisationByCommandId()
+    {
+        var id = Guid.NewGuid();
+        var organisation = OrganisationEntity.Create(id, "Old Name");
+        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(organisation);
+
+        await _handler.Handle(new UpdateOrganisationCommand(id, "New Name"), CancellationToken.None);
+
+        await _repository.Received(1).GetByIdAsync(id, Arg.Any<CancellationToken>());
+    }
 }


### PR DESCRIPTION
## Description

Extends the unit tests for `CreateOrganisation`, `UpdateOrganisation`, and `DeleteOrganisation` command handlers with additional edge-case assertions:

- **Create**: verifies that two successive calls produce distinct IDs.
- **Update**: verifies that `GetByIdAsync` is called with the exact ID from the command.
- **Delete**: verifies that `DeleteAsync` is called with the exact ID from the command.

Core happy-path and not-found tests were already in place from PRs #15 and #16.

## Linked Issue

Closes #10

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Chore / refactor

## Testing Notes

`dotnet test` — 54 application-layer unit tests pass (up from 51), 67 total across all test projects.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)