### PR TITLE
Implement CfeoiRepository

### DIFF
--- a/src/Herit.Infrastructure/Repositories/CfeoiRepository.cs
+++ b/src/Herit.Infrastructure/Repositories/CfeoiRepository.cs
@@ -1,6 +1,7 @@
 using Herit.Application.Interfaces;
 using Herit.Domain.Entities;
 using Herit.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
 
 namespace Herit.Infrastructure.Repositories;
 
@@ -14,14 +15,27 @@ public class CfeoiRepository : ICfeoiRepository
     }
 
     public Task<Cfeoi?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
-        => throw new NotImplementedException();
+        => _context.Cfeois.FindAsync([id], cancellationToken).AsTask();
 
-    public Task<IEnumerable<Cfeoi>> ListByProposalAsync(Guid proposalId, CancellationToken cancellationToken = default)
-        => throw new NotImplementedException();
+    public async Task<IEnumerable<Cfeoi>> ListByProposalAsync(Guid proposalId, CancellationToken cancellationToken = default)
+        => await _context.Cfeois
+            .Where(c => c.ProposalId == proposalId)
+            .ToListAsync(cancellationToken);
 
-    public Task AddAsync(Cfeoi cfeoi, CancellationToken cancellationToken = default)
-        => throw new NotImplementedException();
+    public async Task AddAsync(Cfeoi cfeoi, CancellationToken cancellationToken = default)
+    {
+        await _context.Cfeois.AddAsync(cfeoi, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
 
-    public Task UpdateAsync(Cfeoi cfeoi, CancellationToken cancellationToken = default)
-        => throw new NotImplementedException();
+    public async Task UpdateAsync(Cfeoi cfeoi, CancellationToken cancellationToken = default)
+    {
+        var tracked = _context.ChangeTracker.Entries<Cfeoi>()
+            .FirstOrDefault(e => e.Entity.Id == cfeoi.Id);
+        if (tracked is not null)
+            tracked.State = EntityState.Detached;
+
+        _context.Cfeois.Update(cfeoi);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
 }

--- a/tests/Herit.Infrastructure.Tests/Repositories/CfeoiRepositoryTests.cs
+++ b/tests/Herit.Infrastructure.Tests/Repositories/CfeoiRepositoryTests.cs
@@ -1,0 +1,106 @@
+using Herit.Domain.Entities;
+using Herit.Domain.Enums;
+using Herit.Infrastructure.Persistence;
+using Herit.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Herit.Infrastructure.Tests.Repositories;
+
+public class CfeoiRepositoryTests : IDisposable
+{
+    private readonly HeritDbContext _context;
+    private readonly CfeoiRepository _repository;
+
+    public CfeoiRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<HeritDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _context = new HeritDbContext(options);
+        _repository = new CfeoiRepository(_context);
+    }
+
+    public void Dispose() => _context.Dispose();
+
+    private static Cfeoi CreateCfeoi(Guid? id = null, Guid? proposalId = null, string title = "Test CFEOI")
+        => Cfeoi.Create(
+            id ?? Guid.NewGuid(),
+            title,
+            "Description",
+            CfeoiResourceType.Human,
+            proposalId ?? Guid.NewGuid());
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsCfeoi_WhenExists()
+    {
+        var id = Guid.NewGuid();
+        var cfeoi = CreateCfeoi(id, title: "My CFEOI");
+        await _repository.AddAsync(cfeoi);
+
+        var result = await _repository.GetByIdAsync(id);
+
+        Assert.NotNull(result);
+        Assert.Equal(id, result.Id);
+        Assert.Equal("My CFEOI", result.Title);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsNull_WhenNotExists()
+    {
+        var result = await _repository.GetByIdAsync(Guid.NewGuid());
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ListByProposalAsync_ReturnsMatchingCfeois()
+    {
+        var proposalId = Guid.NewGuid();
+        await _repository.AddAsync(CreateCfeoi(proposalId: proposalId, title: "CFEOI A"));
+        await _repository.AddAsync(CreateCfeoi(proposalId: proposalId, title: "CFEOI B"));
+        await _repository.AddAsync(CreateCfeoi(title: "Other CFEOI"));
+
+        var result = await _repository.ListByProposalAsync(proposalId);
+
+        Assert.Equal(2, result.Count());
+        Assert.All(result, c => Assert.Equal(proposalId, c.ProposalId));
+    }
+
+    [Fact]
+    public async Task ListByProposalAsync_WhenNoneMatch_ReturnsEmptyCollection()
+    {
+        await _repository.AddAsync(CreateCfeoi(title: "Other CFEOI"));
+
+        var result = await _repository.ListByProposalAsync(Guid.NewGuid());
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task AddAsync_PersistsCfeoi()
+    {
+        var id = Guid.NewGuid();
+        var cfeoi = CreateCfeoi(id, title: "New CFEOI");
+
+        await _repository.AddAsync(cfeoi);
+
+        var persisted = await _context.Cfeois.FindAsync(id);
+        Assert.NotNull(persisted);
+        Assert.Equal("New CFEOI", persisted.Title);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_PersistsChanges()
+    {
+        var id = Guid.NewGuid();
+        var cfeoi = CreateCfeoi(id, title: "Original Title");
+        await _repository.AddAsync(cfeoi);
+
+        cfeoi.TransitionStatus(CfeoiStatus.Closed);
+        await _repository.UpdateAsync(cfeoi);
+
+        var persisted = await _context.Cfeois.FindAsync(id);
+        Assert.NotNull(persisted);
+        Assert.Equal(CfeoiStatus.Closed, persisted.Status);
+    }
+}


### PR DESCRIPTION
## Description

Implements all four methods in `CfeoiRepository` — `GetByIdAsync`, `ListByProposalAsync`, `AddAsync`, `UpdateAsync` — following the pattern in `RfpRepository`. `ListByProposalAsync` filters by `ProposalId`.

## Linked Issue

Closes #86

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Added `CfeoiRepositoryTests.cs` covering all four methods including both populated and empty results for `ListByProposalAsync`.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)