### PR TITLE
Implement ProposalRepository

### DIFF
--- a/src/Herit.Infrastructure/Repositories/ProposalRepository.cs
+++ b/src/Herit.Infrastructure/Repositories/ProposalRepository.cs
@@ -1,6 +1,7 @@
 using Herit.Application.Interfaces;
 using Herit.Domain.Entities;
 using Herit.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
 
 namespace Herit.Infrastructure.Repositories;
 
@@ -14,17 +15,34 @@ public class ProposalRepository : IProposalRepository
     }
 
     public Task<Proposal?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
-        => throw new NotImplementedException();
+        => _context.Proposals.FindAsync([id], cancellationToken).AsTask();
 
-    public Task<IEnumerable<Proposal>> ListAsync(CancellationToken cancellationToken = default)
-        => throw new NotImplementedException();
+    public async Task<IEnumerable<Proposal>> ListAsync(CancellationToken cancellationToken = default)
+        => await _context.Proposals.ToListAsync(cancellationToken);
 
-    public Task AddAsync(Proposal proposal, CancellationToken cancellationToken = default)
-        => throw new NotImplementedException();
+    public async Task AddAsync(Proposal proposal, CancellationToken cancellationToken = default)
+    {
+        await _context.Proposals.AddAsync(proposal, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
 
-    public Task UpdateAsync(Proposal proposal, CancellationToken cancellationToken = default)
-        => throw new NotImplementedException();
+    public async Task UpdateAsync(Proposal proposal, CancellationToken cancellationToken = default)
+    {
+        var tracked = _context.ChangeTracker.Entries<Proposal>()
+            .FirstOrDefault(e => e.Entity.Id == proposal.Id);
+        if (tracked is not null)
+            tracked.State = EntityState.Detached;
 
-    public Task DeleteAsync(Guid id, CancellationToken cancellationToken = default)
-        => throw new NotImplementedException();
+        _context.Proposals.Update(proposal);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task DeleteAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var proposal = await _context.Proposals.FindAsync([id], cancellationToken)
+            ?? throw new InvalidOperationException($"Proposal with id '{id}' was not found.");
+
+        _context.Proposals.Remove(proposal);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
 }

--- a/tests/Herit.Infrastructure.Tests/Repositories/ProposalRepositoryTests.cs
+++ b/tests/Herit.Infrastructure.Tests/Repositories/ProposalRepositoryTests.cs
@@ -1,0 +1,122 @@
+using Herit.Domain.Entities;
+using Herit.Infrastructure.Persistence;
+using Herit.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Herit.Infrastructure.Tests.Repositories;
+
+public class ProposalRepositoryTests : IDisposable
+{
+    private readonly HeritDbContext _context;
+    private readonly ProposalRepository _repository;
+
+    public ProposalRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<HeritDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _context = new HeritDbContext(options);
+        _repository = new ProposalRepository(_context);
+    }
+
+    public void Dispose() => _context.Dispose();
+
+    private static Proposal CreateProposal(Guid? id = null, string title = "Test Proposal")
+        => Proposal.Create(
+            id ?? Guid.NewGuid(),
+            title,
+            "Short description",
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "Long description");
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsProposal_WhenExists()
+    {
+        var id = Guid.NewGuid();
+        var proposal = CreateProposal(id, "My Proposal");
+        await _repository.AddAsync(proposal);
+
+        var result = await _repository.GetByIdAsync(id);
+
+        Assert.NotNull(result);
+        Assert.Equal(id, result.Id);
+        Assert.Equal("My Proposal", result.Title);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsNull_WhenNotExists()
+    {
+        var result = await _repository.GetByIdAsync(Guid.NewGuid());
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ListAsync_ReturnsAllProposals()
+    {
+        await _repository.AddAsync(CreateProposal(title: "Proposal A"));
+        await _repository.AddAsync(CreateProposal(title: "Proposal B"));
+
+        var result = await _repository.ListAsync();
+
+        Assert.Equal(2, result.Count());
+    }
+
+    [Fact]
+    public async Task ListAsync_WhenEmpty_ReturnsEmptyCollection()
+    {
+        var result = await _repository.ListAsync();
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task AddAsync_PersistsProposal()
+    {
+        var id = Guid.NewGuid();
+        var proposal = CreateProposal(id, "New Proposal");
+
+        await _repository.AddAsync(proposal);
+
+        var persisted = await _context.Proposals.FindAsync(id);
+        Assert.NotNull(persisted);
+        Assert.Equal("New Proposal", persisted.Title);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_PersistsChanges()
+    {
+        var id = Guid.NewGuid();
+        var proposal = CreateProposal(id, "Original Title");
+        await _repository.AddAsync(proposal);
+
+        proposal.Update("Updated Title", "Updated short", "Updated long");
+        await _repository.UpdateAsync(proposal);
+
+        var persisted = await _context.Proposals.FindAsync(id);
+        Assert.NotNull(persisted);
+        Assert.Equal("Updated Title", persisted.Title);
+        Assert.Equal("Updated short", persisted.ShortDescription);
+        Assert.Equal("Updated long", persisted.LongDescription);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_RemovesProposal_WhenExists()
+    {
+        var id = Guid.NewGuid();
+        await _repository.AddAsync(CreateProposal(id, "To Delete"));
+
+        await _repository.DeleteAsync(id);
+
+        var persisted = await _context.Proposals.FindAsync(id);
+        Assert.Null(persisted);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Throws_WhenNotExists()
+    {
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _repository.DeleteAsync(Guid.NewGuid()));
+    }
+}


### PR DESCRIPTION
## Description

Implements all five methods in `ProposalRepository` — `GetByIdAsync`, `ListAsync`, `AddAsync`, `UpdateAsync`, `DeleteAsync` — following the same pattern as `RfpRepository`. Also adds `ProposalRepositoryTests` with 7 tests covering all five methods.

## Linked Issue

Closes #68

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

7 new tests added in `ProposalRepositoryTests`, using an in-memory EF Core database. All 131 tests pass.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)