### PR TITLE
Add global CFEOI listing endpoint

### DIFF
--- a/src/Herit.Api/Controllers/CfeoiController.cs
+++ b/src/Herit.Api/Controllers/CfeoiController.cs
@@ -1,7 +1,8 @@
 using Herit.Application.Features.Cfeoi.Commands.PublishCfeoi;
 using Herit.Application.Features.Cfeoi.Commands.UpdateCfeoiStatus;
 using Herit.Application.Features.Cfeoi.Queries.GetCfeoiById;
-using Herit.Application.Features.Cfeoi.Queries.ListCfeoisByProposal;
+using Herit.Application.Features.Cfeoi.Queries.ListCfeois;
+using Herit.Domain.Enums;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
@@ -16,8 +17,8 @@ public class CfeoiController : ControllerBase
     public CfeoiController(IMediator mediator) => _mediator = mediator;
 
     [HttpGet]
-    public async Task<IActionResult> ListByProposal([FromQuery] Guid proposalId, CancellationToken ct)
-        => Ok(await _mediator.Send(new ListCfeoisByProposalQuery(proposalId), ct));
+    public async Task<IActionResult> List([FromQuery] CfeoiStatus? status, [FromQuery] Guid? proposalId, CancellationToken ct)
+        => Ok(await _mediator.Send(new ListCfeoisQuery(status, proposalId), ct));
 
     [HttpGet("{id:guid}")]
     public async Task<IActionResult> GetById(Guid id, CancellationToken ct)

--- a/src/Herit.Application/Features/Cfeoi/Queries/ListCfeois/ListCfeoisQuery.cs
+++ b/src/Herit.Application/Features/Cfeoi/Queries/ListCfeois/ListCfeoisQuery.cs
@@ -1,0 +1,20 @@
+using Herit.Application.Interfaces;
+using Herit.Domain.Enums;
+using MediatR;
+
+namespace Herit.Application.Features.Cfeoi.Queries.ListCfeois;
+
+public record ListCfeoisQuery(CfeoiStatus? Status = null, Guid? ProposalId = null) : IRequest<IEnumerable<Herit.Domain.Entities.Cfeoi>>;
+
+public class ListCfeoisQueryHandler : IRequestHandler<ListCfeoisQuery, IEnumerable<Herit.Domain.Entities.Cfeoi>>
+{
+    private readonly ICfeoiRepository _cfeoiRepository;
+
+    public ListCfeoisQueryHandler(ICfeoiRepository cfeoiRepository)
+    {
+        _cfeoiRepository = cfeoiRepository;
+    }
+
+    public Task<IEnumerable<Herit.Domain.Entities.Cfeoi>> Handle(ListCfeoisQuery request, CancellationToken cancellationToken)
+        => _cfeoiRepository.ListAsync(request.Status, request.ProposalId, cancellationToken);
+}

--- a/src/Herit.Application/Interfaces/ICfeoiRepository.cs
+++ b/src/Herit.Application/Interfaces/ICfeoiRepository.cs
@@ -1,10 +1,12 @@
 using Herit.Domain.Entities;
