### PR TITLE
Configure JWT Bearer authentication for Azure AD B2C

### DIFF
--- a/src/Herit.Api/Herit.Api.csproj
+++ b/src/Herit.Api/Herit.Api.csproj
@@ -14,6 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Identity.Web" Version="4.7.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/src/Herit.Api/Program.cs
+++ b/src/Herit.Api/Program.cs
@@ -9,6 +9,7 @@ using Herit.Infrastructure;
 using Herit.Infrastructure.Persistence;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Identity.Web;
 using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -16,6 +17,8 @@ var builder = WebApplication.CreateBuilder(args);
 var keyVaultEndpoint = builder.Configuration["AZURE_KEY_VAULT_ENDPOINT"];
 if (!string.IsNullOrEmpty(keyVaultEndpoint) && !builder.Environment.IsDevelopment())
     builder.Configuration.AddAzureKeyVault(new Uri(keyVaultEndpoint), new DefaultAzureCredential());
+
+builder.Services.AddMicrosoftIdentityWebApiAuthentication(builder.Configuration, "AzureAdB2C");
 
 builder.Services.AddControllers();
 
@@ -65,6 +68,8 @@ if (enableSwagger)
 
 app.UseExceptionHandler();
 app.UseHttpsRedirection();
+app.UseAuthentication();
+app.UseAuthorization();
 app.MapControllers();
 
 app.Run();

--- a/src/Herit.Api/appsettings.json
+++ b/src/Herit.Api/appsettings.json
@@ -8,5 +8,19 @@
   "Features": {
     "EnableSwagger": false
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  // Azure AD B2C JWT authentication settings.
+  // Required keys:
+  //   Instance      – B2C authority base URL, e.g. https://<tenant>.b2clogin.com
+  //   Domain        – B2C tenant domain, e.g. <tenant>.onmicrosoft.com
+  //   TenantId      – Azure AD tenant ID (GUID or "common")
+  //   ClientId      – Application (client) ID of the API registration in Azure AD B2C
+  //   SignUpSignInPolicyId – Name of the B2C user-flow used for sign-up/sign-in, e.g. B2C_1_SignUpSignIn
+  "AzureAdB2C": {
+    "Instance": "https://<your-tenant>.b2clogin.com",
+    "Domain": "<your-tenant>.onmicrosoft.com",
+    "TenantId": "<your-tenant-id>",
+    "ClientId": "<your-client-id>",
+    "SignUpSignInPolicyId": "B2C_1_SignUpSignIn"
+  }
 }


### PR DESCRIPTION
## Description

Adds JWT Bearer authentication configured for Azure AD B2C to the `Herit.Api` project. Uses `Microsoft.Identity.Web` to simplify the B2C-specific JWT configuration. Authentication and authorization middleware are wired into the pipeline in the correct order before `MapControllers()`.

## Linked Issue

Closes #117

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- Build passes cleanly with `dotnet build --configuration Release`
- All 225 existing tests pass with `dotnet test --configuration Release --no-build`
- No new tests required — this is infrastructure wiring; auth behaviour is validated at runtime with real B2C tokens

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)