### PR TITLE
Implement UpdateRfpStatus command handler

### DIFF
--- a/src/Herit.Application/Features/Rfp/Commands/UpdateRfpStatus/UpdateRfpStatusCommand.cs
+++ b/src/Herit.Application/Features/Rfp/Commands/UpdateRfpStatus/UpdateRfpStatusCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
 using MediatR;
 
@@ -7,8 +8,21 @@ public record UpdateRfpStatusCommand(Guid Id, RfpStatus NewStatus) : IRequest<Un
 
 public class UpdateRfpStatusCommandHandler : IRequestHandler<UpdateRfpStatusCommand, Unit>
 {
-    public Task<Unit> Handle(UpdateRfpStatusCommand request, CancellationToken cancellationToken)
+    private readonly IRfpRepository _repository;
+
+    public UpdateRfpStatusCommandHandler(IRfpRepository repository)
     {
-        throw new NotImplementedException();
+        _repository = repository;
+    }
+
+    public async Task<Unit> Handle(UpdateRfpStatusCommand request, CancellationToken cancellationToken)
+    {
+        var rfp = await _repository.GetByIdAsync(request.Id, cancellationToken);
+        if (rfp is null)
+            throw new InvalidOperationException($"Rfp '{request.Id}' does not exist.");
+
+        rfp.TransitionStatus(request.NewStatus);
+        await _repository.UpdateAsync(rfp, cancellationToken);
+        return Unit.Value;
     }
 }

--- a/tests/Herit.Application.Tests/Features/Rfp/Commands/UpdateRfpStatusCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Rfp/Commands/UpdateRfpStatusCommandHandlerTests.cs
@@ -1,15 +1,73 @@
 using Herit.Application.Features.Rfp.Commands.UpdateRfpStatus;
+using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
+using NSubstitute;
+using RfpEntity = Herit.Domain.Entities.Rfp;
 
 namespace Herit.Application.Tests.Features.Rfp.Commands;
 
 public class UpdateRfpStatusCommandHandlerTests
 {
-    [Fact]
-    public async Task Handle_ThrowsNotImplementedException()
+    private readonly IRfpRepository _repository = Substitute.For<IRfpRepository>();
+    private readonly UpdateRfpStatusCommandHandler _handler;
+
+    public UpdateRfpStatusCommandHandlerTests()
     {
-        var handler = new UpdateRfpStatusCommandHandler();
-        var command = new UpdateRfpStatusCommand(Guid.NewGuid(), RfpStatus.Approved);
-        await Assert.ThrowsAsync<NotImplementedException>(() => handler.Handle(command, CancellationToken.None));
+        _handler = new UpdateRfpStatusCommandHandler(_repository);
+    }
+
+    private static RfpEntity CreateDraftRfp(Guid id)
+        => RfpEntity.Create(id, "Title", "Short", Guid.NewGuid(), Guid.NewGuid(), "Long");
+
+    [Fact]
+    public async Task Handle_DraftToApproved_CallsUpdateAsyncOnce()
+    {
+        var id = Guid.NewGuid();
+        var rfp = CreateDraftRfp(id);
+        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(rfp);
+
+        var result = await _handler.Handle(new UpdateRfpStatusCommand(id, RfpStatus.Approved), CancellationToken.None);
+
+        Assert.Equal(MediatR.Unit.Value, result);
+        Assert.Equal(RfpStatus.Approved, rfp.Status);
+        await _repository.Received(1).UpdateAsync(rfp, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ApprovedToPublished_CallsUpdateAsyncOnce()
+    {
+        var id = Guid.NewGuid();
+        var rfp = CreateDraftRfp(id);
+        rfp.TransitionStatus(RfpStatus.Approved);
+        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(rfp);
+
+        var result = await _handler.Handle(new UpdateRfpStatusCommand(id, RfpStatus.Published), CancellationToken.None);
+
+        Assert.Equal(MediatR.Unit.Value, result);
+        Assert.Equal(RfpStatus.Published, rfp.Status);
+        await _repository.Received(1).UpdateAsync(rfp, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_RfpNotFound_ThrowsInvalidOperationException()
+    {
+        var id = Guid.NewGuid();
+        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((RfpEntity?)null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _handler.Handle(new UpdateRfpStatusCommand(id, RfpStatus.Approved), CancellationToken.None));
+        await _repository.DidNotReceive().UpdateAsync(Arg.Any<RfpEntity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_IllegalTransition_ThrowsInvalidOperationException()
+    {
+        var id = Guid.NewGuid();
+        var rfp = CreateDraftRfp(id); // status is Draft
+        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(rfp);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _handler.Handle(new UpdateRfpStatusCommand(id, RfpStatus.Published), CancellationToken.None));
+        await _repository.DidNotReceive().UpdateAsync(Arg.Any<RfpEntity>(), Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
## Description

Implements `UpdateRfpStatusCommandHandler` to fetch an RFP by id, call `entity.TransitionStatus(newStatus)` (domain-enforced guard), and persist via `UpdateAsync`. The domain entity's `AllowedTransitions` dictionary enforces valid state transitions and throws for illegal ones.

## Linked Issue

Closes #55

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Replaced the stub test with four NSubstitute-based tests: `Draft → Approved` happy path; `Approved → Published` happy path; RFP not found throws `InvalidOperationException`; illegal transition (`Draft → Published`) throws `InvalidOperationException` via the domain entity guard.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)