### PR TITLE
Implement ICurrentUserService with async user resolution and first-login registration

### DIFF
--- a/src/Herit.Api/Controllers/EoiController.cs
+++ b/src/Herit.Api/Controllers/EoiController.cs
@@ -33,8 +33,8 @@ public class EoiController : ControllerBase
     [HttpGet("my")]
     public async Task<IActionResult> ListMyEois(CancellationToken ct)
     {
-        var userId = _currentUserService.GetCurrentUserId();
-        return Ok(await _mediator.Send(new ListEoisByUserQuery(userId), ct));
+        var user = await _currentUserService.GetCurrentUserAsync(ct);
+        return Ok(await _mediator.Send(new ListEoisByUserQuery(user.Id), ct));
     }
 
     [HttpGet("{id:guid}")]

--- a/src/Herit.Api/Services/CurrentUserService.cs
+++ b/src/Herit.Api/Services/CurrentUserService.cs
@@ -1,24 +1,63 @@
+using Herit.Application.Features.User.Commands.RegisterExpat;
 using Herit.Application.Interfaces;
+using Herit.Domain.Entities;
+using MediatR;
 
 namespace Herit.Api.Services;
 
 public class CurrentUserService : ICurrentUserService
 {
     private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IUserRepository _userRepository;
+    private readonly IMediator _mediator;
+    private User? _cachedUser;
 
-    public CurrentUserService(IHttpContextAccessor httpContextAccessor)
+    public CurrentUserService(
+        IHttpContextAccessor httpContextAccessor,
+        IUserRepository userRepository,
+        IMediator mediator)
     {
         _httpContextAccessor = httpContextAccessor;
+        _userRepository = userRepository;
+        _mediator = mediator;
     }
 
-    public Guid GetCurrentUserId()
+    public async Task<User> GetCurrentUserAsync(CancellationToken ct = default)
     {
-        var nameIdentifier = _httpContextAccessor.HttpContext?.User.FindFirst(
-            System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+        if (_cachedUser is not null)
+            return _cachedUser;
 
-        if (nameIdentifier is null || !Guid.TryParse(nameIdentifier, out var userId))
-            throw new UnauthorizedAccessException("Current user identity could not be determined.");
+        var claimsPrincipal = _httpContextAccessor.HttpContext?.User
+            ?? throw new UnauthorizedAccessException("No HTTP context available.");
 
-        return userId;
+        var externalId =
+            claimsPrincipal.FindFirst("oid")?.Value
+            ?? claimsPrincipal.FindFirst("http://schemas.microsoft.com/identity/claims/objectidentifier")?.Value
+            ?? claimsPrincipal.FindFirst("sub")?.Value
+            ?? throw new UnauthorizedAccessException("B2C subject claim could not be determined.");
+
+        var user = await _userRepository.GetByExternalIdAsync(externalId, ct);
+
+        if (user is null)
+        {
+            var email =
+                claimsPrincipal.FindFirst("emails")?.Value
+                ?? claimsPrincipal.FindFirst("email")?.Value
+                ?? claimsPrincipal.FindFirst(System.Security.Claims.ClaimTypes.Email)?.Value
+                ?? string.Empty;
+
+            var fullName =
+                claimsPrincipal.FindFirst("name")?.Value
+                ?? claimsPrincipal.FindFirst(System.Security.Claims.ClaimTypes.Name)?.Value
+                ?? string.Empty;
+
+            await _mediator.Send(new RegisterExpatCommand(externalId, email, fullName), ct);
+
+            user = await _userRepository.GetByExternalIdAsync(externalId, ct)
+                ?? throw new InvalidOperationException("User could not be created.");
+        }
+
+        _cachedUser = user;
+        return _cachedUser;
     }
 }

--- a/src/Herit.Application/Interfaces/ICurrentUserService.cs
+++ b/src/Herit.Application/Interfaces/ICurrentUserService.cs
@@ -1,6 +1,8 @@
+using Herit.Domain.Entities;
+
 namespace Herit.Application.Interfaces;
 
 public interface ICurrentUserService
 {
-    Guid GetCurrentUserId();
+    Task<User> GetCurrentUserAsync(CancellationToken ct = default);
 }

--- a/tests/Herit.Api.Tests/Controllers/EoiControllerTests.cs
+++ b/tests/Herit.Api.Tests/Controllers/EoiControllerTests.cs
@@ -1,6 +1,8 @@
 using Herit.Api.Controllers;
 using Herit.Application.Features.Eoi.Queries.ListEoisByUser;
 using Herit.Application.Interfaces;
+using Herit.Domain.Entities;
+using Herit.Domain.Enums;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using NSubstitute;
@@ -23,12 +25,13 @@ public class EoiControllerTests
     public async Task ListMyEois_ReturnsOkWithEois()
     {
         var userId = Guid.NewGuid();
+        var user = User.Create(userId, "ext-123", "test@example.com", "Test User", UserRole.Expat);
         var eois = new[]
         {
             EoiEntity.Create(Guid.NewGuid(), userId, "Message 1", Guid.NewGuid()),
             EoiEntity.Create(Guid.NewGuid(), userId, "Message 2", Guid.NewGuid())
         };
-        _currentUserService.GetCurrentUserId().Returns(userId);
+        _currentUserService.GetCurrentUserAsync(Arg.Any<CancellationToken>()).Returns(user);
         _mediator.Send(Arg.Any<ListEoisByUserQuery>(), Arg.Any<CancellationToken>())
             .Returns((IEnumerable<EoiEntity>)eois);
 
@@ -43,7 +46,8 @@ public class EoiControllerTests
     public async Task ListMyEois_SendsQueryWithCurrentUserId()
     {
         var userId = Guid.NewGuid();
-        _currentUserService.GetCurrentUserId().Returns(userId);
+        var user = User.Create(userId, "ext-123", "test@example.com", "Test User", UserRole.Expat);
+        _currentUserService.GetCurrentUserAsync(Arg.Any<CancellationToken>()).Returns(user);
         _mediator.Send(Arg.Any<ListEoisByUserQuery>(), Arg.Any<CancellationToken>())
             .Returns(Enumerable.Empty<EoiEntity>());
 


### PR DESCRIPTION
## Description

Replaces the synchronous `GetCurrentUserId()` stub on `ICurrentUserService` with `Task<User> GetCurrentUserAsync(CancellationToken ct)`. The new implementation:

- Extracts the B2C subject claim (`oid` / `sub`) from `IHttpContextAccessor`
- Calls `IUserRepository.GetByExternalIdAsync` to resolve the user record
- On first login (no record found), dispatches `RegisterExpatCommand` via `IMediator` to auto-create the expat record, then re-fetches it
- Caches the resolved `User` instance for the lifetime of the request via a private backing field

`IHttpContextAccessor` and `ICurrentUserService` registrations were already present in `Program.cs`; no DI changes needed.

`EoiController.ListMyEois` updated to `await GetCurrentUserAsync(ct)` and use `user.Id`.

## Linked Issue

Closes #118

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- Updated `EoiControllerTests` to mock `GetCurrentUserAsync` with a `User` object
- All 225 tests pass (`dotnet test`)

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/current-user-service`)