### PR TITLE
Add domain methods to Eoi entity

### DIFF
--- a/src/Herit.Domain/Entities/Eoi.cs
+++ b/src/Herit.Domain/Entities/Eoi.cs
@@ -4,6 +4,13 @@ namespace Herit.Domain.Entities;
 
 public class Eoi
 {
+    private static readonly Dictionary<EoiStatus, EoiStatus[]> AllowedTransitions = new()
+    {
+        [EoiStatus.Pending] = [EoiStatus.Approved, EoiStatus.Rejected],
+        [EoiStatus.Approved] = [],
+        [EoiStatus.Rejected] = []
+    };
+
     public Guid Id { get; private set; }
     public Guid SubmittedById { get; private set; }
     public string Message { get; private set; } = default!;
@@ -24,5 +31,18 @@ public class Eoi
             Status = EoiStatus.Pending,
             Visibility = EoiVisibility.Private
         };
+    }
+
+    public void TransitionStatus(EoiStatus newStatus)
+    {
+        if (!AllowedTransitions[Status].Contains(newStatus))
+            throw new InvalidOperationException($"Cannot transition from {Status} to {newStatus}.");
+
+        Status = newStatus;
+    }
+
+    public void SetVisibility(EoiVisibility visibility)
+    {
+        Visibility = visibility;
     }
 }

--- a/tests/Herit.Domain.Tests/Entities/EoiTests.cs
+++ b/tests/Herit.Domain.Tests/Entities/EoiTests.cs
@@ -1,0 +1,82 @@
+using Herit.Domain.Entities;
+using Herit.Domain.Enums;
+
+namespace Herit.Domain.Tests.Entities;
+
+public class EoiTests
+{
+    private static Eoi CreatePendingEoi() =>
+        Eoi.Create(Guid.NewGuid(), Guid.NewGuid(), "Message", Guid.NewGuid());
+
+    // Create tests
+
+    [Fact]
+    public void Create_SetsPropertiesAndDefaultsToPendingPrivate()
+    {
+        var id = Guid.NewGuid();
+        var submittedById = Guid.NewGuid();
+        var cfeoiId = Guid.NewGuid();
+
+        var eoi = Eoi.Create(id, submittedById, "My message", cfeoiId);
+
+        Assert.Equal(id, eoi.Id);
+        Assert.Equal(submittedById, eoi.SubmittedById);
+        Assert.Equal("My message", eoi.Message);
+        Assert.Equal(cfeoiId, eoi.CfeoiId);
+        Assert.Equal(EoiStatus.Pending, eoi.Status);
+        Assert.Equal(EoiVisibility.Private, eoi.Visibility);
+    }
+
+    // TransitionStatus — legal transitions
+
+    [Fact]
+    public void TransitionStatus_PendingToApproved_Succeeds()
+    {
+        var eoi = CreatePendingEoi();
+
+        eoi.TransitionStatus(EoiStatus.Approved);
+
+        Assert.Equal(EoiStatus.Approved, eoi.Status);
+    }
+
+    [Fact]
+    public void TransitionStatus_PendingToRejected_Succeeds()
+    {
+        var eoi = CreatePendingEoi();
+
+        eoi.TransitionStatus(EoiStatus.Rejected);
+
+        Assert.Equal(EoiStatus.Rejected, eoi.Status);
+    }
+
+    // TransitionStatus — illegal transitions
+
+    [Fact]
+    public void TransitionStatus_PendingToPending_Throws()
+    {
+        var eoi = CreatePendingEoi();
+
+        Assert.Throws<InvalidOperationException>(() => eoi.TransitionStatus(EoiStatus.Pending));
+    }
+
+    [Fact]
+    public void TransitionStatus_ApprovedToPending_Throws()
+    {
+        var eoi = CreatePendingEoi();
+        eoi.TransitionStatus(EoiStatus.Approved);
+
+        Assert.Throws<InvalidOperationException>(() => eoi.TransitionStatus(EoiStatus.Pending));
+    }
+
+    // SetVisibility tests
+
+    [Fact]
+    public void SetVisibility_UpdatesVisibility()
+    {
+        var eoi = CreatePendingEoi();
+
+        eoi.SetVisibility(EoiVisibility.Shared);
+
+        Assert.Equal(EoiVisibility.Shared, eoi.Visibility);
+    }
+}


### PR DESCRIPTION
## Description

Adds `TransitionStatus(EoiStatus newStatus)` and `SetVisibility(EoiVisibility visibility)` to the `Eoi` domain entity following the patterns in `Rfp` and `Proposal`. Allowed transitions: `Pending → Approved` and `Pending → Rejected`; all others throw `InvalidOperationException`.

## Linked Issue

Closes #91

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Added `EoiTests.cs` covering `Create`, both valid transitions, an illegal transition, and `SetVisibility`.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)