### PR TITLE
Implement RfpRepository

### DIFF
--- a/src/Herit.Infrastructure/Repositories/RfpRepository.cs
+++ b/src/Herit.Infrastructure/Repositories/RfpRepository.cs
@@ -1,6 +1,7 @@
 using Herit.Application.Interfaces;
 using Herit.Domain.Entities;
 using Herit.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
 
 namespace Herit.Infrastructure.Repositories;
 
@@ -14,17 +15,34 @@ public class RfpRepository : IRfpRepository
     }
 
     public Task<Rfp?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
-        => throw new NotImplementedException();
+        => _context.Rfps.FindAsync([id], cancellationToken).AsTask();
 
-    public Task<IEnumerable<Rfp>> ListAsync(CancellationToken cancellationToken = default)
-        => throw new NotImplementedException();
+    public async Task<IEnumerable<Rfp>> ListAsync(CancellationToken cancellationToken = default)
+        => await _context.Rfps.ToListAsync(cancellationToken);
 
-    public Task AddAsync(Rfp rfp, CancellationToken cancellationToken = default)
-        => throw new NotImplementedException();
+    public async Task AddAsync(Rfp rfp, CancellationToken cancellationToken = default)
+    {
+        await _context.Rfps.AddAsync(rfp, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
 
-    public Task UpdateAsync(Rfp rfp, CancellationToken cancellationToken = default)
-        => throw new NotImplementedException();
+    public async Task UpdateAsync(Rfp rfp, CancellationToken cancellationToken = default)
+    {
+        var tracked = _context.ChangeTracker.Entries<Rfp>()
+            .FirstOrDefault(e => e.Entity.Id == rfp.Id);
+        if (tracked is not null)
+            tracked.State = EntityState.Detached;
 
-    public Task DeleteAsync(Guid id, CancellationToken cancellationToken = default)
-        => throw new NotImplementedException();
+        _context.Rfps.Update(rfp);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task DeleteAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var rfp = await _context.Rfps.FindAsync([id], cancellationToken)
+            ?? throw new InvalidOperationException($"Rfp with id '{id}' was not found.");
+
+        _context.Rfps.Remove(rfp);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
 }

--- a/tests/Herit.Infrastructure.Tests/Repositories/RfpRepositoryTests.cs
+++ b/tests/Herit.Infrastructure.Tests/Repositories/RfpRepositoryTests.cs
@@ -1,0 +1,122 @@
+using Herit.Domain.Entities;
+using Herit.Infrastructure.Persistence;
+using Herit.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Herit.Infrastructure.Tests.Repositories;
+
+public class RfpRepositoryTests : IDisposable
+{
+    private readonly HeritDbContext _context;
+    private readonly RfpRepository _repository;
+
+    public RfpRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<HeritDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _context = new HeritDbContext(options);
+        _repository = new RfpRepository(_context);
+    }
+
+    public void Dispose() => _context.Dispose();
+
+    private static Rfp CreateRfp(Guid? id = null, string title = "Test RFP")
+        => Rfp.Create(
+            id ?? Guid.NewGuid(),
+            title,
+            "Short description",
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "Long description");
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsRfp_WhenExists()
+    {
+        var id = Guid.NewGuid();
+        var rfp = CreateRfp(id, "My RFP");
+        await _repository.AddAsync(rfp);
+
+        var result = await _repository.GetByIdAsync(id);
+
+        Assert.NotNull(result);
+        Assert.Equal(id, result.Id);
+        Assert.Equal("My RFP", result.Title);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsNull_WhenNotExists()
+    {
+        var result = await _repository.GetByIdAsync(Guid.NewGuid());
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ListAsync_ReturnsAllRfps()
+    {
+        await _repository.AddAsync(CreateRfp(title: "RFP A"));
+        await _repository.AddAsync(CreateRfp(title: "RFP B"));
+
+        var result = await _repository.ListAsync();
+
+        Assert.Equal(2, result.Count());
+    }
+
+    [Fact]
+    public async Task ListAsync_WhenEmpty_ReturnsEmptyCollection()
+    {
+        var result = await _repository.ListAsync();
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task AddAsync_PersistsRfp()
+    {
+        var id = Guid.NewGuid();
+        var rfp = CreateRfp(id, "New RFP");
+
+        await _repository.AddAsync(rfp);
+
+        var persisted = await _context.Rfps.FindAsync(id);
+        Assert.NotNull(persisted);
+        Assert.Equal("New RFP", persisted.Title);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_PersistsChanges()
+    {
+        var id = Guid.NewGuid();
+        var rfp = CreateRfp(id, "Original Title");
+        await _repository.AddAsync(rfp);
+
+        rfp.Update("Updated Title", "Updated short", "Updated long");
+        await _repository.UpdateAsync(rfp);
+
+        var persisted = await _context.Rfps.FindAsync(id);
+        Assert.NotNull(persisted);
+        Assert.Equal("Updated Title", persisted.Title);
+        Assert.Equal("Updated short", persisted.ShortDescription);
+        Assert.Equal("Updated long", persisted.LongDescription);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_RemovesRfp_WhenExists()
+    {
+        var id = Guid.NewGuid();
+        await _repository.AddAsync(CreateRfp(id, "To Delete"));
+
+        await _repository.DeleteAsync(id);
+
+        var persisted = await _context.Rfps.FindAsync(id);
+        Assert.Null(persisted);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Throws_WhenNotExists()
+    {
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _repository.DeleteAsync(Guid.NewGuid()));
+    }
+}


### PR DESCRIPTION
## Description

Implements all five stub methods in `RfpRepository` following the same patterns as `UserRepository` and `OrganisationRepository`. `DeleteAsync` throws `InvalidOperationException` when the id does not exist, consistent with `UserRepository`.

## Linked Issue

Closes #51

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Added `RfpRepositoryTests.cs` with 8 integration tests using an in-memory EF Core context, covering: add and retrieve by id, list multiple RFPs, update fields, delete by id, and `DeleteAsync` throwing when the id does not exist.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)