### PR TITLE
Implement GetRfpById query handler

### DIFF
--- a/src/Herit.Api/Controllers/RfpsController.cs
+++ b/src/Herit.Api/Controllers/RfpsController.cs
@@ -23,7 +23,10 @@ public class RfpsController : ControllerBase
 
     [HttpGet("{id:guid}")]
     public async Task<IActionResult> GetById(Guid id, CancellationToken ct)
-        => Ok(await _mediator.Send(new GetRfpByIdQuery(id), ct));
+    {
+        var result = await _mediator.Send(new GetRfpByIdQuery(id), ct);
+        return result is null ? NotFound() : Ok(result);
+    }
 
     [HttpPost]
     public async Task<IActionResult> Create([FromBody] CreateRfpCommand command, CancellationToken ct)

--- a/src/Herit.Application/Features/Rfp/Queries/GetRfpById/GetRfpByIdQuery.cs
+++ b/src/Herit.Application/Features/Rfp/Queries/GetRfpById/GetRfpByIdQuery.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.Rfp.Queries.GetRfpById;
@@ -6,8 +7,13 @@ public record GetRfpByIdQuery(Guid Id) : IRequest<Herit.Domain.Entities.Rfp?>;
 
 public class GetRfpByIdQueryHandler : IRequestHandler<GetRfpByIdQuery, Herit.Domain.Entities.Rfp?>
 {
-    public Task<Herit.Domain.Entities.Rfp?> Handle(GetRfpByIdQuery request, CancellationToken cancellationToken)
+    private readonly IRfpRepository _repository;
+
+    public GetRfpByIdQueryHandler(IRfpRepository repository)
     {
-        throw new NotImplementedException();
+        _repository = repository;
     }
+
+    public Task<Herit.Domain.Entities.Rfp?> Handle(GetRfpByIdQuery request, CancellationToken cancellationToken)
+        => _repository.GetByIdAsync(request.Id, cancellationToken);
 }

--- a/tests/Herit.Application.Tests/Features/Rfp/Queries/GetRfpByIdQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Rfp/Queries/GetRfpByIdQueryHandlerTests.cs
@@ -1,14 +1,41 @@
 using Herit.Application.Features.Rfp.Queries.GetRfpById;
+using Herit.Application.Interfaces;
+using NSubstitute;
+using RfpEntity = Herit.Domain.Entities.Rfp;
 
 namespace Herit.Application.Tests.Features.Rfp.Queries;
 
 public class GetRfpByIdQueryHandlerTests
 {
-    [Fact]
-    public async Task Handle_ThrowsNotImplementedException()
+    private readonly IRfpRepository _repository = Substitute.For<IRfpRepository>();
+    private readonly GetRfpByIdQueryHandler _handler;
+
+    public GetRfpByIdQueryHandlerTests()
     {
-        var handler = new GetRfpByIdQueryHandler();
-        var query = new GetRfpByIdQuery(Guid.NewGuid());
-        await Assert.ThrowsAsync<NotImplementedException>(() => handler.Handle(query, CancellationToken.None));
+        _handler = new GetRfpByIdQueryHandler(_repository);
+    }
+
+    [Fact]
+    public async Task Handle_WhenRfpExists_ReturnsRfp()
+    {
+        var id = Guid.NewGuid();
+        var rfp = RfpEntity.Create(id, "Title", "Short", Guid.NewGuid(), Guid.NewGuid(), "Long");
+        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(rfp);
+
+        var result = await _handler.Handle(new GetRfpByIdQuery(id), CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(id, result.Id);
+    }
+
+    [Fact]
+    public async Task Handle_WhenRfpNotFound_ReturnsNull()
+    {
+        var id = Guid.NewGuid();
+        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((RfpEntity?)null);
+
+        var result = await _handler.Handle(new GetRfpByIdQuery(id), CancellationToken.None);
+
+        Assert.Null(result);
     }
 }


### PR DESCRIPTION
## Description

Implements `GetRfpByIdQueryHandler` to delegate to `IRfpRepository.GetByIdAsync` and return the result (null if not found). Also fixes `RfpsController.GetById` to return `404 NotFound` when the result is null, matching the `OrganisationController` pattern.

## Linked Issue

Closes #56

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Replaced the stub test with two NSubstitute-based tests: when the repository returns an RFP the handler returns it; when the repository returns null the handler returns null.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)