### PR TITLE
Implement ListUsers query handler

### DIFF
--- a/src/Herit.Application/Features/User/Queries/ListUsers/ListUsersQuery.cs
+++ b/src/Herit.Application/Features/User/Queries/ListUsers/ListUsersQuery.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.User.Queries.ListUsers;
@@ -6,8 +7,15 @@ public record ListUsersQuery() : IRequest<IEnumerable<Herit.Domain.Entities.User
 
 public class ListUsersQueryHandler : IRequestHandler<ListUsersQuery, IEnumerable<Herit.Domain.Entities.User>>
 {
-    public Task<IEnumerable<Herit.Domain.Entities.User>> Handle(ListUsersQuery request, CancellationToken cancellationToken)
+    private readonly IUserRepository _userRepository;
+
+    public ListUsersQueryHandler(IUserRepository userRepository)
     {
-        throw new NotImplementedException();
+        _userRepository = userRepository;
+    }
+
+    public async Task<IEnumerable<Herit.Domain.Entities.User>> Handle(ListUsersQuery request, CancellationToken cancellationToken)
+    {
+        return await _userRepository.ListAsync(cancellationToken);
     }
 }

--- a/tests/Herit.Application.Tests/Features/User/Queries/ListUsersQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/User/Queries/ListUsersQueryHandlerTests.cs
@@ -1,14 +1,43 @@
 using Herit.Application.Features.User.Queries.ListUsers;
+using Herit.Application.Interfaces;
+using Herit.Domain.Enums;
+using NSubstitute;
+using UserEntity = Herit.Domain.Entities.User;
 
 namespace Herit.Application.Tests.Features.User.Queries;
 
 public class ListUsersQueryHandlerTests
 {
-    [Fact]
-    public async Task Handle_ThrowsNotImplementedException()
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly ListUsersQueryHandler _handler;
+
+    public ListUsersQueryHandlerTests()
     {
-        var handler = new ListUsersQueryHandler();
-        var query = new ListUsersQuery();
-        await Assert.ThrowsAsync<NotImplementedException>(() => handler.Handle(query, CancellationToken.None));
+        _handler = new ListUsersQueryHandler(_userRepository);
+    }
+
+    [Fact]
+    public async Task Handle_WhenRepositoryReturnsUsers_ReturnsAllUsers()
+    {
+        var users = new List<UserEntity>
+        {
+            UserEntity.Create(Guid.NewGuid(), "user1@gov.eg", "User One", UserRole.Staff),
+            UserEntity.Create(Guid.NewGuid(), "user2@gov.eg", "User Two", UserRole.Staff),
+        };
+        _userRepository.ListAsync(Arg.Any<CancellationToken>()).Returns(users);
+
+        var result = await _handler.Handle(new ListUsersQuery(), CancellationToken.None);
+
+        Assert.Equal(users, result);
+    }
+
+    [Fact]
+    public async Task Handle_WhenRepositoryReturnsEmpty_ReturnsEmptyCollection()
+    {
+        _userRepository.ListAsync(Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<UserEntity>());
+
+        var result = await _handler.Handle(new ListUsersQuery(), CancellationToken.None);
+
+        Assert.Empty(result);
     }
 }


### PR DESCRIPTION
## Description

Implements the `ListUsersQueryHandler` by injecting `IUserRepository` and calling `ListAsync()`. Replaces the stub tests with real unit tests covering non-empty and empty result cases.

## Linked Issue

Closes #36

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Two tests added:
- `Handle_WhenRepositoryReturnsUsers_ReturnsAllUsers` — verifies all items from the repository are returned.
- `Handle_WhenRepositoryReturnsEmpty_ReturnsEmptyCollection` — verifies an empty collection (not null) is returned.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)