### PR TITLE
Implement EOI query handlers (GetById, ListByCfeoi, ListByProposal)

### DIFF
--- a/src/Herit.Application/Features/Eoi/Queries/GetEoiById/GetEoiByIdQuery.cs
+++ b/src/Herit.Application/Features/Eoi/Queries/GetEoiById/GetEoiByIdQuery.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.Eoi.Queries.GetEoiById;
@@ -6,8 +7,13 @@ public record GetEoiByIdQuery(Guid Id) : IRequest<Herit.Domain.Entities.Eoi?>;
 
 public class GetEoiByIdQueryHandler : IRequestHandler<GetEoiByIdQuery, Herit.Domain.Entities.Eoi?>
 {
-    public Task<Herit.Domain.Entities.Eoi?> Handle(GetEoiByIdQuery request, CancellationToken cancellationToken)
+    private readonly IEoiRepository _eoiRepository;
+
+    public GetEoiByIdQueryHandler(IEoiRepository eoiRepository)
     {
-        throw new NotImplementedException();
+        _eoiRepository = eoiRepository;
     }
+
+    public Task<Herit.Domain.Entities.Eoi?> Handle(GetEoiByIdQuery request, CancellationToken cancellationToken)
+        => _eoiRepository.GetByIdAsync(request.Id, cancellationToken);
 }

--- a/src/Herit.Application/Features/Eoi/Queries/ListEoisByCfeoi/ListEoisByCfeoiQuery.cs
+++ b/src/Herit.Application/Features/Eoi/Queries/ListEoisByCfeoi/ListEoisByCfeoiQuery.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.Eoi.Queries.ListEoisByCfeoi;
@@ -6,8 +7,13 @@ public record ListEoisByCfeoiQuery(Guid CfeoiId) : IRequest<IEnumerable<Herit.Do
 
 public class ListEoisByCfeoiQueryHandler : IRequestHandler<ListEoisByCfeoiQuery, IEnumerable<Herit.Domain.Entities.Eoi>>
 {
-    public Task<IEnumerable<Herit.Domain.Entities.Eoi>> Handle(ListEoisByCfeoiQuery request, CancellationToken cancellationToken)
+    private readonly IEoiRepository _eoiRepository;
+
+    public ListEoisByCfeoiQueryHandler(IEoiRepository eoiRepository)
     {
-        throw new NotImplementedException();
+        _eoiRepository = eoiRepository;
     }
+
+    public Task<IEnumerable<Herit.Domain.Entities.Eoi>> Handle(ListEoisByCfeoiQuery request, CancellationToken cancellationToken)
+        => _eoiRepository.ListByCfeoiAsync(request.CfeoiId, cancellationToken);
 }

--- a/src/Herit.Application/Features/Eoi/Queries/ListEoisByProposal/ListEoisByProposalQuery.cs
+++ b/src/Herit.Application/Features/Eoi/Queries/ListEoisByProposal/ListEoisByProposalQuery.cs
@@ -1,1 +1,19 @@
+using Herit.Application.Interfaces;
+using MediatR;
+
 namespace Herit.Application.Features.Eoi.Queries.ListEoisByProposal;
+
+public record ListEoisByProposalQuery(Guid ProposalId) : IRequest<IEnumerable<Herit.Domain.Entities.Eoi>>;
+
+public class ListEoisByProposalQueryHandler : IRequestHandler<ListEoisByProposalQuery, IEnumerable<Herit.Domain.Entities.Eoi>>
+{
+    private readonly IEoiRepository _eoiRepository;
+
+    public ListEoisByProposalQueryHandler(IEoiRepository eoiRepository)
+    {
+        _eoiRepository = eoiRepository;
+    }
+
+    public Task<IEnumerable<Herit.Domain.Entities.Eoi>> Handle(ListEoisByProposalQuery request, CancellationToken cancellationToken)
+        => _eoiRepository.ListByProposalAsync(request.ProposalId, cancellationToken);
+}

--- a/tests/Herit.Application.Tests/Features/Eoi/Queries/GetEoiByIdQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Eoi/Queries/GetEoiByIdQueryHandlerTests.cs
@@ -1,14 +1,41 @@
 using Herit.Application.Features.Eoi.Queries.GetEoiById;
