### PR TITLE
Read connection string from Azure Key Vault

### DIFF
--- a/src/Herit.Api/Herit.Api.csproj
+++ b/src/Herit.Api/Herit.Api.csproj
@@ -8,6 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.0" />
+    <PackageReference Include="Azure.Identity" Version="1.19.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Herit.Api/Program.cs
+++ b/src/Herit.Api/Program.cs
@@ -1,16 +1,26 @@
+using Azure.Identity;
 using Herit.Application.Features.Rfp.Commands.CreateRfp;
 using Herit.Infrastructure;
 using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 
+var keyVaultEndpoint = builder.Configuration["AZURE_KEY_VAULT_ENDPOINT"];
+if (!string.IsNullOrEmpty(keyVaultEndpoint))
+    builder.Configuration.AddAzureKeyVault(new Uri(keyVaultEndpoint), new DefaultAzureCredential());
+
 builder.Services.AddControllers();
 
 builder.Services.AddMediatR(cfg =>
     cfg.RegisterServicesFromAssembly(typeof(CreateRfpCommand).Assembly));
 
-builder.Services.AddInfrastructure(
-    builder.Configuration.GetConnectionString("DefaultConnection")!);
+var connectionStringKey = builder.Configuration["AZURE_SQL_CONNECTION_STRING_KEY"];
+var connectionString = (!string.IsNullOrEmpty(connectionStringKey)
+    ? builder.Configuration[connectionStringKey]
+    : null)
+    ?? builder.Configuration.GetConnectionString("DefaultConnection")!;
+
+builder.Services.AddInfrastructure(connectionString);
 
 builder.Services.AddEndpointsApiExplorer();
 


### PR DESCRIPTION
## Description

Wires up the Azure Key Vault configuration provider in `Program.cs` so the app reads the connection string from Key Vault at startup. The infrastructure provisions the connection string under the key stored in `AZURE_SQL_CONNECTION_STRING_KEY`, but the app was previously calling `GetConnectionString("DefaultConnection")` with no Key Vault provider registered, resulting in a null connection string and a 500 on every request.

Falls back to `ConnectionStrings:DefaultConnection` so local development with `appsettings.Development.json` continues to work unchanged.

## Linked Issue

Closes #43

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Build and all existing tests pass. End-to-end verification requires the deployed Azure environment.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)