### PR TITLE
Add GetByExternalIdAsync to IUserRepository

### DIFF
--- a/src/Herit.Application/Interfaces/IUserRepository.cs
+++ b/src/Herit.Application/Interfaces/IUserRepository.cs
@@ -5,6 +5,7 @@ namespace Herit.Application.Interfaces;
 public interface IUserRepository
 {
     Task<User?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<User?> GetByExternalIdAsync(string externalId, CancellationToken cancellationToken = default);
     Task<IEnumerable<User>> ListAsync(CancellationToken cancellationToken = default);
     Task AddAsync(User user, CancellationToken cancellationToken = default);
     Task UpdateAsync(User user, CancellationToken cancellationToken = default);

--- a/src/Herit.Infrastructure/Repositories/UserRepository.cs
+++ b/src/Herit.Infrastructure/Repositories/UserRepository.cs
@@ -18,6 +18,9 @@ public class UserRepository : IUserRepository
     public Task<User?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
         => _context.Users.FindAsync([id], cancellationToken).AsTask();
 
+    public Task<User?> GetByExternalIdAsync(string externalId, CancellationToken cancellationToken = default)
+        => _context.Users.FirstOrDefaultAsync(u => u.ExternalId == externalId, cancellationToken);
+
     public async Task<IEnumerable<User>> ListAsync(CancellationToken cancellationToken = default)
         => await _context.Users.ToListAsync(cancellationToken);
 

--- a/tests/Herit.Infrastructure.Tests/Repositories/UserRepositoryTests.cs
+++ b/tests/Herit.Infrastructure.Tests/Repositories/UserRepositoryTests.cs
@@ -114,4 +114,26 @@ public class UserRepositoryTests : IDisposable
         await Assert.ThrowsAsync<NotFoundException>(
             () => _repository.DeleteAsync(Guid.NewGuid()));
     }
+
+    [Fact]
+    public async Task GetByExternalIdAsync_ReturnsUser_WhenExists()
+    {
+        var id = Guid.NewGuid();
+        var user = User.Create(id, "ext-carol", "carol@example.com", "Carol White", UserRole.Staff);
+        await _repository.AddAsync(user);
+
+        var result = await _repository.GetByExternalIdAsync("ext-carol");
+
+        Assert.NotNull(result);
+        Assert.Equal(id, result.Id);
+        Assert.Equal("ext-carol", result.ExternalId);
+    }
+
+    [Fact]
+    public async Task GetByExternalIdAsync_ReturnsNull_WhenNotExists()
+    {
+        var result = await _repository.GetByExternalIdAsync("no-such-external-id");
+
+        Assert.Null(result);
+    }
 }


### PR DESCRIPTION
## Description

Adds `GetByExternalIdAsync(string externalId, CancellationToken)` to `IUserRepository` and implements it in `UserRepository` using `FirstOrDefaultAsync` on the `ExternalId` column.

## Linked Issue

Closes #115

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Added two new tests to `UserRepositoryTests`:
- `GetByExternalIdAsync_ReturnsUser_WhenExists` — verifies the correct user is returned when the external ID matches.
- `GetByExternalIdAsync_ReturnsNull_WhenNotExists` — verifies `null` is returned for an unknown external ID.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)