### PR TITLE
Implement DeleteRfp command handler

### DIFF
--- a/src/Herit.Application/Features/Rfp/Commands/DeleteRfp/DeleteRfpCommand.cs
+++ b/src/Herit.Application/Features/Rfp/Commands/DeleteRfp/DeleteRfpCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.Rfp.Commands.DeleteRfp;
@@ -6,8 +7,16 @@ public record DeleteRfpCommand(Guid Id) : IRequest<Unit>;
 
 public class DeleteRfpCommandHandler : IRequestHandler<DeleteRfpCommand, Unit>
 {
-    public Task<Unit> Handle(DeleteRfpCommand request, CancellationToken cancellationToken)
+    private readonly IRfpRepository _repository;
+
+    public DeleteRfpCommandHandler(IRfpRepository repository)
     {
-        throw new NotImplementedException();
+        _repository = repository;
+    }
+
+    public async Task<Unit> Handle(DeleteRfpCommand request, CancellationToken cancellationToken)
+    {
+        await _repository.DeleteAsync(request.Id, cancellationToken);
+        return Unit.Value;
     }
 }

--- a/tests/Herit.Application.Tests/Features/Rfp/Commands/DeleteRfpCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Rfp/Commands/DeleteRfpCommandHandlerTests.cs
@@ -1,14 +1,39 @@
 using Herit.Application.Features.Rfp.Commands.DeleteRfp;
+using Herit.Application.Interfaces;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 namespace Herit.Application.Tests.Features.Rfp.Commands;
 
 public class DeleteRfpCommandHandlerTests
 {
-    [Fact]
-    public async Task Handle_ThrowsNotImplementedException()
+    private readonly IRfpRepository _repository = Substitute.For<IRfpRepository>();
+    private readonly DeleteRfpCommandHandler _handler;
+
+    public DeleteRfpCommandHandlerTests()
     {
-        var handler = new DeleteRfpCommandHandler();
-        var command = new DeleteRfpCommand(Guid.NewGuid());
-        await Assert.ThrowsAsync<NotImplementedException>(() => handler.Handle(command, CancellationToken.None));
+        _handler = new DeleteRfpCommandHandler(_repository);
+    }
+
+    [Fact]
+    public async Task Handle_WithExistingRfp_CallsDeleteAsyncOnce()
+    {
+        var id = Guid.NewGuid();
+
+        var result = await _handler.Handle(new DeleteRfpCommand(id), CancellationToken.None);
+
+        Assert.Equal(MediatR.Unit.Value, result);
+        await _repository.Received(1).DeleteAsync(id, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WithNonExistentRfp_ThrowsInvalidOperationException()
+    {
+        var id = Guid.NewGuid();
+        _repository.DeleteAsync(id, Arg.Any<CancellationToken>())
+            .Throws(new InvalidOperationException($"Rfp with id '{id}' was not found."));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _handler.Handle(new DeleteRfpCommand(id), CancellationToken.None));
     }
 }


### PR DESCRIPTION
## Description

Implements `DeleteRfpCommandHandler` to delegate directly to `IRfpRepository.DeleteAsync`, which already throws `InvalidOperationException` when the id is not found. Returns `Unit.Value` on success.

## Linked Issue

Closes #54

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Replaced the stub test with two NSubstitute-based tests: happy path verifies `DeleteAsync` is called once; not-found case configures the mock to throw `InvalidOperationException` and asserts it propagates.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)