### PR TITLE
Implement GetProposalByIdQueryHandler

### DIFF
--- a/src/Herit.Application/Features/Proposal/Queries/GetProposalById/GetProposalByIdQuery.cs
+++ b/src/Herit.Application/Features/Proposal/Queries/GetProposalById/GetProposalByIdQuery.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.Proposal.Queries.GetProposalById;
@@ -6,8 +7,13 @@ public record GetProposalByIdQuery(Guid Id) : IRequest<Herit.Domain.Entities.Pro
 
 public class GetProposalByIdQueryHandler : IRequestHandler<GetProposalByIdQuery, Herit.Domain.Entities.Proposal?>
 {
-    public Task<Herit.Domain.Entities.Proposal?> Handle(GetProposalByIdQuery request, CancellationToken cancellationToken)
+    private readonly IProposalRepository _proposalRepository;
+
+    public GetProposalByIdQueryHandler(IProposalRepository proposalRepository)
     {
-        throw new NotImplementedException();
+        _proposalRepository = proposalRepository;
     }
+
+    public Task<Herit.Domain.Entities.Proposal?> Handle(GetProposalByIdQuery request, CancellationToken cancellationToken)
+        => _proposalRepository.GetByIdAsync(request.Id, cancellationToken);
 }

--- a/tests/Herit.Application.Tests/Features/Proposal/Queries/GetProposalByIdQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Proposal/Queries/GetProposalByIdQueryHandlerTests.cs
@@ -1,14 +1,41 @@
 using Herit.Application.Features.Proposal.Queries.GetProposalById;
+using Herit.Application.Interfaces;
+using NSubstitute;
+using ProposalEntity = Herit.Domain.Entities.Proposal;
 
 namespace Herit.Application.Tests.Features.Proposal.Queries;
 
 public class GetProposalByIdQueryHandlerTests
 {
-    [Fact]
-    public async Task Handle_ThrowsNotImplementedException()
+    private readonly IProposalRepository _proposalRepository = Substitute.For<IProposalRepository>();
+    private readonly GetProposalByIdQueryHandler _handler;
+
+    public GetProposalByIdQueryHandlerTests()
     {
-        var handler = new GetProposalByIdQueryHandler();
-        var query = new GetProposalByIdQuery(Guid.NewGuid());
-        await Assert.ThrowsAsync<NotImplementedException>(() => handler.Handle(query, CancellationToken.None));
+        _handler = new GetProposalByIdQueryHandler(_proposalRepository);
+    }
+
+    [Fact]
+    public async Task Handle_ProposalFound_ReturnsProposal()
+    {
+        var proposalId = Guid.NewGuid();
+        var proposal = ProposalEntity.Create(proposalId, "Title", "Short", Guid.NewGuid(), Guid.NewGuid(), "Long");
+        _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>()).Returns(proposal);
+
+        var result = await _handler.Handle(new GetProposalByIdQuery(proposalId), CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(proposalId, result.Id);
+    }
+
+    [Fact]
+    public async Task Handle_ProposalNotFound_ReturnsNull()
+    {
+        var proposalId = Guid.NewGuid();
+        _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>()).Returns((ProposalEntity?)null);
+
+        var result = await _handler.Handle(new GetProposalByIdQuery(proposalId), CancellationToken.None);
+
+        Assert.Null(result);
     }
 }


### PR DESCRIPTION
## Description

Implements `GetProposalByIdQueryHandler` by injecting `IProposalRepository` and delegating to `GetByIdAsync`, returning `null` if not found. Replaces the placeholder test with tests for the found and not-found cases.

## Linked Issue

Closes #76

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- Found case: verifies the correct proposal is returned.
- Not-found case: verifies `null` is returned when the proposal does not exist.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)