### PR TITLE
Add NotFoundException and replace null-guard throws across all handlers and repositories

### DIFF
--- a/src/Herit.Api/Controllers/OrganisationController.cs
+++ b/src/Herit.Api/Controllers/OrganisationController.cs
@@ -29,10 +29,7 @@ public class OrganisationsController : ControllerBase
 
     [HttpGet("{id:guid}")]
     public async Task<IActionResult> GetOrganisationById(Guid id, CancellationToken ct)
-    {
-        var result = await _mediator.Send(new GetOrganisationByIdQuery(id), ct);
-        return result is null ? NotFound() : Ok(result);
-    }
+        => Ok(await _mediator.Send(new GetOrganisationByIdQuery(id), ct));
 
     [HttpPut("{id:guid}")]
     public async Task<IActionResult> UpdateOrganisation(Guid id, [FromBody] UpdateOrganisationCommand command, CancellationToken ct)

--- a/src/Herit.Api/Controllers/RfpsController.cs
+++ b/src/Herit.Api/Controllers/RfpsController.cs
@@ -23,10 +23,7 @@ public class RfpsController : ControllerBase
 
     [HttpGet("{id:guid}")]
     public async Task<IActionResult> GetById(Guid id, CancellationToken ct)
-    {
-        var result = await _mediator.Send(new GetRfpByIdQuery(id), ct);
-        return result is null ? NotFound() : Ok(result);
-    }
+        => Ok(await _mediator.Send(new GetRfpByIdQuery(id), ct));
 
     [HttpPost]
     public async Task<IActionResult> Create([FromBody] CreateRfpCommand command, CancellationToken ct)

--- a/src/Herit.Application/Exceptions/NotFoundException.cs
+++ b/src/Herit.Application/Exceptions/NotFoundException.cs
@@ -1,0 +1,6 @@
+namespace Herit.Application.Exceptions;
+
+public class NotFoundException : Exception
+{
+    public NotFoundException(string message) : base(message) { }
+}

--- a/src/Herit.Application/Features/Cfeoi/Commands/PublishCfeoi/PublishCfeoiCommand.cs
+++ b/src/Herit.Application/Features/Cfeoi/Commands/PublishCfeoi/PublishCfeoiCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
 using MediatR;
