### PR TITLE
Implement GetCfeoiByIdQueryHandler and ListCfeoisByProposalQueryHandler

### DIFF
--- a/src/Herit.Application/Features/Cfeoi/Queries/GetCfeoiById/GetCfeoiByIdQuery.cs
+++ b/src/Herit.Application/Features/Cfeoi/Queries/GetCfeoiById/GetCfeoiByIdQuery.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.Cfeoi.Queries.GetCfeoiById;
@@ -6,8 +7,13 @@ public record GetCfeoiByIdQuery(Guid Id) : IRequest<Herit.Domain.Entities.Cfeoi?
 
 public class GetCfeoiByIdQueryHandler : IRequestHandler<GetCfeoiByIdQuery, Herit.Domain.Entities.Cfeoi?>
 {
-    public Task<Herit.Domain.Entities.Cfeoi?> Handle(GetCfeoiByIdQuery request, CancellationToken cancellationToken)
+    private readonly ICfeoiRepository _cfeoiRepository;
+
+    public GetCfeoiByIdQueryHandler(ICfeoiRepository cfeoiRepository)
     {
-        throw new NotImplementedException();
+        _cfeoiRepository = cfeoiRepository;
     }
+
+    public Task<Herit.Domain.Entities.Cfeoi?> Handle(GetCfeoiByIdQuery request, CancellationToken cancellationToken)
+        => _cfeoiRepository.GetByIdAsync(request.Id, cancellationToken);
 }

--- a/src/Herit.Application/Features/Cfeoi/Queries/ListCfeoisByProposal/ListCfeoisByProposalQuery.cs
+++ b/src/Herit.Application/Features/Cfeoi/Queries/ListCfeoisByProposal/ListCfeoisByProposalQuery.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.Cfeoi.Queries.ListCfeoisByProposal;
@@ -6,8 +7,13 @@ public record ListCfeoisByProposalQuery(Guid ProposalId) : IRequest<IEnumerable<
 
 public class ListCfeoisByProposalQueryHandler : IRequestHandler<ListCfeoisByProposalQuery, IEnumerable<Herit.Domain.Entities.Cfeoi>>
 {
-    public Task<IEnumerable<Herit.Domain.Entities.Cfeoi>> Handle(ListCfeoisByProposalQuery request, CancellationToken cancellationToken)
+    private readonly ICfeoiRepository _cfeoiRepository;
+
+    public ListCfeoisByProposalQueryHandler(ICfeoiRepository cfeoiRepository)
     {
-        throw new NotImplementedException();
+        _cfeoiRepository = cfeoiRepository;
     }
+
+    public Task<IEnumerable<Herit.Domain.Entities.Cfeoi>> Handle(ListCfeoisByProposalQuery request, CancellationToken cancellationToken)
+        => _cfeoiRepository.ListByProposalAsync(request.ProposalId, cancellationToken);
 }

--- a/tests/Herit.Application.Tests/Features/Cfeoi/Queries/GetCfeoiByIdQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Cfeoi/Queries/GetCfeoiByIdQueryHandlerTests.cs
@@ -1,14 +1,42 @@
 using Herit.Application.Features.Cfeoi.Queries.GetCfeoiById;
