### PR TITLE
Implement ListRfps query handler

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -38,7 +38,7 @@ jobs:
   cd:
     runs-on: ubuntu-latest
     needs: ci
-    if: false
+    if: github.event_name == 'push'
     env:
       AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}

--- a/src/Herit.Application/Features/Rfp/Queries/ListRfps/ListRfpsQuery.cs
+++ b/src/Herit.Application/Features/Rfp/Queries/ListRfps/ListRfpsQuery.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.Rfp.Queries.ListRfps;
@@ -6,8 +7,13 @@ public record ListRfpsQuery() : IRequest<IEnumerable<Herit.Domain.Entities.Rfp>>
 
 public class ListRfpsQueryHandler : IRequestHandler<ListRfpsQuery, IEnumerable<Herit.Domain.Entities.Rfp>>
 {
-    public Task<IEnumerable<Herit.Domain.Entities.Rfp>> Handle(ListRfpsQuery request, CancellationToken cancellationToken)
+    private readonly IRfpRepository _repository;
+
+    public ListRfpsQueryHandler(IRfpRepository repository)
     {
-        throw new NotImplementedException();
+        _repository = repository;
     }
+
+    public Task<IEnumerable<Herit.Domain.Entities.Rfp>> Handle(ListRfpsQuery request, CancellationToken cancellationToken)
+        => _repository.ListAsync(cancellationToken);
 }

--- a/tests/Herit.Application.Tests/Features/Rfp/Queries/ListRfpsQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Rfp/Queries/ListRfpsQueryHandlerTests.cs
@@ -1,14 +1,43 @@
 using Herit.Application.Features.Rfp.Queries.ListRfps;
+using Herit.Application.Interfaces;
+using NSubstitute;
+using RfpEntity = Herit.Domain.Entities.Rfp;
 
 namespace Herit.Application.Tests.Features.Rfp.Queries;
 
 public class ListRfpsQueryHandlerTests
 {
-    [Fact]
-    public async Task Handle_ThrowsNotImplementedException()
+    private readonly IRfpRepository _repository = Substitute.For<IRfpRepository>();
+    private readonly ListRfpsQueryHandler _handler;
+
+    public ListRfpsQueryHandlerTests()
     {
-        var handler = new ListRfpsQueryHandler();
-        var query = new ListRfpsQuery();
-        await Assert.ThrowsAsync<NotImplementedException>(() => handler.Handle(query, CancellationToken.None));
+        _handler = new ListRfpsQueryHandler(_repository);
+    }
+
+    [Fact]
+    public async Task Handle_WhenRepositoryReturnsItems_ReturnsAllItems()
+    {
+        var rfps = new[]
+        {
+            RfpEntity.Create(Guid.NewGuid(), "RFP A", "Short A", Guid.NewGuid(), Guid.NewGuid(), "Long A"),
+            RfpEntity.Create(Guid.NewGuid(), "RFP B", "Short B", Guid.NewGuid(), Guid.NewGuid(), "Long B"),
+        };
+        _repository.ListAsync(Arg.Any<CancellationToken>()).Returns((IEnumerable<RfpEntity>)rfps);
+
+        var result = await _handler.Handle(new ListRfpsQuery(), CancellationToken.None);
+
+        Assert.Equal(2, result.Count());
+    }
+
+    [Fact]
+    public async Task Handle_WhenRepositoryReturnsEmpty_ReturnsEmptyCollection()
+    {
+        _repository.ListAsync(Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<RfpEntity>());
+
+        var result = await _handler.Handle(new ListRfpsQuery(), CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Empty(result);
     }
 }


### PR DESCRIPTION
## Description

Implements `ListRfpsQueryHandler` to delegate to `IRfpRepository.ListAsync` and return the result. Also re-enables the `cd` workflow step (was disabled as prep work for issue #52).

## Linked Issue

Closes #57

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Replaced the stub test with two NSubstitute-based tests: repository returns items → handler returns all of them; repository returns empty → handler returns empty collection (not null).

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)