### PR TITLE
Skip Key Vault config provider in Development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 !.claude/commands/*
 **/bin/
 **/obj/
+.postman/
+postman/

--- a/src/Herit.Api/Program.cs
+++ b/src/Herit.Api/Program.cs
@@ -8,7 +8,7 @@ using Microsoft.OpenApi.Models;
 var builder = WebApplication.CreateBuilder(args);
 
 var keyVaultEndpoint = builder.Configuration["AZURE_KEY_VAULT_ENDPOINT"];
-if (!string.IsNullOrEmpty(keyVaultEndpoint))
+if (!string.IsNullOrEmpty(keyVaultEndpoint) && !builder.Environment.IsDevelopment())
     builder.Configuration.AddAzureKeyVault(new Uri(keyVaultEndpoint), new DefaultAzureCredential());
 
 builder.Services.AddControllers();


### PR DESCRIPTION
## Description

Adds `&& !builder.Environment.IsDevelopment()` to the Key Vault configuration check in `Program.cs`. When running locally, `AZURE_KEY_VAULT_ENDPOINT` is set in the environment by `azd`, causing a 403 crash because the local identity lacks Key Vault permissions. Skipping it in Development means the app falls back to User Secrets / `appsettings.Development.json` as intended.

Also adds `.postman/` and `postman/` to `.gitignore` to ignore Postman VS Code extension scaffolding files.

## Linked Issue

N/A — discovered during local testing.

## Type of Change

- [x] Bug fix

## Testing Notes

- `dotnet run --project src/Herit.Api` no longer crashes with a 403 when `AZURE_KEY_VAULT_ENDPOINT` is set locally.
- Deployed environment is unaffected — Key Vault is still used in non-Development environments.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`fix/`)