### PR TITLE
Add global exception handler middleware

### DIFF
--- a/src/Herit.Api/Middleware/GlobalExceptionHandler.cs
+++ b/src/Herit.Api/Middleware/GlobalExceptionHandler.cs
@@ -1,0 +1,64 @@
+using FluentValidation;
+using Herit.Application.Exceptions;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Herit.Api.Middleware;
+
+public class GlobalExceptionHandler(ILogger<GlobalExceptionHandler> logger) : IExceptionHandler
+{
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        var problemDetails = exception switch
+        {
+            NotFoundException => new ProblemDetails
+            {
+                Status = StatusCodes.Status404NotFound,
+                Title = "Not Found",
+                Detail = exception.Message
+            },
+            InvalidOperationException => new ProblemDetails
+            {
+                Status = StatusCodes.Status400BadRequest,
+                Title = "Bad Request",
+                Detail = exception.Message
+            },
+            ValidationException validationException => CreateValidationProblemDetails(validationException),
+            _ => null
+        };
+
+        if (problemDetails is null)
+        {
+            logger.LogError(exception, "An unhandled exception occurred.");
+            problemDetails = new ProblemDetails
+            {
+                Status = StatusCodes.Status500InternalServerError,
+                Title = "Internal Server Error"
+            };
+        }
+
+        httpContext.Response.StatusCode = problemDetails.Status!.Value;
+        await httpContext.Response.WriteAsJsonAsync(problemDetails, cancellationToken);
+        return true;
+    }
+
+    private static ProblemDetails CreateValidationProblemDetails(ValidationException exception)
+    {
+        var errors = exception.Errors
+            .GroupBy(e => e.PropertyName)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(e => e.ErrorMessage).ToArray());
+
+        var problemDetails = new ProblemDetails
+        {
+            Status = StatusCodes.Status422UnprocessableEntity,
+            Title = "Validation Failed"
+        };
+        problemDetails.Extensions["errors"] = errors;
+        return problemDetails;
+    }
+}

--- a/src/Herit.Api/Program.cs
+++ b/src/Herit.Api/Program.cs
@@ -1,4 +1,5 @@
 using Azure.Identity;
+using Herit.Api.Middleware;
 using Herit.Application.Features.Rfp.Commands.CreateRfp;
 using Herit.Infrastructure;
 using Herit.Infrastructure.Persistence;
@@ -24,6 +25,9 @@ var connectionString = (!string.IsNullOrEmpty(connectionStringKey)
 
 builder.Services.AddInfrastructure(connectionString);
 
+builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
+builder.Services.AddProblemDetails();
+
 builder.Services.AddEndpointsApiExplorer();
 
 var enableSwagger = builder.Configuration.GetValue<bool>("Features:EnableSwagger");
@@ -47,6 +51,7 @@ if (enableSwagger)
     app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "Herit API v1"));
 }
 
+app.UseExceptionHandler();
 app.UseHttpsRedirection();
 app.MapControllers();
 

--- a/src/Herit.Application/Herit.Application.csproj
+++ b/src/Herit.Application/Herit.Application.csproj
@@ -5,6 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="MediatR" Version="14.1.0" />
   </ItemGroup>
 

--- a/tests/Herit.Api.Tests/Herit.Api.Tests.csproj
+++ b/tests/Herit.Api.Tests/Herit.Api.Tests.csproj
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="FluentValidation" Version="12.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/tests/Herit.Api.Tests/Middleware/GlobalExceptionHandlerTests.cs
+++ b/tests/Herit.Api.Tests/Middleware/GlobalExceptionHandlerTests.cs
@@ -1,0 +1,86 @@
+using System.Net;
+using System.Text.Json;
+using FluentValidation;
+using FluentValidation.Results;
+using Herit.Api.Middleware;
+using Herit.Application.Exceptions;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Herit.Api.Tests.Middleware;
+
+public class GlobalExceptionHandlerTests
+{
+    private readonly GlobalExceptionHandler _handler = new(NullLogger<GlobalExceptionHandler>.Instance);
+
+    private static HttpContext CreateHttpContext()
+    {
+        var context = new DefaultHttpContext();
+        context.Response.Body = new MemoryStream();
+        return context;
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_NotFoundException_Returns404()
+    {
+        var context = CreateHttpContext();
+        var exception = new NotFoundException("Resource not found");
+
+        var handled = await _handler.TryHandleAsync(context, exception, CancellationToken.None);
+
+        Assert.True(handled);
+        Assert.Equal((int)HttpStatusCode.NotFound, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_InvalidOperationException_Returns400()
+    {
+        var context = CreateHttpContext();
+        var exception = new InvalidOperationException("Bad request");
+
+        var handled = await _handler.TryHandleAsync(context, exception, CancellationToken.None);
+
+        Assert.True(handled);
+        Assert.Equal((int)HttpStatusCode.BadRequest, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_ValidationException_Returns422WithErrors()
+    {
+        var context = CreateHttpContext();
+        var failures = new[]
+        {
+            new ValidationFailure("Name", "Name is required"),
+            new ValidationFailure("Email", "Email is invalid")
+        };
+        var exception = new ValidationException(failures);
+
+        var handled = await _handler.TryHandleAsync(context, exception, CancellationToken.None);
+
+        Assert.True(handled);
+        Assert.Equal((int)HttpStatusCode.UnprocessableEntity, context.Response.StatusCode);
+
+        context.Response.Body.Seek(0, SeekOrigin.Begin);
+        var body = await new StreamReader(context.Response.Body).ReadToEndAsync();
+        Assert.Contains("errors", body);
+        Assert.Contains("Name is required", body);
+        Assert.Contains("Email is invalid", body);
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_UnhandledException_Returns500WithoutDetails()
+    {
+        var context = CreateHttpContext();
+        var exception = new Exception("Sensitive internal error");
+
+        var handled = await _handler.TryHandleAsync(context, exception, CancellationToken.None);
+
+        Assert.True(handled);
+        Assert.Equal((int)HttpStatusCode.InternalServerError, context.Response.StatusCode);
+
+        context.Response.Body.Seek(0, SeekOrigin.Begin);
+        var body = await new StreamReader(context.Response.Body).ReadToEndAsync();
+        Assert.DoesNotContain("Sensitive internal error", body);
+    }
+}


### PR DESCRIPTION
## Description

Adds `GlobalExceptionHandler` middleware implementing `IExceptionHandler` to map exceptions to structured `ProblemDetails` HTTP responses, ensuring consistent error handling across the API.

## Linked Issue

Closes #126

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Unit tests added in `Herit.Api.Tests/Middleware/GlobalExceptionHandlerTests.cs` covering all four exception mappings:
- `NotFoundException` → 404
- `InvalidOperationException` → 400
- `ValidationException` → 422 with error details in extensions
- Unhandled exceptions → 500 (verifies sensitive details are not exposed)

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)