### PR TITLE
Make RegisterExpatCommand idempotent and remove public register endpoint

### DIFF
--- a/src/Herit.Api/Controllers/UsersController.cs
+++ b/src/Herit.Api/Controllers/UsersController.cs
@@ -1,6 +1,5 @@
 using Herit.Application.Features.User.Commands.CreateOrganisationAdmin;
 using Herit.Application.Features.User.Commands.CreateStaffUser;
-using Herit.Application.Features.User.Commands.RegisterExpat;
 using Herit.Application.Features.User.Commands.DeleteStaffUser;
 using Herit.Application.Features.User.Commands.DeleteOrganisationAdmin;
 using Herit.Application.Features.User.Commands.UpdateStaffUser;
@@ -70,10 +69,4 @@ public class UsersController : ControllerBase
         return NoContent();
     }
 
-    [HttpPost("register")]
-    public async Task<IActionResult> Register([FromBody] RegisterExpatCommand command, CancellationToken ct)
-    {
-        var id = await _mediator.Send(command, ct);
-        return CreatedAtAction(nameof(GetById), new { id }, id);
-    }
 }

--- a/src/Herit.Application/Features/User/Commands/RegisterExpat/RegisterExpatCommand.cs
+++ b/src/Herit.Application/Features/User/Commands/RegisterExpat/RegisterExpatCommand.cs
@@ -25,6 +25,10 @@ public class RegisterExpatCommandHandler : IRequestHandler<RegisterExpatCommand,
 
     public async Task<Guid> Handle(RegisterExpatCommand request, CancellationToken cancellationToken)
     {
+        var existing = await _userRepository.GetByExternalIdAsync(request.ExternalId, cancellationToken);
+        if (existing is not null)
+            return existing.Id;
+
         var user = UserEntity.Create(
             Guid.NewGuid(),
             request.ExternalId,

--- a/src/Herit.Application/Features/User/Commands/RegisterExpat/RegisterExpatCommandValidator.cs
+++ b/src/Herit.Application/Features/User/Commands/RegisterExpat/RegisterExpatCommandValidator.cs
@@ -6,6 +6,7 @@ public class RegisterExpatCommandValidator : AbstractValidator<RegisterExpatComm
 {
     public RegisterExpatCommandValidator()
     {
+        RuleFor(x => x.ExternalId).NotEmpty();
         RuleFor(x => x.Email).NotEmpty().MaximumLength(256);
         RuleFor(x => x.FullName).NotEmpty().MaximumLength(256);
     }

--- a/tests/Herit.Application.Tests/Features/User/Commands/RegisterExpatCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/User/Commands/RegisterExpatCommandHandlerTests.cs
@@ -17,8 +17,9 @@ public class RegisterExpatCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_ReturnsNonEmptyGuid()
+    public async Task Handle_ReturnsNonEmptyGuid_WhenUserDoesNotExist()
     {
+        _userRepository.GetByExternalIdAsync("ext-123", Arg.Any<CancellationToken>()).Returns((UserEntity?)null);
         var command = new RegisterExpatCommand("ext-123", "expat@example.com", "Jane Doe");
 
         var result = await _handler.Handle(command, CancellationToken.None);
@@ -27,8 +28,9 @@ public class RegisterExpatCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_CallsAddAsyncExactlyOnce()
+    public async Task Handle_CallsAddAsyncExactlyOnce_WhenUserDoesNotExist()
     {
+        _userRepository.GetByExternalIdAsync("ext-123", Arg.Any<CancellationToken>()).Returns((UserEntity?)null);
         var command = new RegisterExpatCommand("ext-123", "expat@example.com", "Jane Doe");
 
         await _handler.Handle(command, CancellationToken.None);
@@ -41,6 +43,7 @@ public class RegisterExpatCommandHandlerTests
     [Fact]
     public async Task Handle_CreatesUserWithExpatRoleAndNullOrganisationId()
     {
+        _userRepository.GetByExternalIdAsync("ext-123", Arg.Any<CancellationToken>()).Returns((UserEntity?)null);
         var command = new RegisterExpatCommand("ext-123", "expat@example.com", "Jane Doe");
         UserEntity? capturedUser = null;
 
@@ -58,6 +61,7 @@ public class RegisterExpatCommandHandlerTests
     [Fact]
     public async Task Handle_PersistsOptionalProfileFields()
     {
+        _userRepository.GetByExternalIdAsync("ext-123", Arg.Any<CancellationToken>()).Returns((UserEntity?)null);
         var termsAt = DateTimeOffset.UtcNow;
         var command = new RegisterExpatCommand(
             "ext-123", "expat@example.com", "Jane Doe",
@@ -78,5 +82,32 @@ public class RegisterExpatCommandHandlerTests
         Assert.Equal("Sydney, AU", capturedUser.Location);
         Assert.Equal("C#,Azure", capturedUser.ExpertiseTags);
         Assert.Equal(termsAt, capturedUser.TermsAcceptedAt);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsExistingId_WhenUserAlreadyExists()
+    {
+        var existingId = Guid.NewGuid();
+        var existingUser = UserEntity.Create(existingId, "ext-123", "expat@example.com", "Jane Doe", UserRole.Expat);
+        _userRepository.GetByExternalIdAsync("ext-123", Arg.Any<CancellationToken>()).Returns(existingUser);
+        var command = new RegisterExpatCommand("ext-123", "expat@example.com", "Jane Doe");
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.Equal(existingId, result);
+    }
+
+    [Fact]
+    public async Task Handle_DoesNotCallAddAsync_WhenUserAlreadyExists()
+    {
+        var existingUser = UserEntity.Create(Guid.NewGuid(), "ext-123", "expat@example.com", "Jane Doe", UserRole.Expat);
+        _userRepository.GetByExternalIdAsync("ext-123", Arg.Any<CancellationToken>()).Returns(existingUser);
+        var command = new RegisterExpatCommand("ext-123", "expat@example.com", "Jane Doe");
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        await _userRepository.DidNotReceive().AddAsync(
+            Arg.Any<UserEntity>(),
+            Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
## Description

Updates `RegisterExpatCommand` handler to be idempotent: before creating a new user it checks whether one with the given `ExternalId` already exists via `GetByExternalIdAsync`. If found, it returns the existing `Id` without inserting a duplicate. This is safe for the JIT provisioning flow in `ICurrentUserService` which may call the command on every first-login resolution.

Also removes the `POST api/v1/Users/register` endpoint from `UsersController` — expat registration is now an internal concern triggered implicitly on first login, not a publicly callable API.

Validator updated to require `ExternalId` (already present on the command record). Tests updated to set up the `GetByExternalIdAsync` stub and add two new cases for the idempotency path.

## Linked Issue

Closes #119

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- Existing handler tests updated to configure the `GetByExternalIdAsync` mock (returns `null` for the "new user" path).
- Two new tests: `Handle_ReturnsExistingId_WhenUserAlreadyExists` and `Handle_DoesNotCallAddAsync_WhenUserAlreadyExists`.
- All 227 tests pass (`dotnet test`).

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)