### PR TITLE
Add FluentValidation pipeline behaviour and validators for all commands

### DIFF
--- a/src/Herit.Api/Program.cs
+++ b/src/Herit.Api/Program.cs
@@ -1,8 +1,11 @@
 using Azure.Identity;
+using FluentValidation;
 using Herit.Api.Middleware;
+using Herit.Application.Behaviours;
 using Herit.Application.Features.Rfp.Commands.CreateRfp;
 using Herit.Infrastructure;
 using Herit.Infrastructure.Persistence;
+using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi.Models;
 
@@ -16,6 +19,9 @@ builder.Services.AddControllers();
 
 builder.Services.AddMediatR(cfg =>
     cfg.RegisterServicesFromAssembly(typeof(CreateRfpCommand).Assembly));
+
+builder.Services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehaviour<,>));
+builder.Services.AddValidatorsFromAssembly(typeof(CreateRfpCommand).Assembly);
 
 var connectionStringKey = builder.Configuration["AZURE_SQL_CONNECTION_STRING_KEY"];
 var connectionString = (!string.IsNullOrEmpty(connectionStringKey)

--- a/src/Herit.Application/Behaviours/ValidationBehaviour.cs
+++ b/src/Herit.Application/Behaviours/ValidationBehaviour.cs
@@ -1,0 +1,33 @@
+using FluentValidation;
+using MediatR;
+
+namespace Herit.Application.Behaviours;
+
+public class ValidationBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull
+{
+    private readonly IEnumerable<IValidator<TRequest>> _validators;
+
+    public ValidationBehaviour(IEnumerable<IValidator<TRequest>> validators)
+    {
+        _validators = validators;
+    }
+
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    {
+        if (!_validators.Any())
+            return await next(cancellationToken);
+
+        var context = new ValidationContext<TRequest>(request);
+        var failures = _validators
+            .Select(v => v.Validate(context))
+            .SelectMany(r => r.Errors)
+            .Where(f => f is not null)
+            .ToList();
+
+        if (failures.Count != 0)
+            throw new ValidationException(failures);
+
+        return await next(cancellationToken);
+    }
+}

--- a/src/Herit.Application/Features/Cfeoi/Commands/PublishCfeoi/PublishCfeoiCommandValidator.cs
+++ b/src/Herit.Application/Features/Cfeoi/Commands/PublishCfeoi/PublishCfeoiCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace Herit.Application.Features.Cfeoi.Commands.PublishCfeoi;
+
+public class PublishCfeoiCommandValidator : AbstractValidator<PublishCfeoiCommand>
+{
+    public PublishCfeoiCommandValidator()
+    {
+        RuleFor(x => x.Title).NotEmpty().MaximumLength(256);
+        RuleFor(x => x.Description).NotEmpty();
+        RuleFor(x => x.ProposalId).NotEqual(Guid.Empty);
+    }
+}

--- a/src/Herit.Application/Features/Eoi/Commands/SubmitEoi/SubmitEoiCommandValidator.cs
+++ b/src/Herit.Application/Features/Eoi/Commands/SubmitEoi/SubmitEoiCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace Herit.Application.Features.Eoi.Commands.SubmitEoi;
+
+public class SubmitEoiCommandValidator : AbstractValidator<SubmitEoiCommand>
+{
+    public SubmitEoiCommandValidator()
+    {
+        RuleFor(x => x.SubmittedById).NotEqual(Guid.Empty);
+        RuleFor(x => x.Message).NotEmpty();
+        RuleFor(x => x.CfeoiId).NotEqual(Guid.Empty);
+    }
+}

--- a/src/Herit.Application/Features/Organisation/Commands/CreateOrganisation/CreateOrganisationCommandValidator.cs
+++ b/src/Herit.Application/Features/Organisation/Commands/CreateOrganisation/CreateOrganisationCommandValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace Herit.Application.Features.Organisation.Commands.CreateOrganisation;
+
+public class CreateOrganisationCommandValidator : AbstractValidator<CreateOrganisationCommand>
+{
+    public CreateOrganisationCommandValidator()
+    {
+        RuleFor(x => x.Name).NotEmpty().MaximumLength(256);
+        RuleFor(x => x.ParentId).NotEqual(Guid.Empty).When(x => x.ParentId.HasValue);
+    }
+}

--- a/src/Herit.Application/Features/Organisation/Commands/UpdateOrganisation/UpdateOrganisationCommandValidator.cs
+++ b/src/Herit.Application/Features/Organisation/Commands/UpdateOrganisation/UpdateOrganisationCommandValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace Herit.Application.Features.Organisation.Commands.UpdateOrganisation;
+
+public class UpdateOrganisationCommandValidator : AbstractValidator<UpdateOrganisationCommand>
+{
+    public UpdateOrganisationCommandValidator()
+    {
+        RuleFor(x => x.Id).NotEqual(Guid.Empty);
+        RuleFor(x => x.Name).NotEmpty().MaximumLength(256);
+    }
+}

--- a/src/Herit.Application/Features/Proposal/Commands/CreateProposal/CreateProposalCommandValidator.cs
+++ b/src/Herit.Application/Features/Proposal/Commands/CreateProposal/CreateProposalCommandValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+
+namespace Herit.Application.Features.Proposal.Commands.CreateProposal;
+
+public class CreateProposalCommandValidator : AbstractValidator<CreateProposalCommand>
+{
+    public CreateProposalCommandValidator()
+    {
+        RuleFor(x => x.Title).NotEmpty().MaximumLength(256);
+        RuleFor(x => x.ShortDescription).NotEmpty().MaximumLength(512);
+        RuleFor(x => x.LongDescription).NotEmpty();
+        RuleFor(x => x.AuthorId).NotEqual(Guid.Empty);
+        RuleFor(x => x.OrganisationId).NotEqual(Guid.Empty);
+        RuleFor(x => x.RfpId).NotEqual(Guid.Empty).When(x => x.RfpId.HasValue);
+    }
+}

--- a/src/Herit.Application/Features/Proposal/Commands/UpdateProposal/UpdateProposalCommandValidator.cs
+++ b/src/Herit.Application/Features/Proposal/Commands/UpdateProposal/UpdateProposalCommandValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+
+namespace Herit.Application.Features.Proposal.Commands.UpdateProposal;
+
+public class UpdateProposalCommandValidator : AbstractValidator<UpdateProposalCommand>
+{
+    public UpdateProposalCommandValidator()
+    {
+        RuleFor(x => x.Id).NotEqual(Guid.Empty);
+        RuleFor(x => x.Title).NotEmpty().MaximumLength(256);
+        RuleFor(x => x.ShortDescription).NotEmpty().MaximumLength(512);
+        RuleFor(x => x.LongDescription).NotEmpty();
+    }
+}

--- a/src/Herit.Application/Features/Rfp/Commands/CreateRfp/CreateRfpCommandValidator.cs
+++ b/src/Herit.Application/Features/Rfp/Commands/CreateRfp/CreateRfpCommandValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+
+namespace Herit.Application.Features.Rfp.Commands.CreateRfp;
+
+public class CreateRfpCommandValidator : AbstractValidator<CreateRfpCommand>
+{
+    public CreateRfpCommandValidator()
+    {
+        RuleFor(x => x.Title).NotEmpty().MaximumLength(256);
+        RuleFor(x => x.ShortDescription).NotEmpty().MaximumLength(512);
+        RuleFor(x => x.LongDescription).NotEmpty();
+        RuleFor(x => x.AuthorId).NotEqual(Guid.Empty);
+        RuleFor(x => x.OrganisationId).NotEqual(Guid.Empty);
+    }
+}

--- a/src/Herit.Application/Features/Rfp/Commands/UpdateRfp/UpdateRfpCommandValidator.cs
+++ b/src/Herit.Application/Features/Rfp/Commands/UpdateRfp/UpdateRfpCommandValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+
+namespace Herit.Application.Features.Rfp.Commands.UpdateRfp;
+
+public class UpdateRfpCommandValidator : AbstractValidator<UpdateRfpCommand>
+{
+    public UpdateRfpCommandValidator()
+    {
+        RuleFor(x => x.Id).NotEqual(Guid.Empty);
+        RuleFor(x => x.Title).NotEmpty().MaximumLength(256);
+        RuleFor(x => x.ShortDescription).NotEmpty().MaximumLength(512);
+        RuleFor(x => x.LongDescription).NotEmpty();
+    }
+}

--- a/src/Herit.Application/Features/User/Commands/CreateOrganisationAdmin/CreateOrganisationAdminCommandValidator.cs
+++ b/src/Herit.Application/Features/User/Commands/CreateOrganisationAdmin/CreateOrganisationAdminCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace Herit.Application.Features.User.Commands.CreateOrganisationAdmin;
+
+public class CreateOrganisationAdminCommandValidator : AbstractValidator<CreateOrganisationAdminCommand>
+{
+    public CreateOrganisationAdminCommandValidator()
+    {
+        RuleFor(x => x.Email).NotEmpty().MaximumLength(256);
+        RuleFor(x => x.FullName).NotEmpty().MaximumLength(256);
+        RuleFor(x => x.OrganisationId).NotEqual(Guid.Empty);
+    }
+}

--- a/src/Herit.Application/Features/User/Commands/CreateStaffUser/CreateStaffUserCommandValidator.cs
+++ b/src/Herit.Application/Features/User/Commands/CreateStaffUser/CreateStaffUserCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace Herit.Application.Features.User.Commands.CreateStaffUser;
+
+public class CreateStaffUserCommandValidator : AbstractValidator<CreateStaffUserCommand>
+{
+    public CreateStaffUserCommandValidator()
+    {
+        RuleFor(x => x.Email).NotEmpty().MaximumLength(256);
+        RuleFor(x => x.FullName).NotEmpty().MaximumLength(256);
+        RuleFor(x => x.OrganisationId).NotEqual(Guid.Empty);
+    }
+}

--- a/src/Herit.Application/Features/User/Commands/RegisterExpat/RegisterExpatCommandValidator.cs
+++ b/src/Herit.Application/Features/User/Commands/RegisterExpat/RegisterExpatCommandValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace Herit.Application.Features.User.Commands.RegisterExpat;
+
+public class RegisterExpatCommandValidator : AbstractValidator<RegisterExpatCommand>
+{
+    public RegisterExpatCommandValidator()
+    {
+        RuleFor(x => x.Email).NotEmpty().MaximumLength(256);
+        RuleFor(x => x.FullName).NotEmpty().MaximumLength(256);
+    }
+}

--- a/src/Herit.Application/Features/User/Commands/UpdateStaffUser/UpdateStaffUserCommandValidator.cs
+++ b/src/Herit.Application/Features/User/Commands/UpdateStaffUser/UpdateStaffUserCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace Herit.Application.Features.User.Commands.UpdateStaffUser;
+
+public class UpdateStaffUserCommandValidator : AbstractValidator<UpdateStaffUserCommand>
+{
+    public UpdateStaffUserCommandValidator()
+    {
+        RuleFor(x => x.Id).NotEqual(Guid.Empty);
+        RuleFor(x => x.Email).NotEmpty().MaximumLength(256);
+        RuleFor(x => x.FullName).NotEmpty().MaximumLength(256);
+    }
+}

--- a/src/Herit.Application/Herit.Application.csproj
+++ b/src/Herit.Application/Herit.Application.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="12.1.1" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageReference Include="MediatR" Version="14.1.0" />
   </ItemGroup>
 

--- a/tests/Herit.Application.Tests/Behaviours/ValidationBehaviourTests.cs
+++ b/tests/Herit.Application.Tests/Behaviours/ValidationBehaviourTests.cs
@@ -1,0 +1,79 @@
+using FluentValidation;
+using Herit.Application.Behaviours;
+using MediatR;
+using NSubstitute;
+
+namespace Herit.Application.Tests.Behaviours;
+
+public class ValidationBehaviourTests
+{
+    public record TestRequest(string Value) : IRequest<string>;
+
+    private class AlwaysValidValidator : AbstractValidator<TestRequest>
+    {
+        public AlwaysValidValidator()
+        {
+            RuleFor(x => x.Value).NotEmpty();
+        }
+    }
+
+    private class AlwaysInvalidValidator : AbstractValidator<TestRequest>
+    {
+        public AlwaysInvalidValidator()
+        {
+            RuleFor(x => x.Value).Must(_ => false).WithMessage("Always fails.");
+        }
+    }
+
+    [Fact]
+    public async Task Handle_NoValidators_CallsNext()
+    {
+        var behaviour = new ValidationBehaviour<TestRequest, string>([]);
+        var next = Substitute.For<RequestHandlerDelegate<string>>();
+        next(Arg.Any<CancellationToken>()).Returns("result");
+
+        var result = await behaviour.Handle(new TestRequest("value"), next, CancellationToken.None);
+
+        Assert.Equal("result", result);
+        await next.Received(1)(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ValidationPasses_CallsNext()
+    {
+        var behaviour = new ValidationBehaviour<TestRequest, string>([new AlwaysValidValidator()]);
+        var next = Substitute.For<RequestHandlerDelegate<string>>();
+        next(Arg.Any<CancellationToken>()).Returns("result");
+
+        var result = await behaviour.Handle(new TestRequest("value"), next, CancellationToken.None);
+
+        Assert.Equal("result", result);
+        await next.Received(1)(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ValidationFails_ThrowsValidationException()
+    {
+        var behaviour = new ValidationBehaviour<TestRequest, string>([new AlwaysInvalidValidator()]);
+        var next = Substitute.For<RequestHandlerDelegate<string>>();
+
+        await Assert.ThrowsAsync<ValidationException>(() =>
+            behaviour.Handle(new TestRequest("value"), next, CancellationToken.None));
+
+        await next.DidNotReceive()(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_MultipleValidators_AggregatesFailures()
+    {
+        var behaviour = new ValidationBehaviour<TestRequest, string>(
+            [new AlwaysInvalidValidator(), new AlwaysInvalidValidator()]);
+        var next = Substitute.For<RequestHandlerDelegate<string>>();
+
+        var ex = await Assert.ThrowsAsync<ValidationException>(() =>
+            behaviour.Handle(new TestRequest("value"), next, CancellationToken.None));
+
+        Assert.True(ex.Errors.Count() >= 2);
+        await next.DidNotReceive()(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Herit.Application.Tests/Herit.Application.Tests.csproj
+++ b/tests/Herit.Application.Tests/Herit.Application.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
## Description

Implements a MediatR `ValidationBehaviour<TRequest, TResponse>` pipeline behaviour that auto-runs FluentValidation validators before handlers execute, throwing `ValidationException` on any failures. Adds `IValidator<T>` classes alongside all 12 commands with the string length and Guid constraints defined in the architecture.

## Linked Issue

Closes #127

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- `ValidationBehaviourTests` covers: no validators (pass-through), validation passes (calls next), validation fails (throws `ValidationException`), multiple validators (aggregates all failures).
- All 190 existing tests continue to pass.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)