### PR TITLE
Implement SubmitEoi, WithdrawEoi, and DeleteEoi command handlers

### DIFF
--- a/src/Herit.Application/Features/Eoi/Commands/DeleteEoi/DeleteEoiCommand.cs
+++ b/src/Herit.Application/Features/Eoi/Commands/DeleteEoi/DeleteEoiCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.Eoi.Commands.DeleteEoi;
@@ -6,8 +7,20 @@ public record DeleteEoiCommand(Guid Id) : IRequest<Unit>;
 
 public class DeleteEoiCommandHandler : IRequestHandler<DeleteEoiCommand, Unit>
 {
-    public Task<Unit> Handle(DeleteEoiCommand request, CancellationToken cancellationToken)
+    private readonly IEoiRepository _eoiRepository;
+
+    public DeleteEoiCommandHandler(IEoiRepository eoiRepository)
     {
-        throw new NotImplementedException();
+        _eoiRepository = eoiRepository;
+    }
+
+    public async Task<Unit> Handle(DeleteEoiCommand request, CancellationToken cancellationToken)
+    {
+        var eoi = await _eoiRepository.GetByIdAsync(request.Id, cancellationToken);
+        if (eoi is null)
+            throw new InvalidOperationException($"Eoi '{request.Id}' does not exist.");
+
+        await _eoiRepository.DeleteAsync(request.Id, cancellationToken);
+        return Unit.Value;
     }
 }

--- a/src/Herit.Application/Features/Eoi/Commands/SubmitEoi/SubmitEoiCommand.cs
+++ b/src/Herit.Application/Features/Eoi/Commands/SubmitEoi/SubmitEoiCommand.cs
@@ -1,4 +1,7 @@
+using Herit.Application.Interfaces;
+using Herit.Domain.Enums;
 using MediatR;
+using EoiEntity = Herit.Domain.Entities.Eoi;
 
 namespace Herit.Application.Features.Eoi.Commands.SubmitEoi;
 
