### PR TITLE
Implement RegisterExpat command handler

### DIFF
--- a/src/Herit.Api/Controllers/UsersController.cs
+++ b/src/Herit.Api/Controllers/UsersController.cs
@@ -1,5 +1,6 @@
 using Herit.Application.Features.User.Commands.CreateOrganisationAdmin;
 using Herit.Application.Features.User.Commands.CreateStaffUser;
+using Herit.Application.Features.User.Commands.RegisterExpat;
 using Herit.Application.Features.User.Commands.DeleteStaffUser;
 using Herit.Application.Features.User.Commands.DeleteSubAdmin;
 using Herit.Application.Features.User.Commands.UpdateStaffUser;
@@ -59,5 +60,12 @@ public class UsersController : ControllerBase
     {
         await _mediator.Send(new DeleteSubAdminCommand(id), ct);
         return NoContent();
+    }
+
+    [HttpPost("register")]
+    public async Task<IActionResult> Register([FromBody] RegisterExpatCommand command, CancellationToken ct)
+    {
+        var id = await _mediator.Send(command, ct);
+        return CreatedAtAction(nameof(GetById), new { id }, id);
     }
 }

--- a/src/Herit.Application/Features/User/Commands/RegisterExpat/RegisterExpatCommand.cs
+++ b/src/Herit.Application/Features/User/Commands/RegisterExpat/RegisterExpatCommand.cs
@@ -1,0 +1,27 @@
+using Herit.Application.Interfaces;
+using Herit.Domain.Enums;
+using MediatR;
+using UserEntity = Herit.Domain.Entities.User;
+
+namespace Herit.Application.Features.User.Commands.RegisterExpat;
+
+public record RegisterExpatCommand(string Email, string FullName) : IRequest<Guid>;
+
+public class RegisterExpatCommandHandler : IRequestHandler<RegisterExpatCommand, Guid>
+{
+    private readonly IUserRepository _userRepository;
+
+    public RegisterExpatCommandHandler(IUserRepository userRepository)
+    {
+        _userRepository = userRepository;
+    }
+
+    public async Task<Guid> Handle(RegisterExpatCommand request, CancellationToken cancellationToken)
+    {
+        var user = UserEntity.Create(Guid.NewGuid(), request.Email, request.FullName, UserRole.Expat);
+
+        await _userRepository.AddAsync(user, cancellationToken);
+
+        return user.Id;
+    }
+}

--- a/tests/Herit.Application.Tests/Features/User/Commands/RegisterExpatCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/User/Commands/RegisterExpatCommandHandlerTests.cs
@@ -1,0 +1,57 @@
+using Herit.Application.Features.User.Commands.RegisterExpat;
+using Herit.Application.Interfaces;
+using Herit.Domain.Enums;
+using NSubstitute;
+using UserEntity = Herit.Domain.Entities.User;
+
+namespace Herit.Application.Tests.Features.User.Commands;
+
+public class RegisterExpatCommandHandlerTests
+{
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly RegisterExpatCommandHandler _handler;
+
+    public RegisterExpatCommandHandlerTests()
+    {
+        _handler = new RegisterExpatCommandHandler(_userRepository);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsNonEmptyGuid()
+    {
+        var command = new RegisterExpatCommand("expat@example.com", "Jane Doe");
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.NotEqual(Guid.Empty, result);
+    }
+
+    [Fact]
+    public async Task Handle_CallsAddAsyncExactlyOnce()
+    {
+        var command = new RegisterExpatCommand("expat@example.com", "Jane Doe");
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        await _userRepository.Received(1).AddAsync(
+            Arg.Any<UserEntity>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_CreatesUserWithExpatRoleAndNullOrganisationId()
+    {
+        var command = new RegisterExpatCommand("expat@example.com", "Jane Doe");
+        UserEntity? capturedUser = null;
+
+        await _userRepository.AddAsync(
+            Arg.Do<UserEntity>(u => capturedUser = u),
+            Arg.Any<CancellationToken>());
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        Assert.NotNull(capturedUser);
+        Assert.Equal(UserRole.Expat, capturedUser.Role);
+        Assert.Null(capturedUser.OrganisationId);
+    }
+}


### PR DESCRIPTION
## Description

Adds the `RegisterExpatCommand` handler and a `POST /api/v1/Users/register` endpoint for expat self-registration. No organisation is required; the user is created with `UserRole.Expat` and a null `OrganisationId`.

## Linked Issue

Closes #31

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Three unit tests cover: happy-path returns a non-empty `Guid`; `AddAsync` is called exactly once; the created user has `Role == UserRole.Expat` and `OrganisationId == null`.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/register-expat`)