### PR TITLE
Implement GetUserById query handler

### DIFF
--- a/src/Herit.Application/Features/User/Queries/GetUserById/GetUserByIdQuery.cs
+++ b/src/Herit.Application/Features/User/Queries/GetUserById/GetUserByIdQuery.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.User.Queries.GetUserById;
@@ -6,8 +7,15 @@ public record GetUserByIdQuery(Guid Id) : IRequest<Herit.Domain.Entities.User?>;
 
 public class GetUserByIdQueryHandler : IRequestHandler<GetUserByIdQuery, Herit.Domain.Entities.User?>
 {
-    public Task<Herit.Domain.Entities.User?> Handle(GetUserByIdQuery request, CancellationToken cancellationToken)
+    private readonly IUserRepository _userRepository;
+
+    public GetUserByIdQueryHandler(IUserRepository userRepository)
     {
-        throw new NotImplementedException();
+        _userRepository = userRepository;
+    }
+
+    public async Task<Herit.Domain.Entities.User?> Handle(GetUserByIdQuery request, CancellationToken cancellationToken)
+    {
+        return await _userRepository.GetByIdAsync(request.Id, cancellationToken);
     }
 }

--- a/tests/Herit.Application.Tests/Features/User/Queries/GetUserByIdQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/User/Queries/GetUserByIdQueryHandlerTests.cs
@@ -1,14 +1,43 @@
 using Herit.Application.Features.User.Queries.GetUserById;
+using Herit.Application.Interfaces;
+using Herit.Domain.Enums;
+using NSubstitute;
+using UserEntity = Herit.Domain.Entities.User;
 
 namespace Herit.Application.Tests.Features.User.Queries;
 
 public class GetUserByIdQueryHandlerTests
 {
-    [Fact]
-    public async Task Handle_ThrowsNotImplementedException()
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly GetUserByIdQueryHandler _handler;
+
+    public GetUserByIdQueryHandlerTests()
     {
-        var handler = new GetUserByIdQueryHandler();
-        var query = new GetUserByIdQuery(Guid.NewGuid());
-        await Assert.ThrowsAsync<NotImplementedException>(() => handler.Handle(query, CancellationToken.None));
+        _handler = new GetUserByIdQueryHandler(_userRepository);
+    }
+
+    [Fact]
+    public async Task Handle_WhenRepositoryReturnsUser_ReturnsUser()
+    {
+        var userId = Guid.NewGuid();
+        var user = UserEntity.Create(userId, "user@gov.eg", "Test User", UserRole.Staff);
+        _userRepository.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+
+        var query = new GetUserByIdQuery(userId);
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        Assert.Equal(user, result);
+    }
+
+    [Fact]
+    public async Task Handle_WhenRepositoryReturnsNull_ReturnsNull()
+    {
+        var userId = Guid.NewGuid();
+        _userRepository.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns((UserEntity?)null);
+
+        var query = new GetUserByIdQuery(userId);
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        Assert.Null(result);
     }
 }


### PR DESCRIPTION
## Description

Implements the `GetUserByIdQueryHandler` to inject `IUserRepository` and call `GetByIdAsync`, returning the user or null if not found.

## Linked Issue

Closes #34

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Replaced the stub test with two real tests using a mocked `IUserRepository` via NSubstitute:
- Returns the user when the repository finds one
- Returns null when the repository returns null

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)