### PR TITLE
Apply EF migrations on startup

### DIFF
--- a/src/Herit.Api/Program.cs
+++ b/src/Herit.Api/Program.cs
@@ -1,6 +1,8 @@
 using Azure.Identity;
 using Herit.Application.Features.Rfp.Commands.CreateRfp;
 using Herit.Infrastructure;
+using Herit.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -32,6 +34,12 @@ if (enableSwagger)
 }
 
 var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<HeritDbContext>();
+    await db.Database.MigrateAsync();
+}
 
 if (enableSwagger)
 {


### PR DESCRIPTION
## Description

Calls `MigrateAsync()` on startup so EF Core applies any pending migrations before the app starts serving requests. The database is provisioned as an empty SQL Server DB by the infra bicep, but the schema (tables) was never being created. This is safe to run on every startup — EF tracks applied migrations in `__EFMigrationsHistory` and skips anything already applied.

## Linked Issue

Closes #45

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Build and all existing tests pass. End-to-end verification requires the deployed Azure environment.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)