### PR TITLE
Implement CreateProposalCommandHandler

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -38,7 +38,7 @@ jobs:
   cd:
     runs-on: ubuntu-latest
     needs: ci
-    if: github.event_name == 'push'
+    if: false
     env:
       AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}

--- a/src/Herit.Application/Features/Proposal/Commands/CreateProposal/CreateProposalCommand.cs
+++ b/src/Herit.Application/Features/Proposal/Commands/CreateProposal/CreateProposalCommand.cs
@@ -1,4 +1,6 @@
+using Herit.Application.Interfaces;
 using MediatR;
+using ProposalEntity = Herit.Domain.Entities.Proposal;
 
 namespace Herit.Application.Features.Proposal.Commands.CreateProposal;
 
@@ -12,8 +14,43 @@ public record CreateProposalCommand(
 
 public class CreateProposalCommandHandler : IRequestHandler<CreateProposalCommand, Guid>
 {
-    public Task<Guid> Handle(CreateProposalCommand request, CancellationToken cancellationToken)
+    private readonly IProposalRepository _proposalRepository;
+    private readonly IUserRepository _userRepository;
+    private readonly IOrganisationRepository _organisationRepository;
+    private readonly IRfpRepository _rfpRepository;
+
+    public CreateProposalCommandHandler(
+        IProposalRepository proposalRepository,
+        IUserRepository userRepository,
+        IOrganisationRepository organisationRepository,
+        IRfpRepository rfpRepository)
     {
-        throw new NotImplementedException();
+        _proposalRepository = proposalRepository;
+        _userRepository = userRepository;
+        _organisationRepository = organisationRepository;
+        _rfpRepository = rfpRepository;
+    }
+
+    public async Task<Guid> Handle(CreateProposalCommand request, CancellationToken cancellationToken)
+    {
+        var author = await _userRepository.GetByIdAsync(request.AuthorId, cancellationToken);
+        if (author is null)
+            throw new InvalidOperationException($"User '{request.AuthorId}' does not exist.");
+
+        var organisation = await _organisationRepository.GetByIdAsync(request.OrganisationId, cancellationToken);
+        if (organisation is null)
+            throw new InvalidOperationException($"Organisation '{request.OrganisationId}' does not exist.");
+
+        if (request.RfpId is not null)
+        {
+            var rfp = await _rfpRepository.GetByIdAsync(request.RfpId.Value, cancellationToken);
+            if (rfp is null)
+                throw new InvalidOperationException($"Rfp '{request.RfpId}' does not exist.");
+        }
+
+        var id = Guid.NewGuid();
+        var proposal = ProposalEntity.Create(id, request.Title, request.ShortDescription, request.AuthorId, request.OrganisationId, request.LongDescription, request.RfpId);
+        await _proposalRepository.AddAsync(proposal, cancellationToken);
+        return id;
     }
 }

--- a/tests/Herit.Application.Tests/Features/Proposal/Commands/CreateProposalCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Proposal/Commands/CreateProposalCommandHandlerTests.cs
@@ -1,14 +1,113 @@
 using Herit.Application.Features.Proposal.Commands.CreateProposal;
+using Herit.Application.Interfaces;
+using Herit.Domain.Enums;
+using NSubstitute;
+using OrganisationEntity = Herit.Domain.Entities.Organisation;
+using ProposalEntity = Herit.Domain.Entities.Proposal;
+using RfpEntity = Herit.Domain.Entities.Rfp;
+using UserEntity = Herit.Domain.Entities.User;
 
 namespace Herit.Application.Tests.Features.Proposal.Commands;
 
 public class CreateProposalCommandHandlerTests
 {
-    [Fact]
-    public async Task Handle_ThrowsNotImplementedException()
+    private readonly IProposalRepository _proposalRepository = Substitute.For<IProposalRepository>();
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly IOrganisationRepository _organisationRepository = Substitute.For<IOrganisationRepository>();
+    private readonly IRfpRepository _rfpRepository = Substitute.For<IRfpRepository>();
+    private readonly CreateProposalCommandHandler _handler;
+
+    public CreateProposalCommandHandlerTests()
     {
-        var handler = new CreateProposalCommandHandler();
-        var command = new CreateProposalCommand("Title", "Short", Guid.NewGuid(), Guid.NewGuid(), "Long");
-        await Assert.ThrowsAsync<NotImplementedException>(() => handler.Handle(command, CancellationToken.None));
+        _handler = new CreateProposalCommandHandler(_proposalRepository, _userRepository, _organisationRepository, _rfpRepository);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_WithoutRfpId_ReturnsValidGuidAndCallsAddAsync()
+    {
+        var authorId = Guid.NewGuid();
+        var organisationId = Guid.NewGuid();
+        _userRepository.GetByIdAsync(authorId, Arg.Any<CancellationToken>())
+            .Returns(UserEntity.Create(authorId, "user@example.com", "Test User", UserRole.Staff));
+        _organisationRepository.GetByIdAsync(organisationId, Arg.Any<CancellationToken>())
+            .Returns(OrganisationEntity.Create(organisationId, "Test Org"));
+
+        var command = new CreateProposalCommand("Title", "Short", authorId, organisationId, "Long");
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.NotEqual(Guid.Empty, result);
+        await _proposalRepository.Received(1).AddAsync(
+            Arg.Is<ProposalEntity>(p => p.Title == "Title" && p.AuthorId == authorId && p.OrganisationId == organisationId && p.RfpId == null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_WithValidRfpId_ReturnsValidGuidAndCallsAddAsync()
+    {
+        var authorId = Guid.NewGuid();
+        var organisationId = Guid.NewGuid();
+        var rfpId = Guid.NewGuid();
+        _userRepository.GetByIdAsync(authorId, Arg.Any<CancellationToken>())
+            .Returns(UserEntity.Create(authorId, "user@example.com", "Test User", UserRole.Staff));
+        _organisationRepository.GetByIdAsync(organisationId, Arg.Any<CancellationToken>())
+            .Returns(OrganisationEntity.Create(organisationId, "Test Org"));
+        _rfpRepository.GetByIdAsync(rfpId, Arg.Any<CancellationToken>())
+            .Returns(RfpEntity.Create(rfpId, "RFP", "Short", authorId, organisationId, "Long"));
+
+        var command = new CreateProposalCommand("Title", "Short", authorId, organisationId, "Long", rfpId);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.NotEqual(Guid.Empty, result);
+        await _proposalRepository.Received(1).AddAsync(
+            Arg.Is<ProposalEntity>(p => p.Title == "Title" && p.RfpId == rfpId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_AuthorNotFound_ThrowsInvalidOperationException()
+    {
+        var authorId = Guid.NewGuid();
+        var organisationId = Guid.NewGuid();
+        _userRepository.GetByIdAsync(authorId, Arg.Any<CancellationToken>()).Returns((UserEntity?)null);
+
+        var command = new CreateProposalCommand("Title", "Short", authorId, organisationId, "Long");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await _proposalRepository.DidNotReceive().AddAsync(Arg.Any<ProposalEntity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_OrganisationNotFound_ThrowsInvalidOperationException()
+    {
+        var authorId = Guid.NewGuid();
+        var organisationId = Guid.NewGuid();
+        _userRepository.GetByIdAsync(authorId, Arg.Any<CancellationToken>())
+            .Returns(UserEntity.Create(authorId, "user@example.com", "Test User", UserRole.Staff));
+        _organisationRepository.GetByIdAsync(organisationId, Arg.Any<CancellationToken>()).Returns((OrganisationEntity?)null);
+
+        var command = new CreateProposalCommand("Title", "Short", authorId, organisationId, "Long");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await _proposalRepository.DidNotReceive().AddAsync(Arg.Any<ProposalEntity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_RfpNotFound_ThrowsInvalidOperationException()
+    {
+        var authorId = Guid.NewGuid();
+        var organisationId = Guid.NewGuid();
+        var rfpId = Guid.NewGuid();
+        _userRepository.GetByIdAsync(authorId, Arg.Any<CancellationToken>())
+            .Returns(UserEntity.Create(authorId, "user@example.com", "Test User", UserRole.Staff));
+        _organisationRepository.GetByIdAsync(organisationId, Arg.Any<CancellationToken>())
+            .Returns(OrganisationEntity.Create(organisationId, "Test Org"));
+        _rfpRepository.GetByIdAsync(rfpId, Arg.Any<CancellationToken>()).Returns((RfpEntity?)null);
+
+        var command = new CreateProposalCommand("Title", "Short", authorId, organisationId, "Long", rfpId);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await _proposalRepository.DidNotReceive().AddAsync(Arg.Any<ProposalEntity>(), Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
## Description

Implements `CreateProposalCommandHandler` with validation against `IUserRepository`, `IOrganisationRepository`, and optionally `IRfpRepository`. Disables the `cd` workflow job. Replaces the placeholder test with 5 tests covering: happy path without RfpId, happy path with a valid RfpId, and `InvalidOperationException` for each missing entity (author, organisation, RFP).

## Linked Issue

Closes #69

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

5 new tests in `CreateProposalCommandHandlerTests` using NSubstitute mocks. All 135 tests pass.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)