### PR TITLE
Add domain methods to Cfeoi entity

### DIFF
--- a/src/Herit.Domain/Entities/Cfeoi.cs
+++ b/src/Herit.Domain/Entities/Cfeoi.cs
@@ -4,6 +4,12 @@ namespace Herit.Domain.Entities;
 
 public class Cfeoi
 {
+    private static readonly Dictionary<CfeoiStatus, CfeoiStatus[]> AllowedTransitions = new()
+    {
+        [CfeoiStatus.Open] = [CfeoiStatus.Closed],
+        [CfeoiStatus.Closed] = []
+    };
+
     public Guid Id { get; private set; }
     public string Title { get; private set; } = default!;
     public string Description { get; private set; } = default!;
@@ -24,5 +30,13 @@ public class Cfeoi
             ProposalId = proposalId,
             Status = CfeoiStatus.Open
         };
+    }
+
+    public void TransitionStatus(CfeoiStatus newStatus)
+    {
+        if (!AllowedTransitions[Status].Contains(newStatus))
+            throw new InvalidOperationException($"Cannot transition from {Status} to {newStatus}.");
+
+        Status = newStatus;
     }
 }

--- a/tests/Herit.Domain.Tests/Entities/CfeoiTests.cs
+++ b/tests/Herit.Domain.Tests/Entities/CfeoiTests.cs
@@ -1,0 +1,59 @@
+using Herit.Domain.Entities;
+using Herit.Domain.Enums;
+
+namespace Herit.Domain.Tests.Entities;
+
+public class CfeoiTests
+{
+    private static Cfeoi CreateOpenCfeoi() =>
+        Cfeoi.Create(Guid.NewGuid(), "Title", "Description", CfeoiResourceType.Human, Guid.NewGuid());
+
+    // Create tests
+
+    [Fact]
+    public void Create_SetsPropertiesAndDefaultsToOpen()
+    {
+        var id = Guid.NewGuid();
+        var proposalId = Guid.NewGuid();
+
+        var cfeoi = Cfeoi.Create(id, "Title", "Description", CfeoiResourceType.Human, proposalId);
+
+        Assert.Equal(id, cfeoi.Id);
+        Assert.Equal("Title", cfeoi.Title);
+        Assert.Equal("Description", cfeoi.Description);
+        Assert.Equal(CfeoiResourceType.Human, cfeoi.ResourceType);
+        Assert.Equal(proposalId, cfeoi.ProposalId);
+        Assert.Equal(CfeoiStatus.Open, cfeoi.Status);
+    }
+
+    // TransitionStatus — legal transitions
+
+    [Fact]
+    public void TransitionStatus_OpenToClosed_Succeeds()
+    {
+        var cfeoi = CreateOpenCfeoi();
+
+        cfeoi.TransitionStatus(CfeoiStatus.Closed);
+
+        Assert.Equal(CfeoiStatus.Closed, cfeoi.Status);
+    }
+
+    // TransitionStatus — illegal transitions
+
+    [Fact]
+    public void TransitionStatus_OpenToOpen_Throws()
+    {
+        var cfeoi = CreateOpenCfeoi();
+
+        Assert.Throws<InvalidOperationException>(() => cfeoi.TransitionStatus(CfeoiStatus.Open));
+    }
+
+    [Fact]
+    public void TransitionStatus_ClosedToOpen_Throws()
+    {
+        var cfeoi = CreateOpenCfeoi();
+        cfeoi.TransitionStatus(CfeoiStatus.Closed);
+
+        Assert.Throws<InvalidOperationException>(() => cfeoi.TransitionStatus(CfeoiStatus.Open));
+    }
+}


### PR DESCRIPTION
## Description

Adds `TransitionStatus(CfeoiStatus newStatus)` to the `Cfeoi` domain entity following the same pattern as `Rfp`. The only allowed transition is `Open → Closed`; all others throw `InvalidOperationException`.

## Linked Issue

Closes #85

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Added `CfeoiTests.cs` covering `Create`, the valid `Open → Closed` transition, and two illegal transition attempts.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)