### PR TITLE
Implement DeleteProposalCommandHandler

### DIFF
--- a/src/Herit.Application/Features/Proposal/Commands/DeleteProposal/DeleteProposalCommand.cs
+++ b/src/Herit.Application/Features/Proposal/Commands/DeleteProposal/DeleteProposalCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.Proposal.Commands.DeleteProposal;
@@ -6,8 +7,20 @@ public record DeleteProposalCommand(Guid Id) : IRequest<Unit>;
 
 public class DeleteProposalCommandHandler : IRequestHandler<DeleteProposalCommand, Unit>
 {
-    public Task<Unit> Handle(DeleteProposalCommand request, CancellationToken cancellationToken)
+    private readonly IProposalRepository _proposalRepository;
+
+    public DeleteProposalCommandHandler(IProposalRepository proposalRepository)
     {
-        throw new NotImplementedException();
+        _proposalRepository = proposalRepository;
+    }
+
+    public async Task<Unit> Handle(DeleteProposalCommand request, CancellationToken cancellationToken)
+    {
+        var proposal = await _proposalRepository.GetByIdAsync(request.Id, cancellationToken);
+        if (proposal is null)
+            throw new InvalidOperationException($"Proposal '{request.Id}' does not exist.");
+
+        await _proposalRepository.DeleteAsync(request.Id, cancellationToken);
+        return Unit.Value;
     }
 }

--- a/tests/Herit.Application.Tests/Features/Proposal/Commands/DeleteProposalCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Proposal/Commands/DeleteProposalCommandHandlerTests.cs
@@ -1,14 +1,47 @@
 using Herit.Application.Features.Proposal.Commands.DeleteProposal;
+using Herit.Application.Interfaces;
+using MediatR;
+using NSubstitute;
+using ProposalEntity = Herit.Domain.Entities.Proposal;
 
 namespace Herit.Application.Tests.Features.Proposal.Commands;
 
 public class DeleteProposalCommandHandlerTests
 {
-    [Fact]
-    public async Task Handle_ThrowsNotImplementedException()
+    private readonly IProposalRepository _proposalRepository = Substitute.For<IProposalRepository>();
+    private readonly DeleteProposalCommandHandler _handler;
+
+    public DeleteProposalCommandHandlerTests()
     {
-        var handler = new DeleteProposalCommandHandler();
-        var command = new DeleteProposalCommand(Guid.NewGuid());
-        await Assert.ThrowsAsync<NotImplementedException>(() => handler.Handle(command, CancellationToken.None));
+        _handler = new DeleteProposalCommandHandler(_proposalRepository);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_CallsDeleteAsync()
+    {
+        var proposalId = Guid.NewGuid();
+        var authorId = Guid.NewGuid();
+        var organisationId = Guid.NewGuid();
+        var proposal = ProposalEntity.Create(proposalId, "Title", "Short", authorId, organisationId, "Long", null);
+        _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>()).Returns(proposal);
+
+        var command = new DeleteProposalCommand(proposalId);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.Equal(Unit.Value, result);
+        await _proposalRepository.Received(1).DeleteAsync(proposalId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ProposalNotFound_ThrowsInvalidOperationException()
+    {
+        var proposalId = Guid.NewGuid();
+        _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>()).Returns((ProposalEntity?)null);
+
+        var command = new DeleteProposalCommand(proposalId);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await _proposalRepository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
## Description

Implements `DeleteProposalCommandHandler` by injecting `IProposalRepository`, fetching the proposal by Id (throwing `InvalidOperationException` if not found), then calling `DeleteAsync`. Replaces the placeholder test with tests for the happy path and the not-found case.

## Linked Issue

Closes #72

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- Happy path: verifies `DeleteAsync` is called with the correct proposal Id.
- Not-found case: verifies `InvalidOperationException` is thrown and `DeleteAsync` is never called.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)