@@ -26,7 +27,7 @@ public class PublishCfeoiCommandHandler : IRequestHandler<PublishCfeoiCommand, G
     {
         var proposal = await _proposalRepository.GetByIdAsync(request.ProposalId, cancellationToken);
         if (proposal is null)
-            throw new InvalidOperationException($"Proposal '{request.ProposalId}' does not exist.");
+            throw new NotFoundException($"Proposal '{request.ProposalId}' does not exist.");
 
         var id = Guid.NewGuid();
         var cfeoi = CfeoiEntity.Create(id, request.Title, request.Description, request.ResourceType, request.ProposalId);

--- a/src/Herit.Application/Features/Cfeoi/Commands/UpdateCfeoiStatus/UpdateCfeoiStatusCommand.cs
+++ b/src/Herit.Application/Features/Cfeoi/Commands/UpdateCfeoiStatus/UpdateCfeoiStatusCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
 using MediatR;
@@ -19,7 +20,7 @@ public class UpdateCfeoiStatusCommandHandler : IRequestHandler<UpdateCfeoiStatus
     {
         var cfeoi = await _repository.GetByIdAsync(request.Id, cancellationToken);
         if (cfeoi is null)
-            throw new InvalidOperationException($"Cfeoi '{request.Id}' does not exist.");
+            throw new NotFoundException($"Cfeoi '{request.Id}' does not exist.");
 
         cfeoi.TransitionStatus(request.NewStatus);
         await _repository.UpdateAsync(cfeoi, cancellationToken);

--- a/src/Herit.Application/Features/Cfeoi/Queries/GetCfeoiById/GetCfeoiByIdQuery.cs
+++ b/src/Herit.Application/Features/Cfeoi/Queries/GetCfeoiById/GetCfeoiByIdQuery.cs
@@ -1,11 +1,12 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.Cfeoi.Queries.GetCfeoiById;
 
-public record GetCfeoiByIdQuery(Guid Id) : IRequest<Herit.Domain.Entities.Cfeoi?>;
+public record GetCfeoiByIdQuery(Guid Id) : IRequest<Herit.Domain.Entities.Cfeoi>;
 
-public class GetCfeoiByIdQueryHandler : IRequestHandler<GetCfeoiByIdQuery, Herit.Domain.Entities.Cfeoi?>
+public class GetCfeoiByIdQueryHandler : IRequestHandler<GetCfeoiByIdQuery, Herit.Domain.Entities.Cfeoi>
 {
     private readonly ICfeoiRepository _cfeoiRepository;
 
@@ -14,6 +15,11 @@ public class GetCfeoiByIdQueryHandler : IRequestHandler<GetCfeoiByIdQuery, Herit
         _cfeoiRepository = cfeoiRepository;
     }
 
-    public Task<Herit.Domain.Entities.Cfeoi?> Handle(GetCfeoiByIdQuery request, CancellationToken cancellationToken)
-        => _cfeoiRepository.GetByIdAsync(request.Id, cancellationToken);
+    public async Task<Herit.Domain.Entities.Cfeoi> Handle(GetCfeoiByIdQuery request, CancellationToken cancellationToken)
+    {
+        var cfeoi = await _cfeoiRepository.GetByIdAsync(request.Id, cancellationToken);
+        if (cfeoi is null)
+            throw new NotFoundException($"Cfeoi '{request.Id}' was not found.");
+        return cfeoi;
+    }
 }

--- a/src/Herit.Application/Features/Eoi/Commands/DeleteEoi/DeleteEoiCommand.cs
+++ b/src/Herit.Application/Features/Eoi/Commands/DeleteEoi/DeleteEoiCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using MediatR;
 
@@ -18,7 +19,7 @@ public class DeleteEoiCommandHandler : IRequestHandler<DeleteEoiCommand, Unit>
     {
         var eoi = await _eoiRepository.GetByIdAsync(request.Id, cancellationToken);
         if (eoi is null)
-            throw new InvalidOperationException($"Eoi '{request.Id}' does not exist.");
+            throw new NotFoundException($"Eoi '{request.Id}' does not exist.");
 
         await _eoiRepository.DeleteAsync(request.Id, cancellationToken);
         return Unit.Value;

--- a/src/Herit.Application/Features/Eoi/Commands/SetEoiVisibility/SetEoiVisibilityCommand.cs
+++ b/src/Herit.Application/Features/Eoi/Commands/SetEoiVisibility/SetEoiVisibilityCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
 using MediatR;
@@ -19,7 +20,7 @@ public class SetEoiVisibilityCommandHandler : IRequestHandler<SetEoiVisibilityCo
     {
         var eoi = await _eoiRepository.GetByIdAsync(request.Id, cancellationToken);
         if (eoi is null)
-            throw new InvalidOperationException($"Eoi '{request.Id}' does not exist.");
+            throw new NotFoundException($"Eoi '{request.Id}' does not exist.");
 
         eoi.SetVisibility(request.Visibility);
         await _eoiRepository.UpdateAsync(eoi, cancellationToken);

--- a/src/Herit.Application/Features/Eoi/Commands/SubmitEoi/SubmitEoiCommand.cs
+++ b/src/Herit.Application/Features/Eoi/Commands/SubmitEoi/SubmitEoiCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
 using MediatR;
@@ -27,11 +28,11 @@ public class SubmitEoiCommandHandler : IRequestHandler<SubmitEoiCommand, Guid>
     {
         var user = await _userRepository.GetByIdAsync(request.SubmittedById, cancellationToken);
         if (user is null)
-            throw new InvalidOperationException($"User '{request.SubmittedById}' does not exist.");
+            throw new NotFoundException($"User '{request.SubmittedById}' does not exist.");
 
         var cfeoi = await _cfeoiRepository.GetByIdAsync(request.CfeoiId, cancellationToken);
         if (cfeoi is null)
-            throw new InvalidOperationException($"Cfeoi '{request.CfeoiId}' does not exist.");
+            throw new NotFoundException($"Cfeoi '{request.CfeoiId}' does not exist.");
 
         if (cfeoi.Status != CfeoiStatus.Open)
             throw new InvalidOperationException($"Cfeoi '{request.CfeoiId}' is not open for submissions.");

--- a/src/Herit.Application/Features/Eoi/Commands/UpdateEoiStatus/UpdateEoiStatusCommand.cs
+++ b/src/Herit.Application/Features/Eoi/Commands/UpdateEoiStatus/UpdateEoiStatusCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
 using MediatR;
@@ -19,7 +20,7 @@ public class UpdateEoiStatusCommandHandler : IRequestHandler<UpdateEoiStatusComm
     {
         var eoi = await _repository.GetByIdAsync(request.Id, cancellationToken);
         if (eoi is null)
-            throw new InvalidOperationException($"Eoi '{request.Id}' does not exist.");
+            throw new NotFoundException($"Eoi '{request.Id}' does not exist.");
 
         eoi.TransitionStatus(request.NewStatus);
         await _repository.UpdateAsync(eoi, cancellationToken);

--- a/src/Herit.Application/Features/Eoi/Commands/WithdrawEoi/WithdrawEoiCommand.cs
+++ b/src/Herit.Application/Features/Eoi/Commands/WithdrawEoi/WithdrawEoiCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using MediatR;
 
@@ -18,7 +19,7 @@ public class WithdrawEoiCommandHandler : IRequestHandler<WithdrawEoiCommand, Uni
     {
         var eoi = await _eoiRepository.GetByIdAsync(request.Id, cancellationToken);
         if (eoi is null)
-            throw new InvalidOperationException($"Eoi '{request.Id}' does not exist.");
+            throw new NotFoundException($"Eoi '{request.Id}' does not exist.");
 
         await _eoiRepository.DeleteAsync(request.Id, cancellationToken);
         return Unit.Value;

--- a/src/Herit.Application/Features/Eoi/Queries/GetEoiById/GetEoiByIdQuery.cs
+++ b/src/Herit.Application/Features/Eoi/Queries/GetEoiById/GetEoiByIdQuery.cs
@@ -1,11 +1,12 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.Eoi.Queries.GetEoiById;
 
-public record GetEoiByIdQuery(Guid Id) : IRequest<Herit.Domain.Entities.Eoi?>;
+public record GetEoiByIdQuery(Guid Id) : IRequest<Herit.Domain.Entities.Eoi>;
 
-public class GetEoiByIdQueryHandler : IRequestHandler<GetEoiByIdQuery, Herit.Domain.Entities.Eoi?>
+public class GetEoiByIdQueryHandler : IRequestHandler<GetEoiByIdQuery, Herit.Domain.Entities.Eoi>
 {
     private readonly IEoiRepository _eoiRepository;
 
@@ -14,6 +15,11 @@ public class GetEoiByIdQueryHandler : IRequestHandler<GetEoiByIdQuery, Herit.Dom
         _eoiRepository = eoiRepository;
     }
 
-    public Task<Herit.Domain.Entities.Eoi?> Handle(GetEoiByIdQuery request, CancellationToken cancellationToken)
-        => _eoiRepository.GetByIdAsync(request.Id, cancellationToken);
+    public async Task<Herit.Domain.Entities.Eoi> Handle(GetEoiByIdQuery request, CancellationToken cancellationToken)
+    {
+        var eoi = await _eoiRepository.GetByIdAsync(request.Id, cancellationToken);
+        if (eoi is null)
+            throw new NotFoundException($"Eoi '{request.Id}' was not found.");
+        return eoi;
+    }
 }

--- a/src/Herit.Application/Features/Organisation/Commands/CreateOrganisation/CreateOrganisationCommand.cs
+++ b/src/Herit.Application/Features/Organisation/Commands/CreateOrganisation/CreateOrganisationCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using MediatR;
 using DomainEntities = Herit.Domain.Entities;
@@ -21,7 +22,7 @@ public class CreateOrganisationCommandHandler : IRequestHandler<CreateOrganisati
         {
             var parent = await _repository.GetByIdAsync(parentId, cancellationToken);
             if (parent is null)
-                throw new InvalidOperationException($"Parent organisation '{parentId}' does not exist.");
+                throw new NotFoundException($"Parent organisation '{parentId}' does not exist.");
         }
 
         var id = Guid.NewGuid();

--- a/src/Herit.Application/Features/Organisation/Commands/DeleteOrganisation/DeleteOrganisationCommand.cs
+++ b/src/Herit.Application/Features/Organisation/Commands/DeleteOrganisation/DeleteOrganisationCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using MediatR;
 
@@ -18,7 +19,7 @@ public class DeleteOrganisationCommandHandler : IRequestHandler<DeleteOrganisati
     {
         var organisation = await _repository.GetByIdAsync(request.Id, cancellationToken);
         if (organisation is null)
-            throw new InvalidOperationException($"Organisation '{request.Id}' does not exist.");
+            throw new NotFoundException($"Organisation '{request.Id}' does not exist.");
 
         await _repository.DeleteAsync(request.Id, cancellationToken);
         return Unit.Value;

--- a/src/Herit.Application/Features/Organisation/Commands/UpdateOrganisation/UpdateOrganisationCommand.cs
+++ b/src/Herit.Application/Features/Organisation/Commands/UpdateOrganisation/UpdateOrganisationCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using MediatR;
 
@@ -18,7 +19,7 @@ public class UpdateOrganisationCommandHandler : IRequestHandler<UpdateOrganisati
     {
         var organisation = await _repository.GetByIdAsync(request.Id, cancellationToken);
         if (organisation is null)
-            throw new InvalidOperationException($"Organisation '{request.Id}' does not exist.");
+            throw new NotFoundException($"Organisation '{request.Id}' does not exist.");
 
         organisation.Update(request.Name);
         await _repository.UpdateAsync(organisation, cancellationToken);

--- a/src/Herit.Application/Features/Organisation/Queries/GetOrganisationById/GetOrganisationByIdQuery.cs
+++ b/src/Herit.Application/Features/Organisation/Queries/GetOrganisationById/GetOrganisationByIdQuery.cs
@@ -1,11 +1,12 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.Organisation.Queries.GetOrganisationById;
 
-public record GetOrganisationByIdQuery(Guid Id) : IRequest<Herit.Domain.Entities.Organisation?>;
+public record GetOrganisationByIdQuery(Guid Id) : IRequest<Herit.Domain.Entities.Organisation>;
 
-public class GetOrganisationByIdQueryHandler : IRequestHandler<GetOrganisationByIdQuery, Herit.Domain.Entities.Organisation?>
+public class GetOrganisationByIdQueryHandler : IRequestHandler<GetOrganisationByIdQuery, Herit.Domain.Entities.Organisation>
 {
     private readonly IOrganisationRepository _repository;
 
@@ -14,6 +15,11 @@ public class GetOrganisationByIdQueryHandler : IRequestHandler<GetOrganisationBy
         _repository = repository;
     }
 
-    public Task<Herit.Domain.Entities.Organisation?> Handle(GetOrganisationByIdQuery request, CancellationToken cancellationToken)
-        => _repository.GetByIdAsync(request.Id, cancellationToken);
+    public async Task<Herit.Domain.Entities.Organisation> Handle(GetOrganisationByIdQuery request, CancellationToken cancellationToken)
+    {
+        var organisation = await _repository.GetByIdAsync(request.Id, cancellationToken);
+        if (organisation is null)
+            throw new NotFoundException($"Organisation '{request.Id}' was not found.");
+        return organisation;
+    }
 }

--- a/src/Herit.Application/Features/Proposal/Commands/CreateProposal/CreateProposalCommand.cs
+++ b/src/Herit.Application/Features/Proposal/Commands/CreateProposal/CreateProposalCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using MediatR;
 using ProposalEntity = Herit.Domain.Entities.Proposal;
@@ -35,17 +36,17 @@ public class CreateProposalCommandHandler : IRequestHandler<CreateProposalComman
     {
         var author = await _userRepository.GetByIdAsync(request.AuthorId, cancellationToken);
         if (author is null)
-            throw new InvalidOperationException($"User '{request.AuthorId}' does not exist.");
+            throw new NotFoundException($"User '{request.AuthorId}' does not exist.");
 
         var organisation = await _organisationRepository.GetByIdAsync(request.OrganisationId, cancellationToken);
         if (organisation is null)
-            throw new InvalidOperationException($"Organisation '{request.OrganisationId}' does not exist.");
+            throw new NotFoundException($"Organisation '{request.OrganisationId}' does not exist.");
 
         if (request.RfpId is not null)
         {
             var rfp = await _rfpRepository.GetByIdAsync(request.RfpId.Value, cancellationToken);
             if (rfp is null)
-                throw new InvalidOperationException($"Rfp '{request.RfpId}' does not exist.");
+                throw new NotFoundException($"Rfp '{request.RfpId}' does not exist.");
         }
 
         var id = Guid.NewGuid();

--- a/src/Herit.Application/Features/Proposal/Commands/DeleteProposal/DeleteProposalCommand.cs
+++ b/src/Herit.Application/Features/Proposal/Commands/DeleteProposal/DeleteProposalCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using MediatR;
 
@@ -18,7 +19,7 @@ public class DeleteProposalCommandHandler : IRequestHandler<DeleteProposalComman
     {
         var proposal = await _proposalRepository.GetByIdAsync(request.Id, cancellationToken);
         if (proposal is null)
-            throw new InvalidOperationException($"Proposal '{request.Id}' does not exist.");
+            throw new NotFoundException($"Proposal '{request.Id}' does not exist.");
 
         await _proposalRepository.DeleteAsync(request.Id, cancellationToken);
         return Unit.Value;

--- a/src/Herit.Application/Features/Proposal/Commands/SetProposalVisibility/SetProposalVisibilityCommand.cs
+++ b/src/Herit.Application/Features/Proposal/Commands/SetProposalVisibility/SetProposalVisibilityCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
 using MediatR;
@@ -19,7 +20,7 @@ public class SetProposalVisibilityCommandHandler : IRequestHandler<SetProposalVi
     {
         var proposal = await _proposalRepository.GetByIdAsync(request.Id, cancellationToken);
         if (proposal is null)
-            throw new InvalidOperationException($"Proposal '{request.Id}' does not exist.");
+            throw new NotFoundException($"Proposal '{request.Id}' does not exist.");
 
         proposal.SetVisibility(request.Visibility);
         await _proposalRepository.UpdateAsync(proposal, cancellationToken);

--- a/src/Herit.Application/Features/Proposal/Commands/UpdateProposal/UpdateProposalCommand.cs
+++ b/src/Herit.Application/Features/Proposal/Commands/UpdateProposal/UpdateProposalCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using MediatR;
 
@@ -22,7 +23,7 @@ public class UpdateProposalCommandHandler : IRequestHandler<UpdateProposalComman
     {
         var proposal = await _proposalRepository.GetByIdAsync(request.Id, cancellationToken);
         if (proposal is null)
-            throw new InvalidOperationException($"Proposal '{request.Id}' does not exist.");
+            throw new NotFoundException($"Proposal '{request.Id}' does not exist.");
 
         proposal.Update(request.Title, request.ShortDescription, request.LongDescription);
         await _proposalRepository.UpdateAsync(proposal, cancellationToken);

--- a/src/Herit.Application/Features/Proposal/Commands/UpdateProposalStatus/UpdateProposalStatusCommand.cs
+++ b/src/Herit.Application/Features/Proposal/Commands/UpdateProposalStatus/UpdateProposalStatusCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
 using MediatR;
@@ -19,7 +20,7 @@ public class UpdateProposalStatusCommandHandler : IRequestHandler<UpdateProposal
     {
         var proposal = await _proposalRepository.GetByIdAsync(request.Id, cancellationToken);
         if (proposal is null)
-            throw new InvalidOperationException($"Proposal '{request.Id}' does not exist.");
+            throw new NotFoundException($"Proposal '{request.Id}' does not exist.");
 
         proposal.TransitionStatus(request.NewStatus);
         await _proposalRepository.UpdateAsync(proposal, cancellationToken);

--- a/src/Herit.Application/Features/Proposal/Queries/GetProposalById/GetProposalByIdQuery.cs
+++ b/src/Herit.Application/Features/Proposal/Queries/GetProposalById/GetProposalByIdQuery.cs
@@ -1,11 +1,12 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.Proposal.Queries.GetProposalById;
 
-public record GetProposalByIdQuery(Guid Id) : IRequest<Herit.Domain.Entities.Proposal?>;
+public record GetProposalByIdQuery(Guid Id) : IRequest<Herit.Domain.Entities.Proposal>;
 
-public class GetProposalByIdQueryHandler : IRequestHandler<GetProposalByIdQuery, Herit.Domain.Entities.Proposal?>
+public class GetProposalByIdQueryHandler : IRequestHandler<GetProposalByIdQuery, Herit.Domain.Entities.Proposal>
 {
     private readonly IProposalRepository _proposalRepository;
 
@@ -14,6 +15,11 @@ public class GetProposalByIdQueryHandler : IRequestHandler<GetProposalByIdQuery,
         _proposalRepository = proposalRepository;
     }
 
-    public Task<Herit.Domain.Entities.Proposal?> Handle(GetProposalByIdQuery request, CancellationToken cancellationToken)
-        => _proposalRepository.GetByIdAsync(request.Id, cancellationToken);
+    public async Task<Herit.Domain.Entities.Proposal> Handle(GetProposalByIdQuery request, CancellationToken cancellationToken)
+    {
+        var proposal = await _proposalRepository.GetByIdAsync(request.Id, cancellationToken);
+        if (proposal is null)
+            throw new NotFoundException($"Proposal '{request.Id}' was not found.");
+        return proposal;
+    }
 }

--- a/src/Herit.Application/Features/Rfp/Commands/CreateRfp/CreateRfpCommand.cs
+++ b/src/Herit.Application/Features/Rfp/Commands/CreateRfp/CreateRfpCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using MediatR;
 using RfpEntity = Herit.Domain.Entities.Rfp;
@@ -31,11 +32,11 @@ public class CreateRfpCommandHandler : IRequestHandler<CreateRfpCommand, Guid>
     {
         var author = await _userRepository.GetByIdAsync(request.AuthorId, cancellationToken);
         if (author is null)
-            throw new InvalidOperationException($"User '{request.AuthorId}' does not exist.");
+            throw new NotFoundException($"User '{request.AuthorId}' does not exist.");
 
         var organisation = await _organisationRepository.GetByIdAsync(request.OrganisationId, cancellationToken);
         if (organisation is null)
-            throw new InvalidOperationException($"Organisation '{request.OrganisationId}' does not exist.");
+            throw new NotFoundException($"Organisation '{request.OrganisationId}' does not exist.");
 
         var id = Guid.NewGuid();
         var rfp = RfpEntity.Create(id, request.Title, request.ShortDescription, request.AuthorId, request.OrganisationId, request.LongDescription);

--- a/src/Herit.Application/Features/Rfp/Commands/UpdateRfp/UpdateRfpCommand.cs
+++ b/src/Herit.Application/Features/Rfp/Commands/UpdateRfp/UpdateRfpCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using MediatR;
 
@@ -22,7 +23,7 @@ public class UpdateRfpCommandHandler : IRequestHandler<UpdateRfpCommand, Unit>
     {
         var rfp = await _repository.GetByIdAsync(request.Id, cancellationToken);
         if (rfp is null)
-            throw new InvalidOperationException($"Rfp '{request.Id}' does not exist.");
+            throw new NotFoundException($"Rfp '{request.Id}' does not exist.");
 
         rfp.Update(request.Title, request.ShortDescription, request.LongDescription);
         await _repository.UpdateAsync(rfp, cancellationToken);

--- a/src/Herit.Application/Features/Rfp/Commands/UpdateRfpStatus/UpdateRfpStatusCommand.cs
+++ b/src/Herit.Application/Features/Rfp/Commands/UpdateRfpStatus/UpdateRfpStatusCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
 using MediatR;
@@ -19,7 +20,7 @@ public class UpdateRfpStatusCommandHandler : IRequestHandler<UpdateRfpStatusComm
     {
         var rfp = await _repository.GetByIdAsync(request.Id, cancellationToken);
         if (rfp is null)
-            throw new InvalidOperationException($"Rfp '{request.Id}' does not exist.");
+            throw new NotFoundException($"Rfp '{request.Id}' does not exist.");
 
         rfp.TransitionStatus(request.NewStatus);
         await _repository.UpdateAsync(rfp, cancellationToken);

--- a/src/Herit.Application/Features/Rfp/Queries/GetRfpById/GetRfpByIdQuery.cs
+++ b/src/Herit.Application/Features/Rfp/Queries/GetRfpById/GetRfpByIdQuery.cs
@@ -1,11 +1,12 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.Rfp.Queries.GetRfpById;
 
-public record GetRfpByIdQuery(Guid Id) : IRequest<Herit.Domain.Entities.Rfp?>;
+public record GetRfpByIdQuery(Guid Id) : IRequest<Herit.Domain.Entities.Rfp>;
 
-public class GetRfpByIdQueryHandler : IRequestHandler<GetRfpByIdQuery, Herit.Domain.Entities.Rfp?>
+public class GetRfpByIdQueryHandler : IRequestHandler<GetRfpByIdQuery, Herit.Domain.Entities.Rfp>
 {
     private readonly IRfpRepository _repository;
 
@@ -14,6 +15,11 @@ public class GetRfpByIdQueryHandler : IRequestHandler<GetRfpByIdQuery, Herit.Dom
         _repository = repository;
     }
 
-    public Task<Herit.Domain.Entities.Rfp?> Handle(GetRfpByIdQuery request, CancellationToken cancellationToken)
-        => _repository.GetByIdAsync(request.Id, cancellationToken);
+    public async Task<Herit.Domain.Entities.Rfp> Handle(GetRfpByIdQuery request, CancellationToken cancellationToken)
+    {
+        var rfp = await _repository.GetByIdAsync(request.Id, cancellationToken);
+        if (rfp is null)
+            throw new NotFoundException($"Rfp '{request.Id}' was not found.");
+        return rfp;
+    }
 }

--- a/src/Herit.Application/Features/User/Commands/CreateOrganisationAdmin/CreateOrganisationAdminCommand.cs
+++ b/src/Herit.Application/Features/User/Commands/CreateOrganisationAdmin/CreateOrganisationAdminCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
 using MediatR;
@@ -22,7 +23,7 @@ public class CreateOrganisationAdminCommandHandler : IRequestHandler<CreateOrgan
     {
         var organisation = await _organisationRepository.GetByIdAsync(request.OrganisationId, cancellationToken);
         if (organisation is null)
-            throw new InvalidOperationException($"Organisation with ID '{request.OrganisationId}' was not found.");
+            throw new NotFoundException($"Organisation with ID '{request.OrganisationId}' was not found.");
 
         var user = UserEntity.Create(Guid.NewGuid(), request.Email, request.FullName, UserRole.OrganisationAdmin, request.OrganisationId);
 

--- a/src/Herit.Application/Features/User/Commands/CreateStaffUser/CreateStaffUserCommand.cs
+++ b/src/Herit.Application/Features/User/Commands/CreateStaffUser/CreateStaffUserCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
 using MediatR;
@@ -22,7 +23,7 @@ public class CreateStaffUserCommandHandler : IRequestHandler<CreateStaffUserComm
     {
         var organisation = await _organisationRepository.GetByIdAsync(request.OrganisationId, cancellationToken);
         if (organisation is null)
-            throw new InvalidOperationException($"Organisation with ID '{request.OrganisationId}' was not found.");
+            throw new NotFoundException($"Organisation with ID '{request.OrganisationId}' was not found.");
 
         var user = UserEntity.Create(Guid.NewGuid(), request.Email, request.FullName, UserRole.Staff, request.OrganisationId);
 

--- a/src/Herit.Application/Features/User/Commands/DeleteOrganisationAdmin/DeleteOrganisationAdminCommand.cs
+++ b/src/Herit.Application/Features/User/Commands/DeleteOrganisationAdmin/DeleteOrganisationAdminCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
 using MediatR;
@@ -19,7 +20,7 @@ public class DeleteOrganisationAdminCommandHandler : IRequestHandler<DeleteOrgan
     {
         var user = await _userRepository.GetByIdAsync(request.Id, cancellationToken);
         if (user is null)
-            throw new InvalidOperationException($"User with ID '{request.Id}' was not found.");
+            throw new NotFoundException($"User with ID '{request.Id}' was not found.");
 
         if (user.Role != UserRole.OrganisationAdmin)
             throw new InvalidOperationException($"User with ID '{request.Id}' is not an OrganisationAdmin.");

--- a/src/Herit.Application/Features/User/Commands/DeleteStaffUser/DeleteStaffUserCommand.cs
+++ b/src/Herit.Application/Features/User/Commands/DeleteStaffUser/DeleteStaffUserCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
 using MediatR;
@@ -19,7 +20,7 @@ public class DeleteStaffUserCommandHandler : IRequestHandler<DeleteStaffUserComm
     {
         var user = await _userRepository.GetByIdAsync(request.Id, cancellationToken);
         if (user is null)
-            throw new InvalidOperationException($"User with ID '{request.Id}' was not found.");
+            throw new NotFoundException($"User with ID '{request.Id}' was not found.");
 
         if (user.Role != UserRole.Staff)
             throw new InvalidOperationException($"User with ID '{request.Id}' is not a Staff user.");

--- a/src/Herit.Application/Features/User/Commands/UpdateStaffUser/UpdateStaffUserCommand.cs
+++ b/src/Herit.Application/Features/User/Commands/UpdateStaffUser/UpdateStaffUserCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using MediatR;
 
@@ -18,7 +19,7 @@ public class UpdateStaffUserCommandHandler : IRequestHandler<UpdateStaffUserComm
     {
         var user = await _userRepository.GetByIdAsync(request.Id, cancellationToken);
         if (user is null)
-            throw new InvalidOperationException($"User with ID '{request.Id}' was not found.");
+            throw new NotFoundException($"User with ID '{request.Id}' was not found.");
 
         user.Update(request.Email, request.FullName);
 

--- a/src/Herit.Application/Features/User/Queries/GetUserById/GetUserByIdQuery.cs
+++ b/src/Herit.Application/Features/User/Queries/GetUserById/GetUserByIdQuery.cs
@@ -1,11 +1,12 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.User.Queries.GetUserById;
 
-public record GetUserByIdQuery(Guid Id) : IRequest<Herit.Domain.Entities.User?>;
+public record GetUserByIdQuery(Guid Id) : IRequest<Herit.Domain.Entities.User>;
 
-public class GetUserByIdQueryHandler : IRequestHandler<GetUserByIdQuery, Herit.Domain.Entities.User?>
+public class GetUserByIdQueryHandler : IRequestHandler<GetUserByIdQuery, Herit.Domain.Entities.User>
 {
     private readonly IUserRepository _userRepository;
 
@@ -14,8 +15,11 @@ public class GetUserByIdQueryHandler : IRequestHandler<GetUserByIdQuery, Herit.D
         _userRepository = userRepository;
     }
 
-    public async Task<Herit.Domain.Entities.User?> Handle(GetUserByIdQuery request, CancellationToken cancellationToken)
+    public async Task<Herit.Domain.Entities.User> Handle(GetUserByIdQuery request, CancellationToken cancellationToken)
     {
-        return await _userRepository.GetByIdAsync(request.Id, cancellationToken);
+        var user = await _userRepository.GetByIdAsync(request.Id, cancellationToken);
+        if (user is null)
+            throw new NotFoundException($"User '{request.Id}' was not found.");
+        return user;
     }
 }

--- a/src/Herit.Infrastructure/Repositories/EoiRepository.cs
+++ b/src/Herit.Infrastructure/Repositories/EoiRepository.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using Herit.Domain.Entities;
 using Herit.Infrastructure.Persistence;
@@ -49,7 +50,7 @@ public class EoiRepository : IEoiRepository
     public async Task DeleteAsync(Guid id, CancellationToken cancellationToken = default)
     {
         var eoi = await _context.Eois.FindAsync([id], cancellationToken)
-            ?? throw new InvalidOperationException($"Eoi with id '{id}' was not found.");
+            ?? throw new NotFoundException($"Eoi with id '{id}' was not found.");
 
         _context.Eois.Remove(eoi);
         await _context.SaveChangesAsync(cancellationToken);

--- a/src/Herit.Infrastructure/Repositories/ProposalRepository.cs
+++ b/src/Herit.Infrastructure/Repositories/ProposalRepository.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using Herit.Domain.Entities;
 using Herit.Infrastructure.Persistence;
@@ -40,7 +41,7 @@ public class ProposalRepository : IProposalRepository
     public async Task DeleteAsync(Guid id, CancellationToken cancellationToken = default)
     {
         var proposal = await _context.Proposals.FindAsync([id], cancellationToken)
-            ?? throw new InvalidOperationException($"Proposal with id '{id}' was not found.");
+            ?? throw new NotFoundException($"Proposal with id '{id}' was not found.");
 
         _context.Proposals.Remove(proposal);
         await _context.SaveChangesAsync(cancellationToken);

--- a/src/Herit.Infrastructure/Repositories/RfpRepository.cs
+++ b/src/Herit.Infrastructure/Repositories/RfpRepository.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using Herit.Domain.Entities;
 using Herit.Infrastructure.Persistence;
@@ -40,7 +41,7 @@ public class RfpRepository : IRfpRepository
     public async Task DeleteAsync(Guid id, CancellationToken cancellationToken = default)
     {
         var rfp = await _context.Rfps.FindAsync([id], cancellationToken)
-            ?? throw new InvalidOperationException($"Rfp with id '{id}' was not found.");
+            ?? throw new NotFoundException($"Rfp with id '{id}' was not found.");
 
         _context.Rfps.Remove(rfp);
         await _context.SaveChangesAsync(cancellationToken);

--- a/src/Herit.Infrastructure/Repositories/UserRepository.cs
+++ b/src/Herit.Infrastructure/Repositories/UserRepository.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using Herit.Domain.Entities;
 using Herit.Infrastructure.Persistence;
@@ -40,7 +41,7 @@ public class UserRepository : IUserRepository
     public async Task DeleteAsync(Guid id, CancellationToken cancellationToken = default)
     {
         var user = await _context.Users.FindAsync([id], cancellationToken)
-            ?? throw new InvalidOperationException($"User with id '{id}' was not found.");
+            ?? throw new NotFoundException($"User with id '{id}' was not found.");
 
         _context.Users.Remove(user);
         await _context.SaveChangesAsync(cancellationToken);

--- a/tests/Herit.Application.Tests/Features/Cfeoi/Commands/PublishCfeoiCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Cfeoi/Commands/PublishCfeoiCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.Cfeoi.Commands.PublishCfeoi;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
@@ -36,14 +37,14 @@ public class PublishCfeoiCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_ProposalNotFound_ThrowsInvalidOperationException()
+    public async Task Handle_ProposalNotFound_ThrowsNotFoundException()
     {
         var proposalId = Guid.NewGuid();
         _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>()).Returns((ProposalEntity?)null);
 
         var command = new PublishCfeoiCommand("CFEOI Title", "Description", CfeoiResourceType.Human, proposalId);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _cfeoiRepository.DidNotReceive().AddAsync(Arg.Any<CfeoiEntity>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Herit.Application.Tests/Features/Cfeoi/Commands/UpdateCfeoiStatusCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Cfeoi/Commands/UpdateCfeoiStatusCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.Cfeoi.Commands.UpdateCfeoiStatus;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
@@ -34,12 +35,12 @@ public class UpdateCfeoiStatusCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_CfeoiNotFound_ThrowsInvalidOperationException()
+    public async Task Handle_CfeoiNotFound_ThrowsNotFoundException()
     {
         var id = Guid.NewGuid();
         _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((CfeoiEntity?)null);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        await Assert.ThrowsAsync<NotFoundException>(
             () => _handler.Handle(new UpdateCfeoiStatusCommand(id, CfeoiStatus.Closed), CancellationToken.None));
         await _repository.DidNotReceive().UpdateAsync(Arg.Any<CfeoiEntity>(), Arg.Any<CancellationToken>());
     }

--- a/tests/Herit.Application.Tests/Features/Cfeoi/Queries/GetCfeoiByIdQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Cfeoi/Queries/GetCfeoiByIdQueryHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.Cfeoi.Queries.GetCfeoiById;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
@@ -30,13 +31,11 @@ public class GetCfeoiByIdQueryHandlerTests
     }
 
     [Fact]
-    public async Task Handle_CfeoiNotFound_ReturnsNull()
+    public async Task Handle_CfeoiNotFound_ThrowsNotFoundException()
     {
         var cfeoiId = Guid.NewGuid();
         _cfeoiRepository.GetByIdAsync(cfeoiId, Arg.Any<CancellationToken>()).Returns((CfeoiEntity?)null);
 
-        var result = await _handler.Handle(new GetCfeoiByIdQuery(cfeoiId), CancellationToken.None);
-
-        Assert.Null(result);
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(new GetCfeoiByIdQuery(cfeoiId), CancellationToken.None));
     }
 }

--- a/tests/Herit.Application.Tests/Features/Eoi/Commands/DeleteEoiCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Eoi/Commands/DeleteEoiCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.Eoi.Commands.DeleteEoi;
 using Herit.Application.Interfaces;
 using MediatR;
@@ -30,12 +31,12 @@ public class DeleteEoiCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_EoiNotFound_ThrowsInvalidOperationException()
+    public async Task Handle_EoiNotFound_ThrowsNotFoundException()
     {
         var eoiId = Guid.NewGuid();
         _eoiRepository.GetByIdAsync(eoiId, Arg.Any<CancellationToken>()).Returns((EoiEntity?)null);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        await Assert.ThrowsAsync<NotFoundException>(
             () => _handler.Handle(new DeleteEoiCommand(eoiId), CancellationToken.None));
         await _eoiRepository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }

--- a/tests/Herit.Application.Tests/Features/Eoi/Commands/SetEoiVisibilityCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Eoi/Commands/SetEoiVisibilityCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.Eoi.Commands.SetEoiVisibility;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
@@ -32,12 +33,12 @@ public class SetEoiVisibilityCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_EoiNotFound_ThrowsInvalidOperationException()
+    public async Task Handle_EoiNotFound_ThrowsNotFoundException()
     {
         var eoiId = Guid.NewGuid();
         _eoiRepository.GetByIdAsync(eoiId, Arg.Any<CancellationToken>()).Returns((EoiEntity?)null);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        await Assert.ThrowsAsync<NotFoundException>(
             () => _handler.Handle(new SetEoiVisibilityCommand(eoiId, EoiVisibility.Shared), CancellationToken.None));
         await _eoiRepository.DidNotReceive().UpdateAsync(Arg.Any<EoiEntity>(), Arg.Any<CancellationToken>());
     }

--- a/tests/Herit.Application.Tests/Features/Eoi/Commands/SubmitEoiCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Eoi/Commands/SubmitEoiCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.Eoi.Commands.SubmitEoi;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
@@ -41,19 +42,19 @@ public class SubmitEoiCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_UserNotFound_ThrowsInvalidOperationException()
+    public async Task Handle_UserNotFound_ThrowsNotFoundException()
     {
         var submittedById = Guid.NewGuid();
         _userRepository.GetByIdAsync(submittedById, Arg.Any<CancellationToken>()).Returns((UserEntity?)null);
 
         var command = new SubmitEoiCommand(submittedById, "Message", Guid.NewGuid());
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _eoiRepository.DidNotReceive().AddAsync(Arg.Any<EoiEntity>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task Handle_CfeoiNotFound_ThrowsInvalidOperationException()
+    public async Task Handle_CfeoiNotFound_ThrowsNotFoundException()
     {
         var submittedById = Guid.NewGuid();
         var cfeoiId = Guid.NewGuid();
@@ -63,7 +64,7 @@ public class SubmitEoiCommandHandlerTests
 
         var command = new SubmitEoiCommand(submittedById, "Message", cfeoiId);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _eoiRepository.DidNotReceive().AddAsync(Arg.Any<EoiEntity>(), Arg.Any<CancellationToken>());
     }
 

--- a/tests/Herit.Application.Tests/Features/Eoi/Commands/UpdateEoiStatusCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Eoi/Commands/UpdateEoiStatusCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.Eoi.Commands.UpdateEoiStatus;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
@@ -48,12 +49,12 @@ public class UpdateEoiStatusCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_EoiNotFound_ThrowsInvalidOperationException()
+    public async Task Handle_EoiNotFound_ThrowsNotFoundException()
     {
         var id = Guid.NewGuid();
         _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((EoiEntity?)null);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        await Assert.ThrowsAsync<NotFoundException>(
             () => _handler.Handle(new UpdateEoiStatusCommand(id, EoiStatus.Approved), CancellationToken.None));
         await _repository.DidNotReceive().UpdateAsync(Arg.Any<EoiEntity>(), Arg.Any<CancellationToken>());
     }

--- a/tests/Herit.Application.Tests/Features/Eoi/Commands/WithdrawEoiCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Eoi/Commands/WithdrawEoiCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.Eoi.Commands.WithdrawEoi;
 using Herit.Application.Interfaces;
 using MediatR;
@@ -30,12 +31,12 @@ public class WithdrawEoiCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_EoiNotFound_ThrowsInvalidOperationException()
+    public async Task Handle_EoiNotFound_ThrowsNotFoundException()
     {
         var eoiId = Guid.NewGuid();
         _eoiRepository.GetByIdAsync(eoiId, Arg.Any<CancellationToken>()).Returns((EoiEntity?)null);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        await Assert.ThrowsAsync<NotFoundException>(
             () => _handler.Handle(new WithdrawEoiCommand(eoiId), CancellationToken.None));
         await _eoiRepository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }

--- a/tests/Herit.Application.Tests/Features/Eoi/Queries/GetEoiByIdQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Eoi/Queries/GetEoiByIdQueryHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.Eoi.Queries.GetEoiById;
 using Herit.Application.Interfaces;
 using NSubstitute;
@@ -29,13 +30,11 @@ public class GetEoiByIdQueryHandlerTests
     }
 
     [Fact]
-    public async Task Handle_EoiNotFound_ReturnsNull()
+    public async Task Handle_EoiNotFound_ThrowsNotFoundException()
     {
         var eoiId = Guid.NewGuid();
         _eoiRepository.GetByIdAsync(eoiId, Arg.Any<CancellationToken>()).Returns((EoiEntity?)null);
 
-        var result = await _handler.Handle(new GetEoiByIdQuery(eoiId), CancellationToken.None);
-
-        Assert.Null(result);
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(new GetEoiByIdQuery(eoiId), CancellationToken.None));
     }
 }

--- a/tests/Herit.Application.Tests/Features/Organisation/Commands/CreateOrganisationCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Organisation/Commands/CreateOrganisationCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.Organisation.Commands.CreateOrganisation;
 using Herit.Application.Interfaces;
 using NSubstitute;
@@ -46,14 +47,14 @@ public class CreateOrganisationCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentParent_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentParent_ThrowsNotFoundException()
     {
         var parentId = Guid.NewGuid();
         _repository.GetByIdAsync(parentId, Arg.Any<CancellationToken>()).Returns((OrganisationEntity?)null);
 
         var command = new CreateOrganisationCommand("Child Organisation", parentId);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _repository.DidNotReceive().AddAsync(Arg.Any<OrganisationEntity>(), Arg.Any<CancellationToken>());
     }
 

--- a/tests/Herit.Application.Tests/Features/Organisation/Commands/DeleteOrganisationCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Organisation/Commands/DeleteOrganisationCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.Organisation.Commands.DeleteOrganisation;
 using Herit.Application.Interfaces;
 using NSubstitute;
@@ -30,14 +31,14 @@ public class DeleteOrganisationCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentOrganisation_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentOrganisation_ThrowsNotFoundException()
     {
         var id = Guid.NewGuid();
         _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((OrganisationEntity?)null);
 
         var command = new DeleteOrganisationCommand(id);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _repository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }
 

--- a/tests/Herit.Application.Tests/Features/Organisation/Commands/UpdateOrganisationCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Organisation/Commands/UpdateOrganisationCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.Organisation.Commands.UpdateOrganisation;
 using Herit.Application.Interfaces;
 using NSubstitute;
@@ -31,14 +32,14 @@ public class UpdateOrganisationCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentOrganisation_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentOrganisation_ThrowsNotFoundException()
     {
         var id = Guid.NewGuid();
         _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((OrganisationEntity?)null);
 
         var command = new UpdateOrganisationCommand(id, "New Name");
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _repository.DidNotReceive().UpdateAsync(Arg.Any<OrganisationEntity>(), Arg.Any<CancellationToken>());
     }
 

--- a/tests/Herit.Application.Tests/Features/Organisation/Queries/GetOrganisationByIdQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Organisation/Queries/GetOrganisationByIdQueryHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.Organisation.Queries.GetOrganisationById;
 using Herit.Application.Interfaces;
 using NSubstitute;
@@ -30,21 +31,20 @@ public class GetOrganisationByIdQueryHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentId_ReturnsNull()
+    public async Task Handle_WithNonExistentId_ThrowsNotFoundException()
     {
         var id = Guid.NewGuid();
         _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((OrganisationEntity?)null);
 
-        var result = await _handler.Handle(new GetOrganisationByIdQuery(id), CancellationToken.None);
-
-        Assert.Null(result);
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(new GetOrganisationByIdQuery(id), CancellationToken.None));
     }
 
     [Fact]
     public async Task Handle_QueriesRepositoryWithCorrectId()
     {
         var id = Guid.NewGuid();
-        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((OrganisationEntity?)null);
+        var organisation = OrganisationEntity.Create(id, "Ministry of Finance");
+        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(organisation);
 
         await _handler.Handle(new GetOrganisationByIdQuery(id), CancellationToken.None);
 

--- a/tests/Herit.Application.Tests/Features/Proposal/Commands/CreateProposalCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Proposal/Commands/CreateProposalCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.Proposal.Commands.CreateProposal;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
@@ -66,7 +67,7 @@ public class CreateProposalCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_AuthorNotFound_ThrowsInvalidOperationException()
+    public async Task Handle_AuthorNotFound_ThrowsNotFoundException()
     {
         var authorId = Guid.NewGuid();
         var organisationId = Guid.NewGuid();
@@ -74,12 +75,12 @@ public class CreateProposalCommandHandlerTests
 
         var command = new CreateProposalCommand("Title", "Short", authorId, organisationId, "Long");
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _proposalRepository.DidNotReceive().AddAsync(Arg.Any<ProposalEntity>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task Handle_OrganisationNotFound_ThrowsInvalidOperationException()
+    public async Task Handle_OrganisationNotFound_ThrowsNotFoundException()
     {
         var authorId = Guid.NewGuid();
         var organisationId = Guid.NewGuid();
@@ -89,12 +90,12 @@ public class CreateProposalCommandHandlerTests
 
         var command = new CreateProposalCommand("Title", "Short", authorId, organisationId, "Long");
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _proposalRepository.DidNotReceive().AddAsync(Arg.Any<ProposalEntity>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task Handle_RfpNotFound_ThrowsInvalidOperationException()
+    public async Task Handle_RfpNotFound_ThrowsNotFoundException()
     {
         var authorId = Guid.NewGuid();
         var organisationId = Guid.NewGuid();
@@ -107,7 +108,7 @@ public class CreateProposalCommandHandlerTests
 
         var command = new CreateProposalCommand("Title", "Short", authorId, organisationId, "Long", rfpId);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _proposalRepository.DidNotReceive().AddAsync(Arg.Any<ProposalEntity>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Herit.Application.Tests/Features/Proposal/Commands/DeleteProposalCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Proposal/Commands/DeleteProposalCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.Proposal.Commands.DeleteProposal;
 using Herit.Application.Interfaces;
 using MediatR;
@@ -34,14 +35,14 @@ public class DeleteProposalCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_ProposalNotFound_ThrowsInvalidOperationException()
+    public async Task Handle_ProposalNotFound_ThrowsNotFoundException()
     {
         var proposalId = Guid.NewGuid();
         _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>()).Returns((ProposalEntity?)null);
 
         var command = new DeleteProposalCommand(proposalId);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _proposalRepository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Herit.Application.Tests/Features/Proposal/Commands/SetProposalVisibilityCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Proposal/Commands/SetProposalVisibilityCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.Proposal.Commands.SetProposalVisibility;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
@@ -34,12 +35,12 @@ public class SetProposalVisibilityCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_ProposalNotFound_ThrowsInvalidOperationException()
+    public async Task Handle_ProposalNotFound_ThrowsNotFoundException()
     {
         var proposalId = Guid.NewGuid();
         _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>()).Returns((ProposalEntity?)null);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        await Assert.ThrowsAsync<NotFoundException>(
             () => _handler.Handle(new SetProposalVisibilityCommand(proposalId, ProposalVisibility.Public), CancellationToken.None));
         await _proposalRepository.DidNotReceive().UpdateAsync(Arg.Any<ProposalEntity>(), Arg.Any<CancellationToken>());
     }

--- a/tests/Herit.Application.Tests/Features/Proposal/Commands/UpdateProposalCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Proposal/Commands/UpdateProposalCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.Proposal.Commands.UpdateProposal;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
@@ -39,14 +40,14 @@ public class UpdateProposalCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_ProposalNotFound_ThrowsInvalidOperationException()
+    public async Task Handle_ProposalNotFound_ThrowsNotFoundException()
     {
         var proposalId = Guid.NewGuid();
         _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>()).Returns((ProposalEntity?)null);
 
         var command = new UpdateProposalCommand(proposalId, "Title", "Short", "Long");
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _proposalRepository.DidNotReceive().UpdateAsync(Arg.Any<ProposalEntity>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Herit.Application.Tests/Features/Proposal/Commands/UpdateProposalStatusCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Proposal/Commands/UpdateProposalStatusCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.Proposal.Commands.UpdateProposalStatus;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
@@ -35,12 +36,12 @@ public class UpdateProposalStatusCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_ProposalNotFound_ThrowsInvalidOperationException()
+    public async Task Handle_ProposalNotFound_ThrowsNotFoundException()
     {
         var id = Guid.NewGuid();
         _proposalRepository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((ProposalEntity?)null);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        await Assert.ThrowsAsync<NotFoundException>(
             () => _handler.Handle(new UpdateProposalStatusCommand(id, ProposalStatus.Resourcing), CancellationToken.None));
         await _proposalRepository.DidNotReceive().UpdateAsync(Arg.Any<ProposalEntity>(), Arg.Any<CancellationToken>());
     }

--- a/tests/Herit.Application.Tests/Features/Proposal/Queries/GetProposalByIdQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Proposal/Queries/GetProposalByIdQueryHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.Proposal.Queries.GetProposalById;
 using Herit.Application.Interfaces;
 using NSubstitute;
@@ -29,13 +30,11 @@ public class GetProposalByIdQueryHandlerTests
     }
 
     [Fact]
-    public async Task Handle_ProposalNotFound_ReturnsNull()
+    public async Task Handle_ProposalNotFound_ThrowsNotFoundException()
     {
         var proposalId = Guid.NewGuid();
         _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>()).Returns((ProposalEntity?)null);
 
-        var result = await _handler.Handle(new GetProposalByIdQuery(proposalId), CancellationToken.None);
-
-        Assert.Null(result);
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(new GetProposalByIdQuery(proposalId), CancellationToken.None));
     }
 }

--- a/tests/Herit.Application.Tests/Features/Rfp/Commands/CreateRfpCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Rfp/Commands/CreateRfpCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.Rfp.Commands.CreateRfp;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
@@ -41,7 +42,7 @@ public class CreateRfpCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_AuthorNotFound_ThrowsInvalidOperationException()
+    public async Task Handle_AuthorNotFound_ThrowsNotFoundException()
     {
         var authorId = Guid.NewGuid();
         var organisationId = Guid.NewGuid();
@@ -49,12 +50,12 @@ public class CreateRfpCommandHandlerTests
 
         var command = new CreateRfpCommand("Title", "Short", authorId, organisationId, "Long");
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _rfpRepository.DidNotReceive().AddAsync(Arg.Any<RfpEntity>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task Handle_OrganisationNotFound_ThrowsInvalidOperationException()
+    public async Task Handle_OrganisationNotFound_ThrowsNotFoundException()
     {
         var authorId = Guid.NewGuid();
         var organisationId = Guid.NewGuid();
@@ -64,7 +65,7 @@ public class CreateRfpCommandHandlerTests
 
         var command = new CreateRfpCommand("Title", "Short", authorId, organisationId, "Long");
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _rfpRepository.DidNotReceive().AddAsync(Arg.Any<RfpEntity>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Herit.Application.Tests/Features/Rfp/Commands/DeleteRfpCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Rfp/Commands/DeleteRfpCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.Rfp.Commands.DeleteRfp;
 using Herit.Application.Interfaces;
 using NSubstitute;
@@ -27,13 +28,13 @@ public class DeleteRfpCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentRfp_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentRfp_ThrowsNotFoundException()
     {
         var id = Guid.NewGuid();
         _repository.DeleteAsync(id, Arg.Any<CancellationToken>())
-            .Throws(new InvalidOperationException($"Rfp with id '{id}' was not found."));
+            .Throws(new NotFoundException($"Rfp with id '{id}' was not found."));
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        await Assert.ThrowsAsync<NotFoundException>(
             () => _handler.Handle(new DeleteRfpCommand(id), CancellationToken.None));
     }
 }

--- a/tests/Herit.Application.Tests/Features/Rfp/Commands/UpdateRfpCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Rfp/Commands/UpdateRfpCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.Rfp.Commands.UpdateRfp;
 using Herit.Application.Interfaces;
 using NSubstitute;
@@ -33,14 +34,14 @@ public class UpdateRfpCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentRfp_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentRfp_ThrowsNotFoundException()
     {
         var id = Guid.NewGuid();
         _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((RfpEntity?)null);
 
         var command = new UpdateRfpCommand(id, "Title", "Short", "Long");
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _repository.DidNotReceive().UpdateAsync(Arg.Any<RfpEntity>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Herit.Application.Tests/Features/Rfp/Commands/UpdateRfpStatusCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Rfp/Commands/UpdateRfpStatusCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.Rfp.Commands.UpdateRfpStatus;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
@@ -49,12 +50,12 @@ public class UpdateRfpStatusCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_RfpNotFound_ThrowsInvalidOperationException()
+    public async Task Handle_RfpNotFound_ThrowsNotFoundException()
     {
         var id = Guid.NewGuid();
         _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((RfpEntity?)null);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        await Assert.ThrowsAsync<NotFoundException>(
             () => _handler.Handle(new UpdateRfpStatusCommand(id, RfpStatus.Approved), CancellationToken.None));
         await _repository.DidNotReceive().UpdateAsync(Arg.Any<RfpEntity>(), Arg.Any<CancellationToken>());
     }

--- a/tests/Herit.Application.Tests/Features/Rfp/Queries/GetRfpByIdQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Rfp/Queries/GetRfpByIdQueryHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.Rfp.Queries.GetRfpById;
 using Herit.Application.Interfaces;
 using NSubstitute;
@@ -29,13 +30,11 @@ public class GetRfpByIdQueryHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WhenRfpNotFound_ReturnsNull()
+    public async Task Handle_WhenRfpNotFound_ThrowsNotFoundException()
     {
         var id = Guid.NewGuid();
         _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((RfpEntity?)null);
 
-        var result = await _handler.Handle(new GetRfpByIdQuery(id), CancellationToken.None);
-
-        Assert.Null(result);
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(new GetRfpByIdQuery(id), CancellationToken.None));
     }
 }

--- a/tests/Herit.Application.Tests/Features/User/Commands/CreateOrganisationAdminCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/User/Commands/CreateOrganisationAdminCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.User.Commands.CreateOrganisationAdmin;
 using Herit.Application.Interfaces;
 using NSubstitute;
@@ -49,14 +50,14 @@ public class CreateOrganisationAdminCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentOrganisation_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentOrganisation_ThrowsNotFoundException()
     {
         var orgId = Guid.NewGuid();
         _organisationRepository.GetByIdAsync(orgId, Arg.Any<CancellationToken>()).Returns((OrganisationEntity?)null);
 
         var command = new CreateOrganisationAdminCommand("admin@gov.eg", "Organisation Admin", orgId);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _userRepository.DidNotReceive().AddAsync(Arg.Any<UserEntity>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Herit.Application.Tests/Features/User/Commands/CreateStaffUserCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/User/Commands/CreateStaffUserCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.User.Commands.CreateStaffUser;
 using Herit.Application.Interfaces;
 using NSubstitute;
@@ -49,14 +50,14 @@ public class CreateStaffUserCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentOrganisation_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentOrganisation_ThrowsNotFoundException()
     {
         var orgId = Guid.NewGuid();
         _organisationRepository.GetByIdAsync(orgId, Arg.Any<CancellationToken>()).Returns((OrganisationEntity?)null);
 
         var command = new CreateStaffUserCommand("staff@gov.eg", "Staff Member", orgId);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _userRepository.DidNotReceive().AddAsync(Arg.Any<UserEntity>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Herit.Application.Tests/Features/User/Commands/DeleteOrganisationAdminCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/User/Commands/DeleteOrganisationAdminCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.User.Commands.DeleteOrganisationAdmin;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
@@ -30,14 +31,14 @@ public class DeleteOrganisationAdminCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentUser_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentUser_ThrowsNotFoundException()
     {
         var userId = Guid.NewGuid();
         _userRepository.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns((UserEntity?)null);
 
         var command = new DeleteOrganisationAdminCommand(userId);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _userRepository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }
 

--- a/tests/Herit.Application.Tests/Features/User/Commands/DeleteStaffUserCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/User/Commands/DeleteStaffUserCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.User.Commands.DeleteStaffUser;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
@@ -30,14 +31,14 @@ public class DeleteStaffUserCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentUser_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentUser_ThrowsNotFoundException()
     {
         var userId = Guid.NewGuid();
         _userRepository.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns((UserEntity?)null);
 
         var command = new DeleteStaffUserCommand(userId);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _userRepository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }
 

--- a/tests/Herit.Application.Tests/Features/User/Commands/UpdateStaffUserCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/User/Commands/UpdateStaffUserCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.User.Commands.UpdateStaffUser;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
@@ -33,14 +34,14 @@ public class UpdateStaffUserCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentUser_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentUser_ThrowsNotFoundException()
     {
         var userId = Guid.NewGuid();
         _userRepository.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns((UserEntity?)null);
 
         var command = new UpdateStaffUserCommand(userId, "updated@gov.eg", "Updated Name");
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _userRepository.DidNotReceive().UpdateAsync(Arg.Any<UserEntity>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Herit.Application.Tests/Features/User/Queries/GetUserByIdQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/User/Queries/GetUserByIdQueryHandlerTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Application.Features.User.Queries.GetUserById;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
@@ -30,14 +31,12 @@ public class GetUserByIdQueryHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WhenRepositoryReturnsNull_ReturnsNull()
+    public async Task Handle_WhenRepositoryReturnsNull_ThrowsNotFoundException()
     {
         var userId = Guid.NewGuid();
         _userRepository.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns((UserEntity?)null);
 
         var query = new GetUserByIdQuery(userId);
-        var result = await _handler.Handle(query, CancellationToken.None);
-
-        Assert.Null(result);
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(query, CancellationToken.None));
     }
 }

--- a/tests/Herit.Infrastructure.Tests/Repositories/EoiRepositoryTests.cs
+++ b/tests/Herit.Infrastructure.Tests/Repositories/EoiRepositoryTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Domain.Entities;
 using Herit.Domain.Enums;
 using Herit.Infrastructure.Persistence;
@@ -144,7 +145,7 @@ public class EoiRepositoryTests : IDisposable
     [Fact]
     public async Task DeleteAsync_Throws_WhenNotExists()
     {
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        await Assert.ThrowsAsync<NotFoundException>(
             () => _repository.DeleteAsync(Guid.NewGuid()));
     }
 }

--- a/tests/Herit.Infrastructure.Tests/Repositories/ProposalRepositoryTests.cs
+++ b/tests/Herit.Infrastructure.Tests/Repositories/ProposalRepositoryTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Domain.Entities;
 using Herit.Infrastructure.Persistence;
 using Herit.Infrastructure.Repositories;
@@ -116,7 +117,7 @@ public class ProposalRepositoryTests : IDisposable
     [Fact]
     public async Task DeleteAsync_Throws_WhenNotExists()
     {
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        await Assert.ThrowsAsync<NotFoundException>(
             () => _repository.DeleteAsync(Guid.NewGuid()));
     }
 }

--- a/tests/Herit.Infrastructure.Tests/Repositories/RfpRepositoryTests.cs
+++ b/tests/Herit.Infrastructure.Tests/Repositories/RfpRepositoryTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Domain.Entities;
 using Herit.Infrastructure.Persistence;
 using Herit.Infrastructure.Repositories;
@@ -116,7 +117,7 @@ public class RfpRepositoryTests : IDisposable
     [Fact]
     public async Task DeleteAsync_Throws_WhenNotExists()
     {
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        await Assert.ThrowsAsync<NotFoundException>(
             () => _repository.DeleteAsync(Guid.NewGuid()));
     }
 }

--- a/tests/Herit.Infrastructure.Tests/Repositories/UserRepositoryTests.cs
+++ b/tests/Herit.Infrastructure.Tests/Repositories/UserRepositoryTests.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Exceptions;
 using Herit.Domain.Entities;
 using Herit.Domain.Enums;
 using Herit.Infrastructure.Persistence;
@@ -110,7 +111,7 @@ public class UserRepositoryTests : IDisposable
     [Fact]
     public async Task DeleteAsync_Throws_WhenNotExists()
     {
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        await Assert.ThrowsAsync<NotFoundException>(
             () => _repository.DeleteAsync(Guid.NewGuid()));
     }
 }


### PR DESCRIPTION
## Description

Introduces `NotFoundException : Exception` in `Herit.Application/Exceptions/` and replaces every `InvalidOperationException` that guards a null repository lookup result (\"does not exist\" / \"was not found\") with `NotFoundException`. Business-rule throws (wrong role, illegal status transition, not open for submissions) remain `InvalidOperationException`.

Key changes:
- **Application command handlers** (22 files): null-guard throws → `NotFoundException`
- **GetById query handlers** (6 files): now throw `NotFoundException` when null instead of returning null; return types changed from `T?` to `T`
- **Infrastructure repositories** (4 files): `DeleteAsync` null-guard throws → `NotFoundException`
- **Controllers** (2 files): removed `result is null ? NotFound() : Ok(result)` patterns; now call `Ok()` directly since handlers throw on not-found
- **All test files** updated to assert `NotFoundException` for null-lookup scenarios

## Linked Issue

Closes #125

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

All 182 tests pass across all four test projects (`dotnet test --configuration Release`).

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/add-not-found-exception`)