### PR TITLE
Add IIdentityProviderService and B2cIdentityProviderService for B2C user management

### DIFF
--- a/src/Herit.Api/Herit.Api.csproj
+++ b/src/Herit.Api/Herit.Api.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.0" />
-    <PackageReference Include="Azure.Identity" Version="1.19.0" />
+    <PackageReference Include="Azure.Identity" Version="1.20.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Herit.Application/Interfaces/IIdentityProviderService.cs
+++ b/src/Herit.Application/Interfaces/IIdentityProviderService.cs
@@ -1,0 +1,10 @@
+namespace Herit.Application.Interfaces;
+
+public interface IIdentityProviderService
+{
+    /// <summary>Creates a B2C account and returns its object ID.</summary>
+    Task<string> CreateUserAsync(string email, string displayName, CancellationToken ct);
+
+    /// <summary>Deletes or disables the B2C account identified by <paramref name="externalId"/>.</summary>
+    Task DeleteUserAsync(string externalId, CancellationToken ct);
+}

--- a/src/Herit.Infrastructure/DependencyInjection.cs
+++ b/src/Herit.Infrastructure/DependencyInjection.cs
@@ -1,6 +1,7 @@
 using Herit.Application.Interfaces;
 using Herit.Infrastructure.Persistence;
 using Herit.Infrastructure.Repositories;
+using Herit.Infrastructure.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -19,6 +20,7 @@ public static class DependencyInjection
         services.AddScoped<ICfeoiRepository, CfeoiRepository>();
         services.AddScoped<IEoiRepository, EoiRepository>();
         services.AddScoped<IOrganisationRepository, OrganisationRepository>();
+        services.AddScoped<IIdentityProviderService, B2cIdentityProviderService>();
 
         return services;
     }

--- a/src/Herit.Infrastructure/Herit.Infrastructure.csproj
+++ b/src/Herit.Infrastructure/Herit.Infrastructure.csproj
@@ -5,8 +5,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.20.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Graph" Version="5.103.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Herit.Infrastructure/Services/B2cIdentityProviderService.cs
+++ b/src/Herit.Infrastructure/Services/B2cIdentityProviderService.cs
@@ -1,0 +1,63 @@
+using Azure.Identity;
+using Herit.Application.Interfaces;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Graph;
+using Microsoft.Graph.Models;
+
+namespace Herit.Infrastructure.Services;
+
+public class B2cIdentityProviderService : IIdentityProviderService
+{
+    private readonly GraphServiceClient _graphClient;
+    private readonly string _b2cExtensionAppId;
+
+    public B2cIdentityProviderService(IConfiguration configuration)
+    {
+        var tenantId = configuration["AzureAdB2C:TenantId"]
+            ?? throw new InvalidOperationException("AzureAdB2C:TenantId is not configured.");
+        var clientId = configuration["AzureAdB2C:ClientId"]
+            ?? throw new InvalidOperationException("AzureAdB2C:ClientId is not configured.");
+        var clientSecret = configuration["AzureAdB2C:ClientSecret"]
+            ?? throw new InvalidOperationException("AzureAdB2C:ClientSecret is not configured.");
+        _b2cExtensionAppId = configuration["AzureAdB2C:ExtensionAppId"]
+            ?? throw new InvalidOperationException("AzureAdB2C:ExtensionAppId is not configured.");
+
+        var credential = new ClientSecretCredential(tenantId, clientId, clientSecret);
+        _graphClient = new GraphServiceClient(credential);
+    }
+
+    public async Task<string> CreateUserAsync(string email, string displayName, CancellationToken ct)
+    {
+        var user = new User
+        {
+            AccountEnabled = true,
+            DisplayName = displayName,
+            Identities =
+            [
+                new ObjectIdentity
+                {
+                    SignInType = "emailAddress",
+                    Issuer = _b2cExtensionAppId,
+                    IssuerAssignedId = email,
+                }
+            ],
+            PasswordProfile = new PasswordProfile
+            {
+                ForceChangePasswordNextSignIn = true,
+                Password = Guid.NewGuid().ToString("N") + "Aa1!",
+            },
+            PasswordPolicies = "DisablePasswordExpiration",
+        };
+
+        var created = await _graphClient.Users.PostAsync(user, cancellationToken: ct)
+            ?? throw new InvalidOperationException("Graph API returned null when creating user.");
+
+        return created.Id
+            ?? throw new InvalidOperationException("Graph API did not return an object ID for the created user.");
+    }
+
+    public async Task DeleteUserAsync(string externalId, CancellationToken ct)
+    {
+        await _graphClient.Users[externalId].DeleteAsync(cancellationToken: ct);
+    }
+}


### PR DESCRIPTION
## Description

Introduces `IIdentityProviderService` as an abstraction for Azure AD B2C user management, and implements it with `B2cIdentityProviderService` using the Microsoft Graph SDK with client-credentials flow.

- `IIdentityProviderService` (in `Herit.Application/Interfaces/`) defines `CreateUserAsync` and `DeleteUserAsync`.
- `B2cIdentityProviderService` (in `Herit.Infrastructure/Services/`) reads tenant ID, client ID, client secret, and extension app ID from `IConfiguration` under the `AzureAdB2C` section, authenticates via `ClientSecretCredential`, and calls the Microsoft Graph Users API.
- Both `Microsoft.Graph` and `Azure.Identity` NuGet packages added to `Herit.Infrastructure`.
- `Azure.Identity` version bumped in `Herit.Api` to align with the transitive dependency.
- Registered as a scoped service in `DependencyInjection.cs`.

## Linked Issue

Closes #116

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Build and all existing tests (225 total) pass. The service integrates with Azure AD B2C at runtime; no live B2C tenant tests are included in this PR.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)