### PR TITLE
Implement EoiRepository and add ListByProposalAsync

### DIFF
--- a/src/Herit.Application/Interfaces/IEoiRepository.cs
+++ b/src/Herit.Application/Interfaces/IEoiRepository.cs
@@ -6,6 +6,7 @@ public interface IEoiRepository
 {
     Task<Eoi?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
     Task<IEnumerable<Eoi>> ListByCfeoiAsync(Guid cfeoiId, CancellationToken cancellationToken = default);
+    Task<IEnumerable<Eoi>> ListByProposalAsync(Guid proposalId, CancellationToken cancellationToken = default);
     Task AddAsync(Eoi eoi, CancellationToken cancellationToken = default);
     Task UpdateAsync(Eoi eoi, CancellationToken cancellationToken = default);
     Task DeleteAsync(Guid id, CancellationToken cancellationToken = default);

--- a/src/Herit.Infrastructure/Repositories/EoiRepository.cs
+++ b/src/Herit.Infrastructure/Repositories/EoiRepository.cs
@@ -1,6 +1,7 @@
 using Herit.Application.Interfaces;
 using Herit.Domain.Entities;
 using Herit.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
 
 namespace Herit.Infrastructure.Repositories;
 
@@ -14,17 +15,43 @@ public class EoiRepository : IEoiRepository
     }
 
     public Task<Eoi?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
-        => throw new NotImplementedException();
+        => _context.Eois.FindAsync([id], cancellationToken).AsTask();
 
-    public Task<IEnumerable<Eoi>> ListByCfeoiAsync(Guid cfeoiId, CancellationToken cancellationToken = default)
-        => throw new NotImplementedException();
+    public async Task<IEnumerable<Eoi>> ListByCfeoiAsync(Guid cfeoiId, CancellationToken cancellationToken = default)
+        => await _context.Eois
+            .Where(e => e.CfeoiId == cfeoiId)
+            .ToListAsync(cancellationToken);
 
-    public Task AddAsync(Eoi eoi, CancellationToken cancellationToken = default)
-        => throw new NotImplementedException();
+    public async Task<IEnumerable<Eoi>> ListByProposalAsync(Guid proposalId, CancellationToken cancellationToken = default)
+        => await _context.Eois
+            .Join(_context.Cfeois, e => e.CfeoiId, c => c.Id, (e, c) => new { Eoi = e, c.ProposalId })
+            .Where(x => x.ProposalId == proposalId)
+            .Select(x => x.Eoi)
+            .ToListAsync(cancellationToken);
 
