### PR TITLE
Implement SetProposalVisibilityCommandHandler

### DIFF
--- a/src/Herit.Application/Features/Proposal/Commands/SetProposalVisibility/SetProposalVisibilityCommand.cs
+++ b/src/Herit.Application/Features/Proposal/Commands/SetProposalVisibility/SetProposalVisibilityCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
 using MediatR;
 
@@ -7,8 +8,21 @@ public record SetProposalVisibilityCommand(Guid Id, ProposalVisibility Visibilit
 
 public class SetProposalVisibilityCommandHandler : IRequestHandler<SetProposalVisibilityCommand, Unit>
 {
-    public Task<Unit> Handle(SetProposalVisibilityCommand request, CancellationToken cancellationToken)
+    private readonly IProposalRepository _proposalRepository;
+
+    public SetProposalVisibilityCommandHandler(IProposalRepository proposalRepository)
     {
-        throw new NotImplementedException();
+        _proposalRepository = proposalRepository;
+    }
+
+    public async Task<Unit> Handle(SetProposalVisibilityCommand request, CancellationToken cancellationToken)
+    {
+        var proposal = await _proposalRepository.GetByIdAsync(request.Id, cancellationToken);
+        if (proposal is null)
+            throw new InvalidOperationException($"Proposal '{request.Id}' does not exist.");
+
+        proposal.SetVisibility(request.Visibility);
+        await _proposalRepository.UpdateAsync(proposal, cancellationToken);
+        return Unit.Value;
     }
 }

--- a/tests/Herit.Application.Tests/Features/Proposal/Commands/SetProposalVisibilityCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Proposal/Commands/SetProposalVisibilityCommandHandlerTests.cs
@@ -1,15 +1,46 @@
 using Herit.Application.Features.Proposal.Commands.SetProposalVisibility;
+using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
+using MediatR;
+using NSubstitute;
+using ProposalEntity = Herit.Domain.Entities.Proposal;
 
 namespace Herit.Application.Tests.Features.Proposal.Commands;
 
 public class SetProposalVisibilityCommandHandlerTests
 {
-    [Fact]
-    public async Task Handle_ThrowsNotImplementedException()
+    private readonly IProposalRepository _proposalRepository = Substitute.For<IProposalRepository>();
+    private readonly SetProposalVisibilityCommandHandler _handler;
+
+    public SetProposalVisibilityCommandHandlerTests()
     {
-        var handler = new SetProposalVisibilityCommandHandler();
-        var command = new SetProposalVisibilityCommand(Guid.NewGuid(), ProposalVisibility.Public);
-        await Assert.ThrowsAsync<NotImplementedException>(() => handler.Handle(command, CancellationToken.None));
+        _handler = new SetProposalVisibilityCommandHandler(_proposalRepository);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_SetsVisibilityAndCallsUpdateAsync()
+    {
+        var proposalId = Guid.NewGuid();
+        var proposal = ProposalEntity.Create(proposalId, "Title", "Short", Guid.NewGuid(), Guid.NewGuid(), "Long");
+        _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>()).Returns(proposal);
+
+        var result = await _handler.Handle(new SetProposalVisibilityCommand(proposalId, ProposalVisibility.Public), CancellationToken.None);
+
+        Assert.Equal(Unit.Value, result);
+        Assert.Equal(ProposalVisibility.Public, proposal.Visibility);
+        await _proposalRepository.Received(1).UpdateAsync(
+            Arg.Is<ProposalEntity>(p => p.Visibility == ProposalVisibility.Public),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ProposalNotFound_ThrowsInvalidOperationException()
+    {
+        var proposalId = Guid.NewGuid();
+        _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>()).Returns((ProposalEntity?)null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _handler.Handle(new SetProposalVisibilityCommand(proposalId, ProposalVisibility.Public), CancellationToken.None));
+        await _proposalRepository.DidNotReceive().UpdateAsync(Arg.Any<ProposalEntity>(), Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
## Description

Implements `SetProposalVisibilityCommandHandler` by injecting `IProposalRepository`, fetching the proposal by Id (throwing `InvalidOperationException` if not found), calling `proposal.SetVisibility(request.Visibility)`, then calling `UpdateAsync`. Replaces the placeholder test with tests for the happy path and the not-found case.

## Linked Issue

Closes #75

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- Happy path: verifies `SetVisibility` is applied and `UpdateAsync` is called with the updated proposal.
- Not-found case: verifies `InvalidOperationException` is thrown and `UpdateAsync` is never called.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)