### PR TITLE
Add domain methods to Proposal entity

### DIFF
--- a/src/Herit.Domain/Entities/Proposal.cs
+++ b/src/Herit.Domain/Entities/Proposal.cs
@@ -4,6 +4,15 @@ namespace Herit.Domain.Entities;
 
 public class Proposal
 {
+    private static readonly Dictionary<ProposalStatus, ProposalStatus[]> AllowedTransitions = new()
+    {
+        [ProposalStatus.Ideation] = [ProposalStatus.Resourcing],
+        [ProposalStatus.Resourcing] = [ProposalStatus.Submitted],
+        [ProposalStatus.Submitted] = [ProposalStatus.UnderReview, ProposalStatus.Resourcing],
+        [ProposalStatus.UnderReview] = [ProposalStatus.Approved],
+        [ProposalStatus.Approved] = []
+    };
+
     public Guid Id { get; private set; }
     public string Title { get; private set; } = default!;
     public string ShortDescription { get; private set; } = default!;
@@ -30,5 +39,25 @@ public class Proposal
             Visibility = ProposalVisibility.Private,
             RfpId = rfpId
         };
+    }
+
+    public void Update(string title, string shortDescription, string longDescription)
+    {
+        Title = title;
+        ShortDescription = shortDescription;
+        LongDescription = longDescription;
+    }
+
+    public void TransitionStatus(ProposalStatus newStatus)
+    {
+        if (!AllowedTransitions[Status].Contains(newStatus))
+            throw new InvalidOperationException($"Cannot transition from {Status} to {newStatus}.");
+
+        Status = newStatus;
+    }
+
+    public void SetVisibility(ProposalVisibility visibility)
+    {
+        Visibility = visibility;
     }
 }