-    public Task UpdateAsync(Eoi eoi, CancellationToken cancellationToken = default)
-        => throw new NotImplementedException();
+    public async Task AddAsync(Eoi eoi, CancellationToken cancellationToken = default)
+    {
+        await _context.Eois.AddAsync(eoi, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
 
-    public Task DeleteAsync(Guid id, CancellationToken cancellationToken = default)
-        => throw new NotImplementedException();
+    public async Task UpdateAsync(Eoi eoi, CancellationToken cancellationToken = default)
+    {
+        var tracked = _context.ChangeTracker.Entries<Eoi>()
+            .FirstOrDefault(e => e.Entity.Id == eoi.Id);
+        if (tracked is not null)
+            tracked.State = EntityState.Detached;
+
+        _context.Eois.Update(eoi);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task DeleteAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var eoi = await _context.Eois.FindAsync([id], cancellationToken)
+            ?? throw new InvalidOperationException($"Eoi with id '{id}' was not found.");
+
+        _context.Eois.Remove(eoi);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
 }

--- a/tests/Herit.Infrastructure.Tests/Repositories/EoiRepositoryTests.cs
+++ b/tests/Herit.Infrastructure.Tests/Repositories/EoiRepositoryTests.cs
@@ -1,0 +1,150 @@
+using Herit.Domain.Entities;
+using Herit.Domain.Enums;
+using Herit.Infrastructure.Persistence;
+using Herit.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Herit.Infrastructure.Tests.Repositories;
+
+public class EoiRepositoryTests : IDisposable
+{
+    private readonly HeritDbContext _context;
+    private readonly EoiRepository _repository;
+    private readonly CfeoiRepository _cfeoiRepository;
+
+    public EoiRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<HeritDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _context = new HeritDbContext(options);
+        _repository = new EoiRepository(_context);
+        _cfeoiRepository = new CfeoiRepository(_context);
+    }
+
+    public void Dispose() => _context.Dispose();
+
+    private static Eoi CreateEoi(Guid? id = null, Guid? cfeoiId = null)
+        => Eoi.Create(id ?? Guid.NewGuid(), Guid.NewGuid(), "Message", cfeoiId ?? Guid.NewGuid());
+
+    private static Cfeoi CreateCfeoi(Guid? id = null, Guid? proposalId = null)
+        => Cfeoi.Create(id ?? Guid.NewGuid(), "Title", "Description", CfeoiResourceType.Human, proposalId ?? Guid.NewGuid());
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsEoi_WhenExists()
+    {
+        var id = Guid.NewGuid();
+        var eoi = CreateEoi(id);
+        await _repository.AddAsync(eoi);
+
+        var result = await _repository.GetByIdAsync(id);
+
+        Assert.NotNull(result);
+        Assert.Equal(id, result.Id);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsNull_WhenNotExists()
+    {
+        var result = await _repository.GetByIdAsync(Guid.NewGuid());
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ListByCfeoiAsync_ReturnsMatchingEois()
+    {
+        var cfeoiId = Guid.NewGuid();
+        await _repository.AddAsync(CreateEoi(cfeoiId: cfeoiId));
+        await _repository.AddAsync(CreateEoi(cfeoiId: cfeoiId));
+        await _repository.AddAsync(CreateEoi());
+
+        var result = await _repository.ListByCfeoiAsync(cfeoiId);
+
+        Assert.Equal(2, result.Count());
+        Assert.All(result, e => Assert.Equal(cfeoiId, e.CfeoiId));
+    }
+
+    [Fact]
+    public async Task ListByCfeoiAsync_WhenNoneMatch_ReturnsEmptyCollection()
+    {
+        await _repository.AddAsync(CreateEoi());
+
+        var result = await _repository.ListByCfeoiAsync(Guid.NewGuid());
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task ListByProposalAsync_ReturnsEoisWhoseCfeoiBelongsToProposal()
+    {
+        var proposalId = Guid.NewGuid();
+        var cfeoiId = Guid.NewGuid();
+        var cfeoi = CreateCfeoi(cfeoiId, proposalId);
+        await _cfeoiRepository.AddAsync(cfeoi);
+        await _repository.AddAsync(CreateEoi(cfeoiId: cfeoiId));
+        await _repository.AddAsync(CreateEoi(cfeoiId: cfeoiId));
+        await _repository.AddAsync(CreateEoi()); // belongs to different cfeoi/proposal
+
+        var result = await _repository.ListByProposalAsync(proposalId);
+
+        Assert.Equal(2, result.Count());
+    }
+
+    [Fact]
+    public async Task ListByProposalAsync_WhenNoneMatch_ReturnsEmptyCollection()
+    {
+        await _repository.AddAsync(CreateEoi());
+
+        var result = await _repository.ListByProposalAsync(Guid.NewGuid());
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task AddAsync_PersistsEoi()
+    {
+        var id = Guid.NewGuid();
+        var eoi = CreateEoi(id);
+
+        await _repository.AddAsync(eoi);
+
+        var persisted = await _context.Eois.FindAsync(id);
+        Assert.NotNull(persisted);
+        Assert.Equal(id, persisted.Id);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_PersistsChanges()
+    {
+        var id = Guid.NewGuid();
+        var eoi = CreateEoi(id);
+        await _repository.AddAsync(eoi);
+
+        eoi.TransitionStatus(EoiStatus.Approved);
+        await _repository.UpdateAsync(eoi);
+
+        var persisted = await _context.Eois.FindAsync(id);
+        Assert.NotNull(persisted);
+        Assert.Equal(EoiStatus.Approved, persisted.Status);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_RemovesEoi_WhenExists()
+    {
+        var id = Guid.NewGuid();
+        await _repository.AddAsync(CreateEoi(id));
+
+        await _repository.DeleteAsync(id);
+
+        var persisted = await _context.Eois.FindAsync(id);
+        Assert.Null(persisted);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Throws_WhenNotExists()
+    {
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _repository.DeleteAsync(Guid.NewGuid()));
+    }
+}


### PR DESCRIPTION
## Description

Adds `ListByProposalAsync` to `IEoiRepository` and implements all six methods in `EoiRepository` — `GetByIdAsync`, `ListByCfeoiAsync`, `ListByProposalAsync`, `AddAsync`, `UpdateAsync`, `DeleteAsync` — following the pattern in `RfpRepository`. `ListByProposalAsync` joins through the `Cfeoi` table to filter by `ProposalId`.

## Linked Issue

Closes #92

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Added `EoiRepositoryTests.cs` covering all six methods, including both populated and empty results for the list methods.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)