+using Herit.Application.Interfaces;
+using Herit.Domain.Enums;
+using NSubstitute;
+using CfeoiEntity = Herit.Domain.Entities.Cfeoi;
 
 namespace Herit.Application.Tests.Features.Cfeoi.Queries;
 
 public class GetCfeoiByIdQueryHandlerTests
 {
-    [Fact]
-    public async Task Handle_ThrowsNotImplementedException()
+    private readonly ICfeoiRepository _cfeoiRepository = Substitute.For<ICfeoiRepository>();
+    private readonly GetCfeoiByIdQueryHandler _handler;
+
+    public GetCfeoiByIdQueryHandlerTests()
     {
-        var handler = new GetCfeoiByIdQueryHandler();
-        var query = new GetCfeoiByIdQuery(Guid.NewGuid());
-        await Assert.ThrowsAsync<NotImplementedException>(() => handler.Handle(query, CancellationToken.None));
+        _handler = new GetCfeoiByIdQueryHandler(_cfeoiRepository);
+    }
+
+    [Fact]
+    public async Task Handle_CfeoiFound_ReturnsCfeoi()
+    {
+        var cfeoiId = Guid.NewGuid();
+        var cfeoi = CfeoiEntity.Create(cfeoiId, "Title", "Description", CfeoiResourceType.Human, Guid.NewGuid());
+        _cfeoiRepository.GetByIdAsync(cfeoiId, Arg.Any<CancellationToken>()).Returns(cfeoi);
+
+        var result = await _handler.Handle(new GetCfeoiByIdQuery(cfeoiId), CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(cfeoiId, result.Id);
+    }
+
+    [Fact]
+    public async Task Handle_CfeoiNotFound_ReturnsNull()
+    {
+        var cfeoiId = Guid.NewGuid();
+        _cfeoiRepository.GetByIdAsync(cfeoiId, Arg.Any<CancellationToken>()).Returns((CfeoiEntity?)null);
+
+        var result = await _handler.Handle(new GetCfeoiByIdQuery(cfeoiId), CancellationToken.None);
+
+        Assert.Null(result);
     }
 }

--- a/tests/Herit.Application.Tests/Features/Cfeoi/Queries/ListCfeoisByProposalQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Cfeoi/Queries/ListCfeoisByProposalQueryHandlerTests.cs
@@ -1,14 +1,45 @@
 using Herit.Application.Features.Cfeoi.Queries.ListCfeoisByProposal;
+using Herit.Application.Interfaces;
+using Herit.Domain.Enums;
+using NSubstitute;
+using CfeoiEntity = Herit.Domain.Entities.Cfeoi;
 
 namespace Herit.Application.Tests.Features.Cfeoi.Queries;
 
 public class ListCfeoisByProposalQueryHandlerTests
 {
-    [Fact]
-    public async Task Handle_ThrowsNotImplementedException()
+    private readonly ICfeoiRepository _cfeoiRepository = Substitute.For<ICfeoiRepository>();
+    private readonly ListCfeoisByProposalQueryHandler _handler;
+
+    public ListCfeoisByProposalQueryHandlerTests()
     {
-        var handler = new ListCfeoisByProposalQueryHandler();
-        var query = new ListCfeoisByProposalQuery(Guid.NewGuid());
-        await Assert.ThrowsAsync<NotImplementedException>(() => handler.Handle(query, CancellationToken.None));
+        _handler = new ListCfeoisByProposalQueryHandler(_cfeoiRepository);
+    }
+
+    [Fact]
+    public async Task Handle_NonEmptyList_ReturnsAllCfeois()
+    {
+        var proposalId = Guid.NewGuid();
+        var cfeois = new[]
+        {
+            CfeoiEntity.Create(Guid.NewGuid(), "Title 1", "Description 1", CfeoiResourceType.Human, proposalId),
+            CfeoiEntity.Create(Guid.NewGuid(), "Title 2", "Description 2", CfeoiResourceType.NonHuman, proposalId)
+        };
+        _cfeoiRepository.ListByProposalAsync(proposalId, Arg.Any<CancellationToken>()).Returns(cfeois);
+
+        var result = await _handler.Handle(new ListCfeoisByProposalQuery(proposalId), CancellationToken.None);
+
+        Assert.Equal(2, result.Count());
+    }
+
+    [Fact]
+    public async Task Handle_EmptyList_ReturnsEmptyEnumerable()
+    {
+        var proposalId = Guid.NewGuid();
+        _cfeoiRepository.ListByProposalAsync(proposalId, Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<CfeoiEntity>());
+
+        var result = await _handler.Handle(new ListCfeoisByProposalQuery(proposalId), CancellationToken.None);
+
+        Assert.Empty(result);
     }
 }


### PR DESCRIPTION
## Description

Implements `GetCfeoiByIdQueryHandler` and `ListCfeoisByProposalQueryHandler` by injecting `ICfeoiRepository` and delegating to the appropriate repository methods.

## Linked Issue

Closes #89
Closes #90

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Replaced placeholder tests with tests for the found/not-found cases (GetById) and non-empty/empty list cases (ListByProposal).

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)