### PR TITLE
Implement CreateStaffUser command handler

### DIFF
--- a/src/Herit.Application/Features/User/Commands/CreateStaffUser/CreateStaffUserCommand.cs
+++ b/src/Herit.Application/Features/User/Commands/CreateStaffUser/CreateStaffUserCommand.cs
@@ -1,4 +1,7 @@
+using Herit.Application.Interfaces;
+using Herit.Domain.Enums;
 using MediatR;
+using UserEntity = Herit.Domain.Entities.User;
 
 namespace Herit.Application.Features.User.Commands.CreateStaffUser;
 
@@ -6,8 +9,25 @@ public record CreateStaffUserCommand(string Email, string FullName, Guid Organis
 
 public class CreateStaffUserCommandHandler : IRequestHandler<CreateStaffUserCommand, Guid>
 {
-    public Task<Guid> Handle(CreateStaffUserCommand request, CancellationToken cancellationToken)
+    private readonly IUserRepository _userRepository;
+    private readonly IOrganisationRepository _organisationRepository;
+
+    public CreateStaffUserCommandHandler(IUserRepository userRepository, IOrganisationRepository organisationRepository)
     {
-        throw new NotImplementedException();
+        _userRepository = userRepository;
+        _organisationRepository = organisationRepository;
+    }
+
+    public async Task<Guid> Handle(CreateStaffUserCommand request, CancellationToken cancellationToken)
+    {
+        var organisation = await _organisationRepository.GetByIdAsync(request.OrganisationId, cancellationToken);
+        if (organisation is null)
+            throw new InvalidOperationException($"Organisation with ID '{request.OrganisationId}' was not found.");
+
+        var user = UserEntity.Create(Guid.NewGuid(), request.Email, request.FullName, UserRole.Staff, request.OrganisationId);
+
+        await _userRepository.AddAsync(user, cancellationToken);
+
+        return user.Id;
     }
 }

--- a/tests/Herit.Application.Tests/Features/User/Commands/CreateStaffUserCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/User/Commands/CreateStaffUserCommandHandlerTests.cs
@@ -1,14 +1,62 @@
 using Herit.Application.Features.User.Commands.CreateStaffUser;
+using Herit.Application.Interfaces;
+using NSubstitute;
+using OrganisationEntity = Herit.Domain.Entities.Organisation;
+using UserEntity = Herit.Domain.Entities.User;
 
 namespace Herit.Application.Tests.Features.User.Commands;
 
 public class CreateStaffUserCommandHandlerTests
 {
-    [Fact]
-    public async Task Handle_ThrowsNotImplementedException()
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly IOrganisationRepository _organisationRepository = Substitute.For<IOrganisationRepository>();
+
+    private readonly CreateStaffUserCommandHandler _handler;
+
+    public CreateStaffUserCommandHandlerTests()
     {
-        var handler = new CreateStaffUserCommandHandler();
-        var command = new CreateStaffUserCommand("staff@gov.eg", "Staff Member", Guid.NewGuid());
-        await Assert.ThrowsAsync<NotImplementedException>(() => handler.Handle(command, CancellationToken.None));
+        _handler = new CreateStaffUserCommandHandler(_userRepository, _organisationRepository);
+    }
+
+    [Fact]
+    public async Task Handle_WithValidOrganisation_ReturnsNonEmptyGuid()
+    {
+        var orgId = Guid.NewGuid();
+        var organisation = OrganisationEntity.Create(orgId, "Test Organisation");
+        _organisationRepository.GetByIdAsync(orgId, Arg.Any<CancellationToken>()).Returns(organisation);
+
+        var command = new CreateStaffUserCommand("staff@gov.eg", "Staff Member", orgId);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.NotEqual(Guid.Empty, result);
+    }
+
+    [Fact]
+    public async Task Handle_WithValidOrganisation_CallsAddAsyncExactlyOnce()
+    {
+        var orgId = Guid.NewGuid();
+        var organisation = OrganisationEntity.Create(orgId, "Test Organisation");
+        _organisationRepository.GetByIdAsync(orgId, Arg.Any<CancellationToken>()).Returns(organisation);
+
+        var command = new CreateStaffUserCommand("staff@gov.eg", "Staff Member", orgId);
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        await _userRepository.Received(1).AddAsync(
+            Arg.Is<UserEntity>(u => u.Email == "staff@gov.eg" && u.FullName == "Staff Member" && u.OrganisationId == orgId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WithNonExistentOrganisation_ThrowsInvalidOperationException()
+    {
+        var orgId = Guid.NewGuid();
+        _organisationRepository.GetByIdAsync(orgId, Arg.Any<CancellationToken>()).Returns((OrganisationEntity?)null);
+
+        var command = new CreateStaffUserCommand("staff@gov.eg", "Staff Member", orgId);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await _userRepository.DidNotReceive().AddAsync(Arg.Any<UserEntity>(), Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
## Description

Implements the `CreateStaffUserCommandHandler` with full organisation validation. The handler verifies the referenced organisation exists, creates a `User` entity with `UserRole.Staff`, persists it via `IUserRepository`, and returns the new user's ID.

## Linked Issue

Closes #27

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Replaced the stub test with three unit tests using NSubstitute mocks:
- Happy path: returns a non-empty `Guid`
- Repository interaction: `AddAsync` called exactly once with correct user properties
- Validation: throws `InvalidOperationException` (and does not call `AddAsync`) when organisation is not found

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)