### PR TITLE
Add LoggingBehaviour MediatR pipeline behaviour

### DIFF
--- a/src/Herit.Api/Program.cs
+++ b/src/Herit.Api/Program.cs
@@ -20,6 +20,7 @@ builder.Services.AddControllers();
 builder.Services.AddMediatR(cfg =>
     cfg.RegisterServicesFromAssembly(typeof(CreateRfpCommand).Assembly));
 
+builder.Services.AddTransient(typeof(IPipelineBehavior<,>), typeof(LoggingBehaviour<,>));
 builder.Services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehaviour<,>));
 builder.Services.AddValidatorsFromAssembly(typeof(CreateRfpCommand).Assembly);
 

--- a/src/Herit.Application/Behaviours/LoggingBehaviour.cs
+++ b/src/Herit.Application/Behaviours/LoggingBehaviour.cs
@@ -1,0 +1,43 @@
+using System.Diagnostics;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Herit.Application.Behaviours;
+
+public class LoggingBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull
+{
+    private readonly ILogger<LoggingBehaviour<TRequest, TResponse>> _logger;
+
+    public LoggingBehaviour(ILogger<LoggingBehaviour<TRequest, TResponse>> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    {
+        var requestName = typeof(TRequest).Name;
+
+        _logger.LogDebug("Handling {RequestName}", requestName);
+
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            var response = await next(cancellationToken);
+            stopwatch.Stop();
+
+            _logger.LogDebug("Handled {RequestName} in {ElapsedMilliseconds}ms", requestName, stopwatch.ElapsedMilliseconds);
+
+            return response;
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+
+            _logger.LogError(ex, "Error handling {RequestName} after {ElapsedMilliseconds}ms", requestName, stopwatch.ElapsedMilliseconds);
+
+            throw;
+        }
+    }
+}

--- a/tests/Herit.Application.Tests/Behaviours/LoggingBehaviourTests.cs
+++ b/tests/Herit.Application.Tests/Behaviours/LoggingBehaviourTests.cs
@@ -1,0 +1,57 @@
+using Herit.Application.Behaviours;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Herit.Application.Tests.Behaviours;
+
+public class LoggingBehaviourTests
+{
+    public record TestRequest(string Value) : IRequest<string>;
+
+    [Fact]
+    public async Task Handle_Success_LogsDebugBeforeAndAfter()
+    {
+        var logger = Substitute.For<ILogger<LoggingBehaviour<TestRequest, string>>>();
+        var behaviour = new LoggingBehaviour<TestRequest, string>(logger);
+        var next = Substitute.For<RequestHandlerDelegate<string>>();
+        next(Arg.Any<CancellationToken>()).Returns("result");
+
+        var result = await behaviour.Handle(new TestRequest("value"), next, CancellationToken.None);
+
+        Assert.Equal("result", result);
+        logger.Received(2).Log(
+            LogLevel.Debug,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public async Task Handle_Exception_LogsErrorAndRethrows()
+    {
+        var logger = Substitute.For<ILogger<LoggingBehaviour<TestRequest, string>>>();
+        var behaviour = new LoggingBehaviour<TestRequest, string>(logger);
+        var next = Substitute.For<RequestHandlerDelegate<string>>();
+        var exception = new InvalidOperationException("boom");
+        next(Arg.Any<CancellationToken>()).Returns<string>(_ => throw exception);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            behaviour.Handle(new TestRequest("value"), next, CancellationToken.None));
+
+        logger.Received(1).Log(
+            LogLevel.Debug,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+
+        logger.Received(1).Log(
+            LogLevel.Error,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            exception,
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+}


### PR DESCRIPTION
## Description

Adds `LoggingBehaviour<TRequest, TResponse>` as a MediatR pipeline behaviour that logs each request at Debug level before and after handling (with elapsed time), and at Error level with exception details if the handler throws. The behaviour is registered before `ValidationBehaviour` so all requests — including those that fail validation — are logged.

## Linked Issue

Closes #128

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Two new unit tests in `LoggingBehaviourTests.cs` verify:
- Debug logs are emitted before and after successful handling
- Error log (with exception) is emitted and the exception is rethrown on failure

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)