### PR TITLE
Implement UpdateProposalCommandHandler

### DIFF
--- a/src/Herit.Application/Features/Proposal/Commands/UpdateProposal/UpdateProposalCommand.cs
+++ b/src/Herit.Application/Features/Proposal/Commands/UpdateProposal/UpdateProposalCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.Proposal.Commands.UpdateProposal;
@@ -10,8 +11,21 @@ public record UpdateProposalCommand(
 
 public class UpdateProposalCommandHandler : IRequestHandler<UpdateProposalCommand, Unit>
 {
-    public Task<Unit> Handle(UpdateProposalCommand request, CancellationToken cancellationToken)
+    private readonly IProposalRepository _proposalRepository;
+
+    public UpdateProposalCommandHandler(IProposalRepository proposalRepository)
     {
-        throw new NotImplementedException();
+        _proposalRepository = proposalRepository;
+    }
+
+    public async Task<Unit> Handle(UpdateProposalCommand request, CancellationToken cancellationToken)
+    {
+        var proposal = await _proposalRepository.GetByIdAsync(request.Id, cancellationToken);
+        if (proposal is null)
+            throw new InvalidOperationException($"Proposal '{request.Id}' does not exist.");
+
+        proposal.Update(request.Title, request.ShortDescription, request.LongDescription);
+        await _proposalRepository.UpdateAsync(proposal, cancellationToken);
+        return Unit.Value;
     }
 }

--- a/tests/Herit.Application.Tests/Features/Proposal/Commands/UpdateProposalCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Proposal/Commands/UpdateProposalCommandHandlerTests.cs
@@ -1,14 +1,52 @@
 using Herit.Application.Features.Proposal.Commands.UpdateProposal;
+using Herit.Application.Interfaces;
+using Herit.Domain.Enums;
+using MediatR;
+using NSubstitute;
+using ProposalEntity = Herit.Domain.Entities.Proposal;
+using UserEntity = Herit.Domain.Entities.User;
+using OrganisationEntity = Herit.Domain.Entities.Organisation;
 
 namespace Herit.Application.Tests.Features.Proposal.Commands;
 
 public class UpdateProposalCommandHandlerTests
 {
-    [Fact]
-    public async Task Handle_ThrowsNotImplementedException()
+    private readonly IProposalRepository _proposalRepository = Substitute.For<IProposalRepository>();
+    private readonly UpdateProposalCommandHandler _handler;
+
+    public UpdateProposalCommandHandlerTests()
     {
-        var handler = new UpdateProposalCommandHandler();
-        var command = new UpdateProposalCommand(Guid.NewGuid(), "Title", "Short", "Long");
-        await Assert.ThrowsAsync<NotImplementedException>(() => handler.Handle(command, CancellationToken.None));
+        _handler = new UpdateProposalCommandHandler(_proposalRepository);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_UpdatesProposalAndCallsUpdateAsync()
+    {
+        var proposalId = Guid.NewGuid();
+        var authorId = Guid.NewGuid();
+        var organisationId = Guid.NewGuid();
+        var proposal = ProposalEntity.Create(proposalId, "Old Title", "Old Short", authorId, organisationId, "Old Long", null);
+        _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>()).Returns(proposal);
+
+        var command = new UpdateProposalCommand(proposalId, "New Title", "New Short", "New Long");
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.Equal(Unit.Value, result);
+        await _proposalRepository.Received(1).UpdateAsync(
+            Arg.Is<ProposalEntity>(p => p.Title == "New Title" && p.ShortDescription == "New Short" && p.LongDescription == "New Long"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ProposalNotFound_ThrowsInvalidOperationException()
+    {
+        var proposalId = Guid.NewGuid();
+        _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>()).Returns((ProposalEntity?)null);
+
+        var command = new UpdateProposalCommand(proposalId, "Title", "Short", "Long");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await _proposalRepository.DidNotReceive().UpdateAsync(Arg.Any<ProposalEntity>(), Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
## Description

Implements `UpdateProposalCommandHandler` by injecting `IProposalRepository`, fetching the proposal by Id (throwing `InvalidOperationException` if not found), calling `proposal.Update(...)`, and then calling `UpdateAsync`. Replaces the placeholder test with tests for the happy path and the not-found case.

## Linked Issue

Closes #71

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- Happy path: verifies `UpdateAsync` is called with the updated proposal fields.
- Not-found case: verifies `InvalidOperationException` is thrown and `UpdateAsync` is never called.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)