### PR TITLE
Add user-scoped My EOIs listing endpoint

### DIFF
--- a/src/Herit.Api/Controllers/EoiController.cs
+++ b/src/Herit.Api/Controllers/EoiController.cs
@@ -5,6 +5,8 @@ using Herit.Application.Features.Eoi.Commands.UpdateEoiStatus;
 using Herit.Application.Features.Eoi.Commands.WithdrawEoi;
 using Herit.Application.Features.Eoi.Queries.GetEoiById;
 using Herit.Application.Features.Eoi.Queries.ListEoisByCfeoi;
+using Herit.Application.Features.Eoi.Queries.ListEoisByUser;
+using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
@@ -16,12 +18,24 @@ namespace Herit.Api.Controllers;
 public class EoiController : ControllerBase
 {
     private readonly IMediator _mediator;
+    private readonly ICurrentUserService _currentUserService;
 
-    public EoiController(IMediator mediator) => _mediator = mediator;
+    public EoiController(IMediator mediator, ICurrentUserService currentUserService)
+    {
+        _mediator = mediator;
+        _currentUserService = currentUserService;
+    }
 
     [HttpGet]
     public async Task<IActionResult> ListByCfeoi([FromQuery] Guid cfeoiId, CancellationToken ct)
         => Ok(await _mediator.Send(new ListEoisByCfeoiQuery(cfeoiId), ct));
+
+    [HttpGet("my")]
+    public async Task<IActionResult> ListMyEois(CancellationToken ct)
+    {
+        var userId = _currentUserService.GetCurrentUserId();
+        return Ok(await _mediator.Send(new ListEoisByUserQuery(userId), ct));
+    }
 
     [HttpGet("{id:guid}")]
     public async Task<IActionResult> GetById(Guid id, CancellationToken ct)

--- a/src/Herit.Api/Program.cs
+++ b/src/Herit.Api/Program.cs
@@ -1,8 +1,10 @@
 using Azure.Identity;
 using FluentValidation;
 using Herit.Api.Middleware;
+using Herit.Api.Services;
 using Herit.Application.Behaviours;
 using Herit.Application.Features.Rfp.Commands.CreateRfp;
+using Herit.Application.Interfaces;
 using Herit.Infrastructure;
 using Herit.Infrastructure.Persistence;
 using MediatR;
@@ -31,6 +33,9 @@ var connectionString = (!string.IsNullOrEmpty(connectionStringKey)
     ?? builder.Configuration.GetConnectionString("DefaultConnection")!;
 
 builder.Services.AddInfrastructure(connectionString);
+
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddScoped<ICurrentUserService, CurrentUserService>();
 
 builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
 builder.Services.AddProblemDetails();

--- a/src/Herit.Api/Services/CurrentUserService.cs
+++ b/src/Herit.Api/Services/CurrentUserService.cs
@@ -1,0 +1,24 @@
+using Herit.Application.Interfaces;
+
+namespace Herit.Api.Services;
+
+public class CurrentUserService : ICurrentUserService
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public CurrentUserService(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public Guid GetCurrentUserId()
+    {
+        var nameIdentifier = _httpContextAccessor.HttpContext?.User.FindFirst(
+            System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+
+        if (nameIdentifier is null || !Guid.TryParse(nameIdentifier, out var userId))
+            throw new UnauthorizedAccessException("Current user identity could not be determined.");
+
+        return userId;
+    }
+}

--- a/src/Herit.Application/Features/Eoi/Queries/ListEoisByUser/ListEoisByUserQuery.cs
+++ b/src/Herit.Application/Features/Eoi/Queries/ListEoisByUser/ListEoisByUserQuery.cs
@@ -1,0 +1,19 @@
+using Herit.Application.Interfaces;
+using MediatR;
+
+namespace Herit.Application.Features.Eoi.Queries.ListEoisByUser;
+
+public record ListEoisByUserQuery(Guid UserId) : IRequest<IEnumerable<Herit.Domain.Entities.Eoi>>;
+
+public class ListEoisByUserQueryHandler : IRequestHandler<ListEoisByUserQuery, IEnumerable<Herit.Domain.Entities.Eoi>>
+{
+    private readonly IEoiRepository _eoiRepository;
+
+    public ListEoisByUserQueryHandler(IEoiRepository eoiRepository)
+    {
+        _eoiRepository = eoiRepository;
+    }
+
+    public Task<IEnumerable<Herit.Domain.Entities.Eoi>> Handle(ListEoisByUserQuery request, CancellationToken cancellationToken)
+        => _eoiRepository.ListByUserAsync(request.UserId, cancellationToken);
+}

--- a/src/Herit.Application/Interfaces/ICurrentUserService.cs
+++ b/src/Herit.Application/Interfaces/ICurrentUserService.cs
@@ -1,0 +1,6 @@
+namespace Herit.Application.Interfaces;
+
+public interface ICurrentUserService
+{
+    Guid GetCurrentUserId();
+}

--- a/src/Herit.Application/Interfaces/IEoiRepository.cs
+++ b/src/Herit.Application/Interfaces/IEoiRepository.cs
@@ -7,6 +7,7 @@ public interface IEoiRepository
     Task<Eoi?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
     Task<IEnumerable<Eoi>> ListByCfeoiAsync(Guid cfeoiId, CancellationToken cancellationToken = default);
     Task<IEnumerable<Eoi>> ListByProposalAsync(Guid proposalId, CancellationToken cancellationToken = default);
+    Task<IEnumerable<Eoi>> ListByUserAsync(Guid userId, CancellationToken cancellationToken = default);
     Task AddAsync(Eoi eoi, CancellationToken cancellationToken = default);
     Task UpdateAsync(Eoi eoi, CancellationToken cancellationToken = default);
     Task DeleteAsync(Guid id, CancellationToken cancellationToken = default);

--- a/src/Herit.Infrastructure/Repositories/EoiRepository.cs
+++ b/src/Herit.Infrastructure/Repositories/EoiRepository.cs
@@ -30,6 +30,11 @@ public class EoiRepository : IEoiRepository
             .Select(x => x.Eoi)
             .ToListAsync(cancellationToken);
 
+    public async Task<IEnumerable<Eoi>> ListByUserAsync(Guid userId, CancellationToken cancellationToken = default)
+        => await _context.Eois
+            .Where(e => e.SubmittedById == userId)
+            .ToListAsync(cancellationToken);
+
     public async Task AddAsync(Eoi eoi, CancellationToken cancellationToken = default)
     {
         await _context.Eois.AddAsync(eoi, cancellationToken);

--- a/tests/Herit.Api.Tests/Controllers/EoiControllerTests.cs
+++ b/tests/Herit.Api.Tests/Controllers/EoiControllerTests.cs
@@ -1,0 +1,56 @@
+using Herit.Api.Controllers;
+using Herit.Application.Features.Eoi.Queries.ListEoisByUser;
+using Herit.Application.Interfaces;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using EoiEntity = Herit.Domain.Entities.Eoi;
+
+namespace Herit.Api.Tests.Controllers;
+
+public class EoiControllerTests
+{
+    private readonly IMediator _mediator = Substitute.For<IMediator>();
+    private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
+    private readonly EoiController _controller;
+
+    public EoiControllerTests()
+    {
+        _controller = new EoiController(_mediator, _currentUserService);
+    }
+
+    [Fact]
+    public async Task ListMyEois_ReturnsOkWithEois()
+    {
+        var userId = Guid.NewGuid();
+        var eois = new[]
+        {
+            EoiEntity.Create(Guid.NewGuid(), userId, "Message 1", Guid.NewGuid()),
+            EoiEntity.Create(Guid.NewGuid(), userId, "Message 2", Guid.NewGuid())
+        };
+        _currentUserService.GetCurrentUserId().Returns(userId);
+        _mediator.Send(Arg.Any<ListEoisByUserQuery>(), Arg.Any<CancellationToken>())
+            .Returns((IEnumerable<EoiEntity>)eois);
+
+        var result = await _controller.ListMyEois(CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var returned = Assert.IsAssignableFrom<IEnumerable<EoiEntity>>(ok.Value);
+        Assert.Equal(2, returned.Count());
+    }
+
+    [Fact]
+    public async Task ListMyEois_SendsQueryWithCurrentUserId()
+    {
+        var userId = Guid.NewGuid();
+        _currentUserService.GetCurrentUserId().Returns(userId);
+        _mediator.Send(Arg.Any<ListEoisByUserQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Enumerable.Empty<EoiEntity>());
+
+        await _controller.ListMyEois(CancellationToken.None);
+
+        await _mediator.Received(1).Send(
+            Arg.Is<ListEoisByUserQuery>(q => q.UserId == userId),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Herit.Api.Tests/Herit.Api.Tests.csproj
+++ b/tests/Herit.Api.Tests/Herit.Api.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/tests/Herit.Application.Tests/Features/Eoi/Queries/ListEoisByUserQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Eoi/Queries/ListEoisByUserQueryHandlerTests.cs
@@ -1,0 +1,44 @@
+using Herit.Application.Features.Eoi.Queries.ListEoisByUser;
+using Herit.Application.Interfaces;
+using NSubstitute;
+using EoiEntity = Herit.Domain.Entities.Eoi;
+
+namespace Herit.Application.Tests.Features.Eoi.Queries;
+
+public class ListEoisByUserQueryHandlerTests
+{
+    private readonly IEoiRepository _eoiRepository = Substitute.For<IEoiRepository>();
+    private readonly ListEoisByUserQueryHandler _handler;
+
+    public ListEoisByUserQueryHandlerTests()
+    {
+        _handler = new ListEoisByUserQueryHandler(_eoiRepository);
+    }
+
+    [Fact]
+    public async Task Handle_NonEmptyList_ReturnsAllEoisForUser()
+    {
+        var userId = Guid.NewGuid();
+        var eois = new[]
+        {
+            EoiEntity.Create(Guid.NewGuid(), userId, "Message 1", Guid.NewGuid()),
+            EoiEntity.Create(Guid.NewGuid(), userId, "Message 2", Guid.NewGuid())
+        };
+        _eoiRepository.ListByUserAsync(userId, Arg.Any<CancellationToken>()).Returns(eois);
+
+        var result = await _handler.Handle(new ListEoisByUserQuery(userId), CancellationToken.None);
+
+        Assert.Equal(2, result.Count());
+    }
+
+    [Fact]
+    public async Task Handle_EmptyList_ReturnsEmptyEnumerable()
+    {
+        var userId = Guid.NewGuid();
+        _eoiRepository.ListByUserAsync(userId, Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<EoiEntity>());
+
+        var result = await _handler.Handle(new ListEoisByUserQuery(userId), CancellationToken.None);
+
+        Assert.Empty(result);
+    }
+}


### PR DESCRIPTION
## Description

Adds a `GET /api/v1/Eoi/my` endpoint so portal users can retrieve their own EOIs. The endpoint resolves the current user's identity from `ICurrentUserService` (backed by `ClaimsPrincipal`) rather than accepting a `userId` query parameter, ensuring users can only see their own EOIs.

## Linked Issue

Closes #135

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- Unit tests added for `ListEoisByUserQueryHandler` covering non-empty and empty list cases.
- Controller tests added for `EoiController.ListMyEois` verifying the correct `OkObjectResult` is returned and that the query is dispatched with the current user's ID.
- All 208 tests pass.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)