@@ -9,8 +12,33 @@ public record SubmitEoiCommand(
 
 public class SubmitEoiCommandHandler : IRequestHandler<SubmitEoiCommand, Guid>
 {
-    public Task<Guid> Handle(SubmitEoiCommand request, CancellationToken cancellationToken)
+    private readonly IEoiRepository _eoiRepository;
+    private readonly IUserRepository _userRepository;
+    private readonly ICfeoiRepository _cfeoiRepository;
+
+    public SubmitEoiCommandHandler(IEoiRepository eoiRepository, IUserRepository userRepository, ICfeoiRepository cfeoiRepository)
     {
-        throw new NotImplementedException();
+        _eoiRepository = eoiRepository;
+        _userRepository = userRepository;
+        _cfeoiRepository = cfeoiRepository;
+    }
+
+    public async Task<Guid> Handle(SubmitEoiCommand request, CancellationToken cancellationToken)
+    {
+        var user = await _userRepository.GetByIdAsync(request.SubmittedById, cancellationToken);
+        if (user is null)
+            throw new InvalidOperationException($"User '{request.SubmittedById}' does not exist.");
+
+        var cfeoi = await _cfeoiRepository.GetByIdAsync(request.CfeoiId, cancellationToken);
+        if (cfeoi is null)
+            throw new InvalidOperationException($"Cfeoi '{request.CfeoiId}' does not exist.");
+
+        if (cfeoi.Status != CfeoiStatus.Open)
+            throw new InvalidOperationException($"Cfeoi '{request.CfeoiId}' is not open for submissions.");
+
+        var id = Guid.NewGuid();
+        var eoi = EoiEntity.Create(id, request.SubmittedById, request.Message, request.CfeoiId);
+        await _eoiRepository.AddAsync(eoi, cancellationToken);
+        return id;
     }
 }

--- a/src/Herit.Application/Features/Eoi/Commands/WithdrawEoi/WithdrawEoiCommand.cs
+++ b/src/Herit.Application/Features/Eoi/Commands/WithdrawEoi/WithdrawEoiCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.Eoi.Commands.WithdrawEoi;
@@ -6,8 +7,20 @@ public record WithdrawEoiCommand(Guid Id) : IRequest<Unit>;
 
 public class WithdrawEoiCommandHandler : IRequestHandler<WithdrawEoiCommand, Unit>
 {
-    public Task<Unit> Handle(WithdrawEoiCommand request, CancellationToken cancellationToken)
+    private readonly IEoiRepository _eoiRepository;
+
+    public WithdrawEoiCommandHandler(IEoiRepository eoiRepository)
     {
-        throw new NotImplementedException();
+        _eoiRepository = eoiRepository;
+    }
+
+    public async Task<Unit> Handle(WithdrawEoiCommand request, CancellationToken cancellationToken)
+    {
+        var eoi = await _eoiRepository.GetByIdAsync(request.Id, cancellationToken);
+        if (eoi is null)
+            throw new InvalidOperationException($"Eoi '{request.Id}' does not exist.");
+
+        await _eoiRepository.DeleteAsync(request.Id, cancellationToken);
+        return Unit.Value;
     }
 }

--- a/tests/Herit.Application.Tests/Features/Eoi/Commands/DeleteEoiCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Eoi/Commands/DeleteEoiCommandHandlerTests.cs
@@ -1,14 +1,42 @@
 using Herit.Application.Features.Eoi.Commands.DeleteEoi;
+using Herit.Application.Interfaces;
+using MediatR;
+using NSubstitute;
+using EoiEntity = Herit.Domain.Entities.Eoi;
 
 namespace Herit.Application.Tests.Features.Eoi.Commands;
 
 public class DeleteEoiCommandHandlerTests
 {
-    [Fact]
-    public async Task Handle_ThrowsNotImplementedException()
+    private readonly IEoiRepository _eoiRepository = Substitute.For<IEoiRepository>();
+    private readonly DeleteEoiCommandHandler _handler;
+
+    public DeleteEoiCommandHandlerTests()
     {
-        var handler = new DeleteEoiCommandHandler();
-        var command = new DeleteEoiCommand(Guid.NewGuid());
-        await Assert.ThrowsAsync<NotImplementedException>(() => handler.Handle(command, CancellationToken.None));
+        _handler = new DeleteEoiCommandHandler(_eoiRepository);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_CallsDeleteAsync()
+    {
+        var eoiId = Guid.NewGuid();
+        var eoi = EoiEntity.Create(eoiId, Guid.NewGuid(), "Message", Guid.NewGuid());
+        _eoiRepository.GetByIdAsync(eoiId, Arg.Any<CancellationToken>()).Returns(eoi);
+
+        var result = await _handler.Handle(new DeleteEoiCommand(eoiId), CancellationToken.None);
+
+        Assert.Equal(Unit.Value, result);
+        await _eoiRepository.Received(1).DeleteAsync(eoiId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_EoiNotFound_ThrowsInvalidOperationException()
+    {
+        var eoiId = Guid.NewGuid();
+        _eoiRepository.GetByIdAsync(eoiId, Arg.Any<CancellationToken>()).Returns((EoiEntity?)null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _handler.Handle(new DeleteEoiCommand(eoiId), CancellationToken.None));
+        await _eoiRepository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Herit.Application.Tests/Features/Eoi/Commands/SubmitEoiCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Eoi/Commands/SubmitEoiCommandHandlerTests.cs
@@ -1,14 +1,86 @@
 using Herit.Application.Features.Eoi.Commands.SubmitEoi;
+using Herit.Application.Interfaces;
+using Herit.Domain.Enums;
+using NSubstitute;
+using CfeoiEntity = Herit.Domain.Entities.Cfeoi;
+using EoiEntity = Herit.Domain.Entities.Eoi;
+using UserEntity = Herit.Domain.Entities.User;
 
 namespace Herit.Application.Tests.Features.Eoi.Commands;
 
 public class SubmitEoiCommandHandlerTests
 {
-    [Fact]
-    public async Task Handle_ThrowsNotImplementedException()
+    private readonly IEoiRepository _eoiRepository = Substitute.For<IEoiRepository>();
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly ICfeoiRepository _cfeoiRepository = Substitute.For<ICfeoiRepository>();
+    private readonly SubmitEoiCommandHandler _handler;
+
+    public SubmitEoiCommandHandlerTests()
     {
-        var handler = new SubmitEoiCommandHandler();
-        var command = new SubmitEoiCommand(Guid.NewGuid(), "Message", Guid.NewGuid());
-        await Assert.ThrowsAsync<NotImplementedException>(() => handler.Handle(command, CancellationToken.None));
+        _handler = new SubmitEoiCommandHandler(_eoiRepository, _userRepository, _cfeoiRepository);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_ReturnsValidGuidAndCallsAddAsync()
+    {
+        var submittedById = Guid.NewGuid();
+        var cfeoiId = Guid.NewGuid();
+        _userRepository.GetByIdAsync(submittedById, Arg.Any<CancellationToken>())
+            .Returns(UserEntity.Create(submittedById, "user@example.com", "Test User", UserRole.Staff));
+        _cfeoiRepository.GetByIdAsync(cfeoiId, Arg.Any<CancellationToken>())
+            .Returns(CfeoiEntity.Create(cfeoiId, "Title", "Desc", CfeoiResourceType.Human, Guid.NewGuid()));
+
+        var command = new SubmitEoiCommand(submittedById, "My message", cfeoiId);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.NotEqual(Guid.Empty, result);
+        await _eoiRepository.Received(1).AddAsync(
+            Arg.Is<EoiEntity>(e => e.SubmittedById == submittedById && e.CfeoiId == cfeoiId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_UserNotFound_ThrowsInvalidOperationException()
+    {
+        var submittedById = Guid.NewGuid();
+        _userRepository.GetByIdAsync(submittedById, Arg.Any<CancellationToken>()).Returns((UserEntity?)null);
+
+        var command = new SubmitEoiCommand(submittedById, "Message", Guid.NewGuid());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await _eoiRepository.DidNotReceive().AddAsync(Arg.Any<EoiEntity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_CfeoiNotFound_ThrowsInvalidOperationException()
+    {
+        var submittedById = Guid.NewGuid();
+        var cfeoiId = Guid.NewGuid();
+        _userRepository.GetByIdAsync(submittedById, Arg.Any<CancellationToken>())
+            .Returns(UserEntity.Create(submittedById, "user@example.com", "Test User", UserRole.Staff));
+        _cfeoiRepository.GetByIdAsync(cfeoiId, Arg.Any<CancellationToken>()).Returns((CfeoiEntity?)null);
+
+        var command = new SubmitEoiCommand(submittedById, "Message", cfeoiId);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await _eoiRepository.DidNotReceive().AddAsync(Arg.Any<EoiEntity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_CfeoiNotOpen_ThrowsInvalidOperationException()
+    {
+        var submittedById = Guid.NewGuid();
+        var cfeoiId = Guid.NewGuid();
+        var closedCfeoi = CfeoiEntity.Create(cfeoiId, "Title", "Desc", CfeoiResourceType.Human, Guid.NewGuid());
+        closedCfeoi.TransitionStatus(CfeoiStatus.Closed);
+        _userRepository.GetByIdAsync(submittedById, Arg.Any<CancellationToken>())
+            .Returns(UserEntity.Create(submittedById, "user@example.com", "Test User", UserRole.Staff));
+        _cfeoiRepository.GetByIdAsync(cfeoiId, Arg.Any<CancellationToken>()).Returns(closedCfeoi);
+
+        var command = new SubmitEoiCommand(submittedById, "Message", cfeoiId);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await _eoiRepository.DidNotReceive().AddAsync(Arg.Any<EoiEntity>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Herit.Application.Tests/Features/Eoi/Commands/WithdrawEoiCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Eoi/Commands/WithdrawEoiCommandHandlerTests.cs
@@ -1,14 +1,42 @@
 using Herit.Application.Features.Eoi.Commands.WithdrawEoi;
+using Herit.Application.Interfaces;
+using MediatR;
+using NSubstitute;
+using EoiEntity = Herit.Domain.Entities.Eoi;
 
 namespace Herit.Application.Tests.Features.Eoi.Commands;
 
 public class WithdrawEoiCommandHandlerTests
 {
-    [Fact]
-    public async Task Handle_ThrowsNotImplementedException()
+    private readonly IEoiRepository _eoiRepository = Substitute.For<IEoiRepository>();
+    private readonly WithdrawEoiCommandHandler _handler;
+
+    public WithdrawEoiCommandHandlerTests()
     {
-        var handler = new WithdrawEoiCommandHandler();
-        var command = new WithdrawEoiCommand(Guid.NewGuid());
-        await Assert.ThrowsAsync<NotImplementedException>(() => handler.Handle(command, CancellationToken.None));
+        _handler = new WithdrawEoiCommandHandler(_eoiRepository);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_CallsDeleteAsync()
+    {
+        var eoiId = Guid.NewGuid();
+        var eoi = EoiEntity.Create(eoiId, Guid.NewGuid(), "Message", Guid.NewGuid());
+        _eoiRepository.GetByIdAsync(eoiId, Arg.Any<CancellationToken>()).Returns(eoi);
+
+        var result = await _handler.Handle(new WithdrawEoiCommand(eoiId), CancellationToken.None);
+
+        Assert.Equal(Unit.Value, result);
+        await _eoiRepository.Received(1).DeleteAsync(eoiId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_EoiNotFound_ThrowsInvalidOperationException()
+    {
+        var eoiId = Guid.NewGuid();
+        _eoiRepository.GetByIdAsync(eoiId, Arg.Any<CancellationToken>()).Returns((EoiEntity?)null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _handler.Handle(new WithdrawEoiCommand(eoiId), CancellationToken.None));
+        await _eoiRepository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
## Description

Implements three EOI command handlers:
- `SubmitEoiCommandHandler`: validates user and CFEOI existence (and that CFEOI is `Open`), then creates and persists the EOI
- `WithdrawEoiCommandHandler`: fetches EOI by Id (throws if not found), then deletes it (expat-initiated withdrawal)
- `DeleteEoiCommandHandler`: fetches EOI by Id (throws if not found), then deletes it (staff-initiated deletion)

## Linked Issue

Closes #93
Closes #94
Closes #95

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Replaced placeholder tests with full happy path and not-found tests for all three handlers, plus a CFEOI-not-open test for SubmitEoi.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)