### PR TITLE
Unit tests for Organisation query handlers

### DIFF
--- a/tests/Herit.Application.Tests/Features/Organisation/Queries/GetOrganisationByIdQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Organisation/Queries/GetOrganisationByIdQueryHandlerTests.cs
@@ -39,4 +39,15 @@ public class GetOrganisationByIdQueryHandlerTests
 
         Assert.Null(result);
     }
+
+    [Fact]
+    public async Task Handle_QueriesRepositoryWithCorrectId()
+    {
+        var id = Guid.NewGuid();
+        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((OrganisationEntity?)null);
+
+        await _handler.Handle(new GetOrganisationByIdQuery(id), CancellationToken.None);
+
+        await _repository.Received(1).GetByIdAsync(id, Arg.Any<CancellationToken>());
+    }
 }

--- a/tests/Herit.Application.Tests/Features/Organisation/Queries/ListOrganisationsQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Organisation/Queries/ListOrganisationsQueryHandlerTests.cs
@@ -39,4 +39,20 @@ public class ListOrganisationsQueryHandlerTests
 
         Assert.Empty(result);
     }
+
+    [Fact]
+    public async Task Handle_ReturnsOrganisationsWithCorrectNames()
+    {
+        var organisations = new[]
+        {
+            OrganisationEntity.Create(Guid.NewGuid(), "Ministry of Finance"),
+            OrganisationEntity.Create(Guid.NewGuid(), "Ministry of Health")
+        };
+        _repository.ListAsync(Arg.Any<CancellationToken>()).Returns(organisations.AsEnumerable());
+
+        var result = (await _handler.Handle(new ListOrganisationsQuery(), CancellationToken.None)).ToList();
+
+        Assert.Contains(result, o => o.Name == "Ministry of Finance");
+        Assert.Contains(result, o => o.Name == "Ministry of Health");
+    }
 }


### PR DESCRIPTION
## Description

Extends unit tests for `GetOrganisationById` and `ListOrganisations` query handlers with additional assertions:

- **GetOrganisationById**: verifies the handler forwards the exact query ID to `GetByIdAsync`.
- **ListOrganisations**: verifies the returned collection preserves all organisation names from the repository.

Core happy-path and empty/not-found tests were already in place from PRs #17 and #18.

## Linked Issue

Closes #11

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Chore / refactor

## Testing Notes

`dotnet test` — 56 application-layer unit tests pass (up from 54), 69 total across all test projects.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)