### PR TITLE
Implement UpdateRfp command handler

### DIFF
--- a/src/Herit.Application/Features/Rfp/Commands/UpdateRfp/UpdateRfpCommand.cs
+++ b/src/Herit.Application/Features/Rfp/Commands/UpdateRfp/UpdateRfpCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.Rfp.Commands.UpdateRfp;
@@ -10,8 +11,21 @@ public record UpdateRfpCommand(
 
 public class UpdateRfpCommandHandler : IRequestHandler<UpdateRfpCommand, Unit>
 {
-    public Task<Unit> Handle(UpdateRfpCommand request, CancellationToken cancellationToken)
+    private readonly IRfpRepository _repository;
+
+    public UpdateRfpCommandHandler(IRfpRepository repository)
     {
-        throw new NotImplementedException();
+        _repository = repository;
+    }
+
+    public async Task<Unit> Handle(UpdateRfpCommand request, CancellationToken cancellationToken)
+    {
+        var rfp = await _repository.GetByIdAsync(request.Id, cancellationToken);
+        if (rfp is null)
+            throw new InvalidOperationException($"Rfp '{request.Id}' does not exist.");
+
+        rfp.Update(request.Title, request.ShortDescription, request.LongDescription);
+        await _repository.UpdateAsync(rfp, cancellationToken);
+        return Unit.Value;
     }
 }

--- a/tests/Herit.Application.Tests/Features/Rfp/Commands/UpdateRfpCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Rfp/Commands/UpdateRfpCommandHandlerTests.cs
@@ -1,14 +1,46 @@
 using Herit.Application.Features.Rfp.Commands.UpdateRfp;
+using Herit.Application.Interfaces;
+using NSubstitute;
+using RfpEntity = Herit.Domain.Entities.Rfp;
 
 namespace Herit.Application.Tests.Features.Rfp.Commands;
 
 public class UpdateRfpCommandHandlerTests
 {
-    [Fact]
-    public async Task Handle_ThrowsNotImplementedException()
+    private readonly IRfpRepository _repository = Substitute.For<IRfpRepository>();
+    private readonly UpdateRfpCommandHandler _handler;
+
+    public UpdateRfpCommandHandlerTests()
     {
-        var handler = new UpdateRfpCommandHandler();
-        var command = new UpdateRfpCommand(Guid.NewGuid(), "Title", "Short", "Long");
-        await Assert.ThrowsAsync<NotImplementedException>(() => handler.Handle(command, CancellationToken.None));
+        _handler = new UpdateRfpCommandHandler(_repository);
+    }
+
+    [Fact]
+    public async Task Handle_WithExistingRfp_UpdatesFieldsAndCallsUpdateAsync()
+    {
+        var id = Guid.NewGuid();
+        var rfp = RfpEntity.Create(id, "Old Title", "Old Short", Guid.NewGuid(), Guid.NewGuid(), "Old Long");
+        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(rfp);
+
+        var command = new UpdateRfpCommand(id, "New Title", "New Short", "New Long");
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.Equal(MediatR.Unit.Value, result);
+        Assert.Equal("New Title", rfp.Title);
+        Assert.Equal("New Short", rfp.ShortDescription);
+        Assert.Equal("New Long", rfp.LongDescription);
+        await _repository.Received(1).UpdateAsync(rfp, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WithNonExistentRfp_ThrowsInvalidOperationException()
+    {
+        var id = Guid.NewGuid();
+        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((RfpEntity?)null);
+
+        var command = new UpdateRfpCommand(id, "Title", "Short", "Long");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await _repository.DidNotReceive().UpdateAsync(Arg.Any<RfpEntity>(), Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
## Description

Implements `UpdateRfpCommandHandler` to look up an RFP by id, call `entity.Update(...)` for the content fields (Title, ShortDescription, LongDescription), and persist via `UpdateAsync`. Throws `InvalidOperationException` if the RFP is not found.

## Linked Issue

Closes #53

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Replaced the stub test with two NSubstitute-based tests: happy path verifies fields are updated and `UpdateAsync` is called once; not-found case verifies `InvalidOperationException` is thrown and `UpdateAsync` is not called.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)