+using Herit.Application.Interfaces;
+using NSubstitute;
+using EoiEntity = Herit.Domain.Entities.Eoi;
 
 namespace Herit.Application.Tests.Features.Eoi.Queries;
 
 public class GetEoiByIdQueryHandlerTests
 {
-    [Fact]
-    public async Task Handle_ThrowsNotImplementedException()
+    private readonly IEoiRepository _eoiRepository = Substitute.For<IEoiRepository>();
+    private readonly GetEoiByIdQueryHandler _handler;
+
+    public GetEoiByIdQueryHandlerTests()
     {
-        var handler = new GetEoiByIdQueryHandler();
-        var query = new GetEoiByIdQuery(Guid.NewGuid());
-        await Assert.ThrowsAsync<NotImplementedException>(() => handler.Handle(query, CancellationToken.None));
+        _handler = new GetEoiByIdQueryHandler(_eoiRepository);
+    }
+
+    [Fact]
+    public async Task Handle_EoiFound_ReturnsEoi()
+    {
+        var eoiId = Guid.NewGuid();
+        var eoi = EoiEntity.Create(eoiId, Guid.NewGuid(), "Message", Guid.NewGuid());
+        _eoiRepository.GetByIdAsync(eoiId, Arg.Any<CancellationToken>()).Returns(eoi);
+
+        var result = await _handler.Handle(new GetEoiByIdQuery(eoiId), CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(eoiId, result.Id);
+    }
+
+    [Fact]
+    public async Task Handle_EoiNotFound_ReturnsNull()
+    {
+        var eoiId = Guid.NewGuid();
+        _eoiRepository.GetByIdAsync(eoiId, Arg.Any<CancellationToken>()).Returns((EoiEntity?)null);
+
+        var result = await _handler.Handle(new GetEoiByIdQuery(eoiId), CancellationToken.None);
+
+        Assert.Null(result);
     }
 }

--- a/tests/Herit.Application.Tests/Features/Eoi/Queries/ListEoisByCfeoiQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Eoi/Queries/ListEoisByCfeoiQueryHandlerTests.cs
@@ -1,0 +1,44 @@
+using Herit.Application.Features.Eoi.Queries.ListEoisByCfeoi;
+using Herit.Application.Interfaces;
+using NSubstitute;
+using EoiEntity = Herit.Domain.Entities.Eoi;
+
+namespace Herit.Application.Tests.Features.Eoi.Queries;
+
+public class ListEoisByCfeoiQueryHandlerTests
+{
+    private readonly IEoiRepository _eoiRepository = Substitute.For<IEoiRepository>();
+    private readonly ListEoisByCfeoiQueryHandler _handler;
+
+    public ListEoisByCfeoiQueryHandlerTests()
+    {
+        _handler = new ListEoisByCfeoiQueryHandler(_eoiRepository);
+    }
+
+    [Fact]
+    public async Task Handle_NonEmptyList_ReturnsAllEois()
+    {
+        var cfeoiId = Guid.NewGuid();
+        var eois = new[]
+        {
+            EoiEntity.Create(Guid.NewGuid(), Guid.NewGuid(), "Message 1", cfeoiId),
+            EoiEntity.Create(Guid.NewGuid(), Guid.NewGuid(), "Message 2", cfeoiId)
+        };
+        _eoiRepository.ListByCfeoiAsync(cfeoiId, Arg.Any<CancellationToken>()).Returns(eois);
+
+        var result = await _handler.Handle(new ListEoisByCfeoiQuery(cfeoiId), CancellationToken.None);
+
+        Assert.Equal(2, result.Count());
+    }
+
+    [Fact]
+    public async Task Handle_EmptyList_ReturnsEmptyEnumerable()
+    {
+        var cfeoiId = Guid.NewGuid();
+        _eoiRepository.ListByCfeoiAsync(cfeoiId, Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<EoiEntity>());
+
+        var result = await _handler.Handle(new ListEoisByCfeoiQuery(cfeoiId), CancellationToken.None);
+
+        Assert.Empty(result);
+    }
+}

--- a/tests/Herit.Application.Tests/Features/Eoi/Queries/ListEoisByProposalQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Eoi/Queries/ListEoisByProposalQueryHandlerTests.cs
@@ -1,14 +1,44 @@
-using Herit.Application.Features.Eoi.Queries.ListEoisByCfeoi;
+using Herit.Application.Features.Eoi.Queries.ListEoisByProposal;
+using Herit.Application.Interfaces;
+using NSubstitute;
+using EoiEntity = Herit.Domain.Entities.Eoi;
 
 namespace Herit.Application.Tests.Features.Eoi.Queries;
 
-public class ListEoisByCfeoiQueryHandlerTests
+public class ListEoisByProposalQueryHandlerTests
 {
-    [Fact]
-    public async Task Handle_ThrowsNotImplementedException()
+    private readonly IEoiRepository _eoiRepository = Substitute.For<IEoiRepository>();
+    private readonly ListEoisByProposalQueryHandler _handler;
+
+    public ListEoisByProposalQueryHandlerTests()
     {
-        var handler = new ListEoisByCfeoiQueryHandler();
-        var query = new ListEoisByCfeoiQuery(Guid.NewGuid());
-        await Assert.ThrowsAsync<NotImplementedException>(() => handler.Handle(query, CancellationToken.None));
+        _handler = new ListEoisByProposalQueryHandler(_eoiRepository);
+    }
+
+    [Fact]
+    public async Task Handle_NonEmptyList_ReturnsAllEois()
+    {
+        var proposalId = Guid.NewGuid();
+        var eois = new[]
+        {
+            EoiEntity.Create(Guid.NewGuid(), Guid.NewGuid(), "Message 1", Guid.NewGuid()),
+            EoiEntity.Create(Guid.NewGuid(), Guid.NewGuid(), "Message 2", Guid.NewGuid())
+        };
+        _eoiRepository.ListByProposalAsync(proposalId, Arg.Any<CancellationToken>()).Returns(eois);
+
+        var result = await _handler.Handle(new ListEoisByProposalQuery(proposalId), CancellationToken.None);
+
+        Assert.Equal(2, result.Count());
+    }
+
+    [Fact]
+    public async Task Handle_EmptyList_ReturnsEmptyEnumerable()
+    {
+        var proposalId = Guid.NewGuid();
+        _eoiRepository.ListByProposalAsync(proposalId, Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<EoiEntity>());
+
+        var result = await _handler.Handle(new ListEoisByProposalQuery(proposalId), CancellationToken.None);
+
+        Assert.Empty(result);
     }
 }


### PR DESCRIPTION
## Description

Implements three EOI query handlers by injecting `IEoiRepository` and delegating to the appropriate repository methods:
- `GetEoiByIdQueryHandler` → `GetByIdAsync`
- `ListEoisByCfeoiQueryHandler` → `ListByCfeoiAsync`
- `ListEoisByProposalQueryHandler` → `ListByProposalAsync` (also scaffolds the previously empty query class)

## Linked Issue

Closes #98
Closes #99
Closes #100

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Replaced placeholder tests with found/not-found tests (GetById) and non-empty/empty list tests (ListByCfeoi, ListByProposal). Also added a new `ListEoisByCfeoiQueryHandlerTests.cs` file (the existing file was incorrectly named).

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)