### PR TITLE
Implement SetEoiVisibilityCommandHandler

### DIFF
--- a/src/Herit.Application/Features/Eoi/Commands/SetEoiVisibility/SetEoiVisibilityCommand.cs
+++ b/src/Herit.Application/Features/Eoi/Commands/SetEoiVisibility/SetEoiVisibilityCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
 using MediatR;
 
@@ -7,8 +8,21 @@ public record SetEoiVisibilityCommand(Guid Id, EoiVisibility Visibility) : IRequ
 
 public class SetEoiVisibilityCommandHandler : IRequestHandler<SetEoiVisibilityCommand, Unit>
 {
-    public Task<Unit> Handle(SetEoiVisibilityCommand request, CancellationToken cancellationToken)
+    private readonly IEoiRepository _eoiRepository;
+
+    public SetEoiVisibilityCommandHandler(IEoiRepository eoiRepository)
     {
-        throw new NotImplementedException();
+        _eoiRepository = eoiRepository;
+    }
+
+    public async Task<Unit> Handle(SetEoiVisibilityCommand request, CancellationToken cancellationToken)
+    {
+        var eoi = await _eoiRepository.GetByIdAsync(request.Id, cancellationToken);
+        if (eoi is null)
+            throw new InvalidOperationException($"Eoi '{request.Id}' does not exist.");
+
+        eoi.SetVisibility(request.Visibility);
+        await _eoiRepository.UpdateAsync(eoi, cancellationToken);
+        return Unit.Value;
     }
 }

--- a/tests/Herit.Application.Tests/Features/Eoi/Commands/SetEoiVisibilityCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Eoi/Commands/SetEoiVisibilityCommandHandlerTests.cs
@@ -1,15 +1,44 @@
 using Herit.Application.Features.Eoi.Commands.SetEoiVisibility;
+using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
+using MediatR;
+using NSubstitute;
+using EoiEntity = Herit.Domain.Entities.Eoi;
 
 namespace Herit.Application.Tests.Features.Eoi.Commands;
 
 public class SetEoiVisibilityCommandHandlerTests
 {
-    [Fact]
-    public async Task Handle_ThrowsNotImplementedException()
+    private readonly IEoiRepository _eoiRepository = Substitute.For<IEoiRepository>();
+    private readonly SetEoiVisibilityCommandHandler _handler;
+
+    public SetEoiVisibilityCommandHandlerTests()
     {
-        var handler = new SetEoiVisibilityCommandHandler();
-        var command = new SetEoiVisibilityCommand(Guid.NewGuid(), EoiVisibility.Shared);
-        await Assert.ThrowsAsync<NotImplementedException>(() => handler.Handle(command, CancellationToken.None));
+        _handler = new SetEoiVisibilityCommandHandler(_eoiRepository);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_SetsVisibilityAndCallsUpdateAsync()
+    {
+        var eoiId = Guid.NewGuid();
+        var eoi = EoiEntity.Create(eoiId, Guid.NewGuid(), "Message", Guid.NewGuid());
+        _eoiRepository.GetByIdAsync(eoiId, Arg.Any<CancellationToken>()).Returns(eoi);
+
+        var result = await _handler.Handle(new SetEoiVisibilityCommand(eoiId, EoiVisibility.Shared), CancellationToken.None);
+
+        Assert.Equal(Unit.Value, result);
+        Assert.Equal(EoiVisibility.Shared, eoi.Visibility);
+        await _eoiRepository.Received(1).UpdateAsync(eoi, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_EoiNotFound_ThrowsInvalidOperationException()
+    {
+        var eoiId = Guid.NewGuid();
+        _eoiRepository.GetByIdAsync(eoiId, Arg.Any<CancellationToken>()).Returns((EoiEntity?)null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _handler.Handle(new SetEoiVisibilityCommand(eoiId, EoiVisibility.Shared), CancellationToken.None));
+        await _eoiRepository.DidNotReceive().UpdateAsync(Arg.Any<EoiEntity>(), Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
## Description

Implements `SetEoiVisibilityCommandHandler` by injecting `IEoiRepository`, fetching the EOI by Id (throwing if not found), calling `eoi.SetVisibility(request.Visibility)`, then calling `UpdateAsync`.

## Linked Issue

Closes #97

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Replaced placeholder test with tests for the happy path and the not-found case.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)