### PR TITLE
Implement ListProposalsQueryHandler

### DIFF
--- a/src/Herit.Application/Features/Proposal/Queries/ListProposals/ListProposalsQuery.cs
+++ b/src/Herit.Application/Features/Proposal/Queries/ListProposals/ListProposalsQuery.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.Proposal.Queries.ListProposals;
@@ -6,8 +7,13 @@ public record ListProposalsQuery() : IRequest<IEnumerable<Herit.Domain.Entities.
 
 public class ListProposalsQueryHandler : IRequestHandler<ListProposalsQuery, IEnumerable<Herit.Domain.Entities.Proposal>>
 {
-    public Task<IEnumerable<Herit.Domain.Entities.Proposal>> Handle(ListProposalsQuery request, CancellationToken cancellationToken)
+    private readonly IProposalRepository _proposalRepository;
+
+    public ListProposalsQueryHandler(IProposalRepository proposalRepository)
     {
-        throw new NotImplementedException();
+        _proposalRepository = proposalRepository;
     }
+
+    public Task<IEnumerable<Herit.Domain.Entities.Proposal>> Handle(ListProposalsQuery request, CancellationToken cancellationToken)
+        => _proposalRepository.ListAsync(cancellationToken);
 }

--- a/tests/Herit.Application.Tests/Features/Proposal/Queries/ListProposalsQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Proposal/Queries/ListProposalsQueryHandlerTests.cs
@@ -1,14 +1,42 @@
 using Herit.Application.Features.Proposal.Queries.ListProposals;
+using Herit.Application.Interfaces;
+using NSubstitute;
+using ProposalEntity = Herit.Domain.Entities.Proposal;
 
 namespace Herit.Application.Tests.Features.Proposal.Queries;
 
 public class ListProposalsQueryHandlerTests
 {
-    [Fact]
-    public async Task Handle_ThrowsNotImplementedException()
+    private readonly IProposalRepository _proposalRepository = Substitute.For<IProposalRepository>();
+    private readonly ListProposalsQueryHandler _handler;
+
+    public ListProposalsQueryHandlerTests()
     {
-        var handler = new ListProposalsQueryHandler();
-        var query = new ListProposalsQuery();
-        await Assert.ThrowsAsync<NotImplementedException>(() => handler.Handle(query, CancellationToken.None));
+        _handler = new ListProposalsQueryHandler(_proposalRepository);
+    }
+
+    [Fact]
+    public async Task Handle_NonEmptyList_ReturnsAllProposals()
+    {
+        var proposals = new[]
+        {
+            ProposalEntity.Create(Guid.NewGuid(), "Title 1", "Short 1", Guid.NewGuid(), Guid.NewGuid(), "Long 1"),
+            ProposalEntity.Create(Guid.NewGuid(), "Title 2", "Short 2", Guid.NewGuid(), Guid.NewGuid(), "Long 2")
+        };
+        _proposalRepository.ListAsync(Arg.Any<CancellationToken>()).Returns(proposals);
+
+        var result = await _handler.Handle(new ListProposalsQuery(), CancellationToken.None);
+
+        Assert.Equal(2, result.Count());
+    }
+
+    [Fact]
+    public async Task Handle_EmptyList_ReturnsEmptyEnumerable()
+    {
+        _proposalRepository.ListAsync(Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<ProposalEntity>());
+
+        var result = await _handler.Handle(new ListProposalsQuery(), CancellationToken.None);
+
+        Assert.Empty(result);
     }
 }


### PR DESCRIPTION
## Description

Implements `ListProposalsQueryHandler` by injecting `IProposalRepository` and delegating to `ListAsync`. Replaces the placeholder test with tests for a non-empty list and an empty list.

## Linked Issue

Closes #77

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- Non-empty list: verifies all proposals returned by the repository are returned.
- Empty list: verifies an empty enumerable is returned when there are no proposals.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)