### PR TITLE
Implement UpdateUser command handler

### DIFF
--- a/src/Herit.Application/Features/User/Commands/UpdateStaffUser/UpdateStaffUserCommand.cs
+++ b/src/Herit.Application/Features/User/Commands/UpdateStaffUser/UpdateStaffUserCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.User.Commands.UpdateStaffUser;
@@ -6,8 +7,23 @@ public record UpdateStaffUserCommand(Guid Id, string Email, string FullName) : I
 
 public class UpdateStaffUserCommandHandler : IRequestHandler<UpdateStaffUserCommand, Unit>
 {
-    public Task<Unit> Handle(UpdateStaffUserCommand request, CancellationToken cancellationToken)
+    private readonly IUserRepository _userRepository;
+
+    public UpdateStaffUserCommandHandler(IUserRepository userRepository)
     {
-        throw new NotImplementedException();
+        _userRepository = userRepository;
+    }
+
+    public async Task<Unit> Handle(UpdateStaffUserCommand request, CancellationToken cancellationToken)
+    {
+        var user = await _userRepository.GetByIdAsync(request.Id, cancellationToken);
+        if (user is null)
+            throw new InvalidOperationException($"User with ID '{request.Id}' was not found.");
+
+        user.Update(request.Email, request.FullName);
+
+        await _userRepository.UpdateAsync(user, cancellationToken);
+
+        return Unit.Value;
     }
 }

--- a/src/Herit.Domain/Entities/User.cs
+++ b/src/Herit.Domain/Entities/User.cs
@@ -23,4 +23,10 @@ public class User
             OrganisationId = organisationId
         };
     }
+
+    public void Update(string email, string fullName)
+    {
+        Email = email;
+        FullName = fullName;
+    }
 }

--- a/tests/Herit.Application.Tests/Features/User/Commands/UpdateStaffUserCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/User/Commands/UpdateStaffUserCommandHandlerTests.cs
@@ -1,14 +1,46 @@
 using Herit.Application.Features.User.Commands.UpdateStaffUser;
+using Herit.Application.Interfaces;
+using Herit.Domain.Enums;
+using NSubstitute;
+using UserEntity = Herit.Domain.Entities.User;
 
 namespace Herit.Application.Tests.Features.User.Commands;
 
 public class UpdateStaffUserCommandHandlerTests
 {
-    [Fact]
-    public async Task Handle_ThrowsNotImplementedException()
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly UpdateStaffUserCommandHandler _handler;
+
+    public UpdateStaffUserCommandHandlerTests()
     {
-        var handler = new UpdateStaffUserCommandHandler();
-        var command = new UpdateStaffUserCommand(Guid.NewGuid(), "updated@gov.eg", "Updated Name");
-        await Assert.ThrowsAsync<NotImplementedException>(() => handler.Handle(command, CancellationToken.None));
+        _handler = new UpdateStaffUserCommandHandler(_userRepository);
+    }
+
+    [Fact]
+    public async Task Handle_WithExistingUser_CallsUpdateAsyncExactlyOnce()
+    {
+        var userId = Guid.NewGuid();
+        var user = UserEntity.Create(userId, "old@gov.eg", "Old Name", UserRole.Staff);
+        _userRepository.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+
+        var command = new UpdateStaffUserCommand(userId, "updated@gov.eg", "Updated Name");
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        await _userRepository.Received(1).UpdateAsync(
+            Arg.Is<UserEntity>(u => u.Id == userId && u.Email == "updated@gov.eg" && u.FullName == "Updated Name"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WithNonExistentUser_ThrowsInvalidOperationException()
+    {
+        var userId = Guid.NewGuid();
+        _userRepository.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns((UserEntity?)null);
+
+        var command = new UpdateStaffUserCommand(userId, "updated@gov.eg", "Updated Name");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await _userRepository.DidNotReceive().UpdateAsync(Arg.Any<UserEntity>(), Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
## Description

Implements the `UpdateStaffUserCommandHandler` end-to-end:
- Adds `User.Update(string email, string fullName)` to the domain entity
- Injects `IUserRepository` into the handler; fetches user by ID and throws `InvalidOperationException` if not found
- Calls `entity.Update(...)` then `UpdateAsync`, returns `Unit.Value`
- Replaces the stub test with real tests covering the happy path and not-found error case

## Linked Issue

Closes #32

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- Happy path: verifies `UpdateAsync` is called exactly once with the correct entity values
- Not-found path: verifies `InvalidOperationException` is thrown and `UpdateAsync` is never called

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)