+using Herit.Domain.Enums;
 
 namespace Herit.Application.Interfaces;
 
 public interface ICfeoiRepository
 {
     Task<Cfeoi?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<IEnumerable<Cfeoi>> ListAsync(CfeoiStatus? status = null, Guid? proposalId = null, CancellationToken cancellationToken = default);
     Task<IEnumerable<Cfeoi>> ListByProposalAsync(Guid proposalId, CancellationToken cancellationToken = default);
     Task AddAsync(Cfeoi cfeoi, CancellationToken cancellationToken = default);
     Task UpdateAsync(Cfeoi cfeoi, CancellationToken cancellationToken = default);

--- a/src/Herit.Infrastructure/Repositories/CfeoiRepository.cs
+++ b/src/Herit.Infrastructure/Repositories/CfeoiRepository.cs
@@ -1,5 +1,6 @@
 using Herit.Application.Interfaces;
 using Herit.Domain.Entities;
+using Herit.Domain.Enums;
 using Herit.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 
@@ -16,6 +17,16 @@ public class CfeoiRepository : ICfeoiRepository
 
     public Task<Cfeoi?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
         => _context.Cfeois.FindAsync([id], cancellationToken).AsTask();
+
+    public async Task<IEnumerable<Cfeoi>> ListAsync(CfeoiStatus? status = null, Guid? proposalId = null, CancellationToken cancellationToken = default)
+    {
+        var query = _context.Cfeois.AsQueryable();
+        if (status is not null)
+            query = query.Where(c => c.Status == status);
+        if (proposalId is not null)
+            query = query.Where(c => c.ProposalId == proposalId);
+        return await query.ToListAsync(cancellationToken);
+    }
 
     public async Task<IEnumerable<Cfeoi>> ListByProposalAsync(Guid proposalId, CancellationToken cancellationToken = default)
         => await _context.Cfeois

--- a/tests/Herit.Application.Tests/Features/Cfeoi/Queries/ListCfeois/ListCfeoisQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Cfeoi/Queries/ListCfeois/ListCfeoisQueryHandlerTests.cs
@@ -1,0 +1,77 @@
+using Herit.Application.Features.Cfeoi.Queries.ListCfeois;
+using Herit.Application.Interfaces;
+using Herit.Domain.Enums;
+using NSubstitute;
+using CfeoiEntity = Herit.Domain.Entities.Cfeoi;
+
+namespace Herit.Application.Tests.Features.Cfeoi.Queries.ListCfeois;
+
+public class ListCfeoisQueryHandlerTests
+{
+    private readonly ICfeoiRepository _cfeoiRepository = Substitute.For<ICfeoiRepository>();
+    private readonly ListCfeoisQueryHandler _handler;
+
+    public ListCfeoisQueryHandlerTests()
+    {
+        _handler = new ListCfeoisQueryHandler(_cfeoiRepository);
+    }
+
+    [Fact]
+    public async Task Handle_NoFilters_ReturnsAllCfeois()
+    {
+        var cfeois = new[]
+        {
+            CfeoiEntity.Create(Guid.NewGuid(), "Title 1", "Description 1", CfeoiResourceType.Human, Guid.NewGuid()),
+            CfeoiEntity.Create(Guid.NewGuid(), "Title 2", "Description 2", CfeoiResourceType.NonHuman, Guid.NewGuid()),
+            CfeoiEntity.Create(Guid.NewGuid(), "Title 3", "Description 3", CfeoiResourceType.Human, Guid.NewGuid())
+        };
+        _cfeoiRepository.ListAsync(null, null, Arg.Any<CancellationToken>()).Returns(cfeois);
+
+        var result = await _handler.Handle(new ListCfeoisQuery(), CancellationToken.None);
+
+        Assert.Equal(3, result.Count());
+    }
+
+    [Fact]
+    public async Task Handle_FilterByStatus_PassesStatusToRepository()
+    {
+        var proposalId = Guid.NewGuid();
+        var cfeois = new[]
+        {
+            CfeoiEntity.Create(Guid.NewGuid(), "Open CFEOI", "Description", CfeoiResourceType.Human, proposalId)
+        };
+        _cfeoiRepository.ListAsync(CfeoiStatus.Open, null, Arg.Any<CancellationToken>()).Returns(cfeois);
+
+        var result = await _handler.Handle(new ListCfeoisQuery(Status: CfeoiStatus.Open), CancellationToken.None);
+
+        Assert.Single(result);
+        await _cfeoiRepository.Received(1).ListAsync(CfeoiStatus.Open, null, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_FilterByProposalId_PassesProposalIdToRepository()
+    {
+        var proposalId = Guid.NewGuid();
+        var cfeois = new[]
+        {
+            CfeoiEntity.Create(Guid.NewGuid(), "Title A", "Description", CfeoiResourceType.Human, proposalId),
+            CfeoiEntity.Create(Guid.NewGuid(), "Title B", "Description", CfeoiResourceType.NonHuman, proposalId)
+        };
+        _cfeoiRepository.ListAsync(null, proposalId, Arg.Any<CancellationToken>()).Returns(cfeois);
+
+        var result = await _handler.Handle(new ListCfeoisQuery(ProposalId: proposalId), CancellationToken.None);
+
+        Assert.Equal(2, result.Count());
+        await _cfeoiRepository.Received(1).ListAsync(null, proposalId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_EmptyList_ReturnsEmptyEnumerable()
+    {
+        _cfeoiRepository.ListAsync(null, null, Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<CfeoiEntity>());
+
+        var result = await _handler.Handle(new ListCfeoisQuery(), CancellationToken.None);
+
+        Assert.Empty(result);
+    }
+}

--- a/tests/Herit.Infrastructure.Tests/Repositories/CfeoiRepositoryTests.cs
+++ b/tests/Herit.Infrastructure.Tests/Repositories/CfeoiRepositoryTests.cs
@@ -103,4 +103,54 @@ public class CfeoiRepositoryTests : IDisposable
         Assert.NotNull(persisted);
         Assert.Equal(CfeoiStatus.Closed, persisted.Status);
     }
+
+    [Fact]
+    public async Task ListAsync_NoFilters_ReturnsAllCfeois()
+    {
+        await _repository.AddAsync(CreateCfeoi(title: "CFEOI 1"));
+        await _repository.AddAsync(CreateCfeoi(title: "CFEOI 2"));
+        await _repository.AddAsync(CreateCfeoi(title: "CFEOI 3"));
+
+        var result = await _repository.ListAsync();
+
+        Assert.Equal(3, result.Count());
+    }
+
+    [Fact]
+    public async Task ListAsync_FilterByStatus_ReturnsOnlyMatchingCfeois()
+    {
+        var open = CreateCfeoi(title: "Open CFEOI");
+        var closed = CreateCfeoi(title: "Closed CFEOI");
+        await _repository.AddAsync(open);
+        await _repository.AddAsync(closed);
+        closed.TransitionStatus(CfeoiStatus.Closed);
+        await _repository.UpdateAsync(closed);
+
+        var result = await _repository.ListAsync(status: CfeoiStatus.Open);
+
+        Assert.Single(result);
+        Assert.All(result, c => Assert.Equal(CfeoiStatus.Open, c.Status));
+    }
+
+    [Fact]
+    public async Task ListAsync_FilterByProposalId_ReturnsOnlyMatchingCfeois()
+    {
+        var proposalId = Guid.NewGuid();
+        await _repository.AddAsync(CreateCfeoi(proposalId: proposalId, title: "Match 1"));
+        await _repository.AddAsync(CreateCfeoi(proposalId: proposalId, title: "Match 2"));
+        await _repository.AddAsync(CreateCfeoi(title: "Other"));
+
+        var result = await _repository.ListAsync(proposalId: proposalId);
+
+        Assert.Equal(2, result.Count());
+        Assert.All(result, c => Assert.Equal(proposalId, c.ProposalId));
+    }
+
+    [Fact]
+    public async Task ListAsync_WhenEmpty_ReturnsEmptyCollection()
+    {
+        var result = await _repository.ListAsync();
+
+        Assert.Empty(result);
+    }
 }


### PR DESCRIPTION
## Description

Adds a global `GET /api/v1/Cfeoi` endpoint that returns all CFEOIs without requiring a proposal ID. Accepts optional `status` and `proposalId` query parameters to filter results. The existing behaviour of passing `proposalId` is preserved through the same unified endpoint.

## Linked Issue

Closes #134

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- Unit tests added for `ListCfeoisQueryHandler` covering: no filters, filter by status, filter by proposalId, empty result.
- Integration tests added for `CfeoiRepository.ListAsync` covering: no filters (returns all), filter by status, filter by proposalId, empty database.
- All 204 tests pass.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)