--- a/tests/Herit.Domain.Tests/Entities/ProposalTests.cs
+++ b/tests/Herit.Domain.Tests/Entities/ProposalTests.cs
@@ -1,0 +1,169 @@
+using Herit.Domain.Entities;
+using Herit.Domain.Enums;
+
+namespace Herit.Domain.Tests.Entities;
+
+public class ProposalTests
+{
+    private static Proposal CreateIdeationProposal() =>
+        Proposal.Create(Guid.NewGuid(), "Title", "Short", Guid.NewGuid(), Guid.NewGuid(), "Long");
+
+    // Create tests
+
+    [Fact]
+    public void Create_SetsDefaultStatusAndVisibility()
+    {
+        var proposal = CreateIdeationProposal();
+
+        Assert.Equal(ProposalStatus.Ideation, proposal.Status);
+        Assert.Equal(ProposalVisibility.Private, proposal.Visibility);
+    }
+
+    // Update tests
+
+    [Fact]
+    public void Update_SetsContentFields()
+    {
+        var proposal = CreateIdeationProposal();
+
+        proposal.Update("New Title", "New Short", "New Long");
+
+        Assert.Equal("New Title", proposal.Title);
+        Assert.Equal("New Short", proposal.ShortDescription);
+        Assert.Equal("New Long", proposal.LongDescription);
+    }
+
+    // TransitionStatus — legal transitions
+
+    [Fact]
+    public void TransitionStatus_IdeationToResourcing_Succeeds()
+    {
+        var proposal = CreateIdeationProposal();
+
+        proposal.TransitionStatus(ProposalStatus.Resourcing);
+
+        Assert.Equal(ProposalStatus.Resourcing, proposal.Status);
+    }
+
+    [Fact]
+    public void TransitionStatus_ResourcingToSubmitted_Succeeds()
+    {
+        var proposal = CreateIdeationProposal();
+        proposal.TransitionStatus(ProposalStatus.Resourcing);
+
+        proposal.TransitionStatus(ProposalStatus.Submitted);
+
+        Assert.Equal(ProposalStatus.Submitted, proposal.Status);
+    }
+
+    [Fact]
+    public void TransitionStatus_SubmittedToUnderReview_Succeeds()
+    {
+        var proposal = CreateIdeationProposal();
+        proposal.TransitionStatus(ProposalStatus.Resourcing);
+        proposal.TransitionStatus(ProposalStatus.Submitted);
+
+        proposal.TransitionStatus(ProposalStatus.UnderReview);
+
+        Assert.Equal(ProposalStatus.UnderReview, proposal.Status);
+    }
+
+    [Fact]
+    public void TransitionStatus_SubmittedToResourcing_Succeeds()
+    {
+        var proposal = CreateIdeationProposal();
+        proposal.TransitionStatus(ProposalStatus.Resourcing);
+        proposal.TransitionStatus(ProposalStatus.Submitted);
+
+        proposal.TransitionStatus(ProposalStatus.Resourcing);
+
+        Assert.Equal(ProposalStatus.Resourcing, proposal.Status);
+    }
+
+    [Fact]
+    public void TransitionStatus_UnderReviewToApproved_Succeeds()
+    {
+        var proposal = CreateIdeationProposal();
+        proposal.TransitionStatus(ProposalStatus.Resourcing);
+        proposal.TransitionStatus(ProposalStatus.Submitted);
+        proposal.TransitionStatus(ProposalStatus.UnderReview);
+
+        proposal.TransitionStatus(ProposalStatus.Approved);
+
+        Assert.Equal(ProposalStatus.Approved, proposal.Status);
+    }
+
+    // TransitionStatus — illegal transitions
+
+    [Fact]
+    public void TransitionStatus_IdeationToSubmitted_Throws()
+    {
+        var proposal = CreateIdeationProposal();
+
+        Assert.Throws<InvalidOperationException>(() => proposal.TransitionStatus(ProposalStatus.Submitted));
+    }
+
+    [Fact]
+    public void TransitionStatus_ResourcingToIdeation_Throws()
+    {
+        var proposal = CreateIdeationProposal();
+        proposal.TransitionStatus(ProposalStatus.Resourcing);
+
+        Assert.Throws<InvalidOperationException>(() => proposal.TransitionStatus(ProposalStatus.Ideation));
+    }
+
+    [Fact]
+    public void TransitionStatus_SubmittedToApproved_Throws()
+    {
+        var proposal = CreateIdeationProposal();
+        proposal.TransitionStatus(ProposalStatus.Resourcing);
+        proposal.TransitionStatus(ProposalStatus.Submitted);
+
+        Assert.Throws<InvalidOperationException>(() => proposal.TransitionStatus(ProposalStatus.Approved));
+    }
+
+    [Fact]
+    public void TransitionStatus_UnderReviewToResourcing_Throws()
+    {
+        var proposal = CreateIdeationProposal();
+        proposal.TransitionStatus(ProposalStatus.Resourcing);
+        proposal.TransitionStatus(ProposalStatus.Submitted);
+        proposal.TransitionStatus(ProposalStatus.UnderReview);
+
+        Assert.Throws<InvalidOperationException>(() => proposal.TransitionStatus(ProposalStatus.Resourcing));
+    }
+
+    [Fact]
+    public void TransitionStatus_ApprovedToUnderReview_Throws()
+    {
+        var proposal = CreateIdeationProposal();
+        proposal.TransitionStatus(ProposalStatus.Resourcing);
+        proposal.TransitionStatus(ProposalStatus.Submitted);
+        proposal.TransitionStatus(ProposalStatus.UnderReview);
+        proposal.TransitionStatus(ProposalStatus.Approved);
+
+        Assert.Throws<InvalidOperationException>(() => proposal.TransitionStatus(ProposalStatus.UnderReview));
+    }
+
+    // SetVisibility tests
+
+    [Fact]
+    public void SetVisibility_UpdatesVisibility()
+    {
+        var proposal = CreateIdeationProposal();
+
+        proposal.SetVisibility(ProposalVisibility.Public);
+
+        Assert.Equal(ProposalVisibility.Public, proposal.Visibility);
+    }
+
+    [Fact]
+    public void SetVisibility_CanSetToShared()
+    {
+        var proposal = CreateIdeationProposal();
+
+        proposal.SetVisibility(ProposalVisibility.Shared);
+
+        Assert.Equal(ProposalVisibility.Shared, proposal.Visibility);
+    }
+}


### PR DESCRIPTION
## Description

Adds `Update`, `TransitionStatus`, and `SetVisibility` domain methods to the `Proposal` entity, following the same pattern as `Rfp`. The `TransitionStatus` method enforces a state machine with an `AllowedTransitions` dictionary: `Ideation → Resourcing`, `Resourcing → Submitted`, `Submitted → UnderReview`, `Submitted → Resourcing` (withdraw), `UnderReview → Approved`. All other transitions throw `InvalidOperationException`.

Also adds `ProposalTests.cs` with full coverage: `Create`, `Update`, all five legal status transitions, one illegal transition per state, and `SetVisibility`.

## Linked Issue

Closes #67

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

13 new tests in `Herit.Domain.Tests/Entities/ProposalTests.cs`. All 123 tests pass.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)