### PR TITLE
Implement PublishCfeoiCommandHandler

### DIFF
--- a/src/Herit.Application/Features/Cfeoi/Commands/PublishCfeoi/PublishCfeoiCommand.cs
+++ b/src/Herit.Application/Features/Cfeoi/Commands/PublishCfeoi/PublishCfeoiCommand.cs
@@ -1,5 +1,7 @@
+using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
 using MediatR;
+using CfeoiEntity = Herit.Domain.Entities.Cfeoi;
 
 namespace Herit.Application.Features.Cfeoi.Commands.PublishCfeoi;
 
@@ -11,8 +13,24 @@ public record PublishCfeoiCommand(
 
 public class PublishCfeoiCommandHandler : IRequestHandler<PublishCfeoiCommand, Guid>
 {
-    public Task<Guid> Handle(PublishCfeoiCommand request, CancellationToken cancellationToken)
+    private readonly ICfeoiRepository _cfeoiRepository;
+    private readonly IProposalRepository _proposalRepository;
+
+    public PublishCfeoiCommandHandler(ICfeoiRepository cfeoiRepository, IProposalRepository proposalRepository)
     {
-        throw new NotImplementedException();
+        _cfeoiRepository = cfeoiRepository;
+        _proposalRepository = proposalRepository;
+    }
+
+    public async Task<Guid> Handle(PublishCfeoiCommand request, CancellationToken cancellationToken)
+    {
+        var proposal = await _proposalRepository.GetByIdAsync(request.ProposalId, cancellationToken);
+        if (proposal is null)
+            throw new InvalidOperationException($"Proposal '{request.ProposalId}' does not exist.");
+
+        var id = Guid.NewGuid();
+        var cfeoi = CfeoiEntity.Create(id, request.Title, request.Description, request.ResourceType, request.ProposalId);
+        await _cfeoiRepository.AddAsync(cfeoi, cancellationToken);
+        return id;
     }
 }

--- a/tests/Herit.Application.Tests/Features/Cfeoi/Commands/PublishCfeoiCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Cfeoi/Commands/PublishCfeoiCommandHandlerTests.cs
@@ -1,15 +1,49 @@
 using Herit.Application.Features.Cfeoi.Commands.PublishCfeoi;
+using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
+using NSubstitute;
+using CfeoiEntity = Herit.Domain.Entities.Cfeoi;
+using ProposalEntity = Herit.Domain.Entities.Proposal;
 
 namespace Herit.Application.Tests.Features.Cfeoi.Commands;
 
 public class PublishCfeoiCommandHandlerTests
 {
-    [Fact]
-    public async Task Handle_ThrowsNotImplementedException()
+    private readonly ICfeoiRepository _cfeoiRepository = Substitute.For<ICfeoiRepository>();
+    private readonly IProposalRepository _proposalRepository = Substitute.For<IProposalRepository>();
+    private readonly PublishCfeoiCommandHandler _handler;
+
+    public PublishCfeoiCommandHandlerTests()
     {
-        var handler = new PublishCfeoiCommandHandler();
-        var command = new PublishCfeoiCommand("Title", "Desc", CfeoiResourceType.Human, Guid.NewGuid());
-        await Assert.ThrowsAsync<NotImplementedException>(() => handler.Handle(command, CancellationToken.None));
+        _handler = new PublishCfeoiCommandHandler(_cfeoiRepository, _proposalRepository);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_ReturnsValidGuidAndCallsAddAsync()
+    {
+        var proposalId = Guid.NewGuid();
+        _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>())
+            .Returns(ProposalEntity.Create(proposalId, "Title", "Short", Guid.NewGuid(), Guid.NewGuid(), "Long"));
+
+        var command = new PublishCfeoiCommand("CFEOI Title", "Description", CfeoiResourceType.Human, proposalId);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.NotEqual(Guid.Empty, result);
+        await _cfeoiRepository.Received(1).AddAsync(
+            Arg.Is<CfeoiEntity>(c => c.Title == "CFEOI Title" && c.ProposalId == proposalId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ProposalNotFound_ThrowsInvalidOperationException()
+    {
+        var proposalId = Guid.NewGuid();
+        _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>()).Returns((ProposalEntity?)null);
+
+        var command = new PublishCfeoiCommand("CFEOI Title", "Description", CfeoiResourceType.Human, proposalId);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await _cfeoiRepository.DidNotReceive().AddAsync(Arg.Any<CfeoiEntity>(), Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
## Description

Implements `PublishCfeoiCommandHandler` by injecting `ICfeoiRepository` and `IProposalRepository`, validating the referenced proposal exists, then calling `Cfeoi.Create` and `AddAsync`.

## Linked Issue

Closes #87

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Replaced the placeholder test with tests for the happy path and the not-found proposal case.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)