### PR TITLE
Provision B2C accounts in CreateOrganisationAdminCommand and CreateStaffUserCommand

### DIFF
--- a/src/Herit.Application/Features/User/Commands/CreateOrganisationAdmin/CreateOrganisationAdminCommand.cs
+++ b/src/Herit.Application/Features/User/Commands/CreateOrganisationAdmin/CreateOrganisationAdminCommand.cs
@@ -6,17 +6,19 @@ using UserEntity = Herit.Domain.Entities.User;
 
 namespace Herit.Application.Features.User.Commands.CreateOrganisationAdmin;
 
-public record CreateOrganisationAdminCommand(string ExternalId, string Email, string FullName, Guid OrganisationId) : IRequest<Guid>;
+public record CreateOrganisationAdminCommand(string Email, string FullName, Guid OrganisationId) : IRequest<Guid>;
 
 public class CreateOrganisationAdminCommandHandler : IRequestHandler<CreateOrganisationAdminCommand, Guid>
 {
     private readonly IUserRepository _userRepository;
     private readonly IOrganisationRepository _organisationRepository;
+    private readonly IIdentityProviderService _identityProviderService;
 
-    public CreateOrganisationAdminCommandHandler(IUserRepository userRepository, IOrganisationRepository organisationRepository)
+    public CreateOrganisationAdminCommandHandler(IUserRepository userRepository, IOrganisationRepository organisationRepository, IIdentityProviderService identityProviderService)
     {
         _userRepository = userRepository;
         _organisationRepository = organisationRepository;
+        _identityProviderService = identityProviderService;
     }
 
     public async Task<Guid> Handle(CreateOrganisationAdminCommand request, CancellationToken cancellationToken)
@@ -25,7 +27,9 @@ public class CreateOrganisationAdminCommandHandler : IRequestHandler<CreateOrgan
         if (organisation is null)
             throw new NotFoundException($"Organisation with ID '{request.OrganisationId}' was not found.");
 
-        var user = UserEntity.Create(Guid.NewGuid(), request.ExternalId, request.Email, request.FullName, UserRole.OrganisationAdmin, request.OrganisationId);
+        var externalId = await _identityProviderService.CreateUserAsync(request.Email, request.FullName, cancellationToken);
+
+        var user = UserEntity.Create(Guid.NewGuid(), externalId, request.Email, request.FullName, UserRole.OrganisationAdmin, request.OrganisationId);
 
         await _userRepository.AddAsync(user, cancellationToken);
 

--- a/src/Herit.Application/Features/User/Commands/CreateStaffUser/CreateStaffUserCommand.cs
+++ b/src/Herit.Application/Features/User/Commands/CreateStaffUser/CreateStaffUserCommand.cs
@@ -6,17 +6,19 @@ using UserEntity = Herit.Domain.Entities.User;
 
 namespace Herit.Application.Features.User.Commands.CreateStaffUser;
 
-public record CreateStaffUserCommand(string ExternalId, string Email, string FullName, Guid OrganisationId) : IRequest<Guid>;
+public record CreateStaffUserCommand(string Email, string FullName, Guid OrganisationId) : IRequest<Guid>;
 
 public class CreateStaffUserCommandHandler : IRequestHandler<CreateStaffUserCommand, Guid>
 {
     private readonly IUserRepository _userRepository;
     private readonly IOrganisationRepository _organisationRepository;
+    private readonly IIdentityProviderService _identityProviderService;
 
-    public CreateStaffUserCommandHandler(IUserRepository userRepository, IOrganisationRepository organisationRepository)
+    public CreateStaffUserCommandHandler(IUserRepository userRepository, IOrganisationRepository organisationRepository, IIdentityProviderService identityProviderService)
     {
         _userRepository = userRepository;
         _organisationRepository = organisationRepository;
+        _identityProviderService = identityProviderService;
     }
 
     public async Task<Guid> Handle(CreateStaffUserCommand request, CancellationToken cancellationToken)
@@ -25,7 +27,9 @@ public class CreateStaffUserCommandHandler : IRequestHandler<CreateStaffUserComm
         if (organisation is null)
             throw new NotFoundException($"Organisation with ID '{request.OrganisationId}' was not found.");
 
-        var user = UserEntity.Create(Guid.NewGuid(), request.ExternalId, request.Email, request.FullName, UserRole.Staff, request.OrganisationId);
+        var externalId = await _identityProviderService.CreateUserAsync(request.Email, request.FullName, cancellationToken);
+
+        var user = UserEntity.Create(Guid.NewGuid(), externalId, request.Email, request.FullName, UserRole.Staff, request.OrganisationId);
 
         await _userRepository.AddAsync(user, cancellationToken);
 

--- a/tests/Herit.Application.Tests/Features/User/Commands/CreateOrganisationAdminCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/User/Commands/CreateOrganisationAdminCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using Herit.Application.Exceptions;
 using Herit.Application.Features.User.Commands.CreateOrganisationAdmin;
 using Herit.Application.Interfaces;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using OrganisationEntity = Herit.Domain.Entities.Organisation;
 using UserEntity = Herit.Domain.Entities.User;
 
@@ -11,12 +12,13 @@ public class CreateOrganisationAdminCommandHandlerTests
 {
     private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
     private readonly IOrganisationRepository _organisationRepository = Substitute.For<IOrganisationRepository>();
+    private readonly IIdentityProviderService _identityProviderService = Substitute.For<IIdentityProviderService>();
 
     private readonly CreateOrganisationAdminCommandHandler _handler;
 
     public CreateOrganisationAdminCommandHandlerTests()
     {
-        _handler = new CreateOrganisationAdminCommandHandler(_userRepository, _organisationRepository);
+        _handler = new CreateOrganisationAdminCommandHandler(_userRepository, _organisationRepository, _identityProviderService);
     }
 
     [Fact]
@@ -25,8 +27,9 @@ public class CreateOrganisationAdminCommandHandlerTests
         var orgId = Guid.NewGuid();
         var organisation = OrganisationEntity.Create(orgId, "Test Organisation");
         _organisationRepository.GetByIdAsync(orgId, Arg.Any<CancellationToken>()).Returns(organisation);
+        _identityProviderService.CreateUserAsync("admin@gov.eg", "Organisation Admin", Arg.Any<CancellationToken>()).Returns("ext-admin-1");
 
-        var command = new CreateOrganisationAdminCommand("ext-admin-1", "admin@gov.eg", "Organisation Admin", orgId);
+        var command = new CreateOrganisationAdminCommand("admin@gov.eg", "Organisation Admin", orgId);
 
         var result = await _handler.Handle(command, CancellationToken.None);
 
@@ -39,8 +42,9 @@ public class CreateOrganisationAdminCommandHandlerTests
         var orgId = Guid.NewGuid();
         var organisation = OrganisationEntity.Create(orgId, "Test Organisation");
         _organisationRepository.GetByIdAsync(orgId, Arg.Any<CancellationToken>()).Returns(organisation);
+        _identityProviderService.CreateUserAsync("admin@gov.eg", "Organisation Admin", Arg.Any<CancellationToken>()).Returns("ext-admin-1");
 
-        var command = new CreateOrganisationAdminCommand("ext-admin-1", "admin@gov.eg", "Organisation Admin", orgId);
+        var command = new CreateOrganisationAdminCommand("admin@gov.eg", "Organisation Admin", orgId);
 
         await _handler.Handle(command, CancellationToken.None);
 
@@ -55,9 +59,24 @@ public class CreateOrganisationAdminCommandHandlerTests
         var orgId = Guid.NewGuid();
         _organisationRepository.GetByIdAsync(orgId, Arg.Any<CancellationToken>()).Returns((OrganisationEntity?)null);
 
-        var command = new CreateOrganisationAdminCommand("ext-admin-1", "admin@gov.eg", "Organisation Admin", orgId);
+        var command = new CreateOrganisationAdminCommand("admin@gov.eg", "Organisation Admin", orgId);
 
         await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
+        await _userRepository.DidNotReceive().AddAsync(Arg.Any<UserEntity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenB2cCreationThrows_DoesNotWriteToDatabase()
+    {
+        var orgId = Guid.NewGuid();
+        var organisation = OrganisationEntity.Create(orgId, "Test Organisation");
+        _organisationRepository.GetByIdAsync(orgId, Arg.Any<CancellationToken>()).Returns(organisation);
+        _identityProviderService.CreateUserAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("B2C provisioning failed"));
+
+        var command = new CreateOrganisationAdminCommand("admin@gov.eg", "Organisation Admin", orgId);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
         await _userRepository.DidNotReceive().AddAsync(Arg.Any<UserEntity>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Herit.Application.Tests/Features/User/Commands/CreateStaffUserCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/User/Commands/CreateStaffUserCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using Herit.Application.Exceptions;
 using Herit.Application.Features.User.Commands.CreateStaffUser;
 using Herit.Application.Interfaces;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using OrganisationEntity = Herit.Domain.Entities.Organisation;
 using UserEntity = Herit.Domain.Entities.User;
 
@@ -11,12 +12,13 @@ public class CreateStaffUserCommandHandlerTests
 {
     private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
     private readonly IOrganisationRepository _organisationRepository = Substitute.For<IOrganisationRepository>();
+    private readonly IIdentityProviderService _identityProviderService = Substitute.For<IIdentityProviderService>();
 
     private readonly CreateStaffUserCommandHandler _handler;
 
     public CreateStaffUserCommandHandlerTests()
     {
-        _handler = new CreateStaffUserCommandHandler(_userRepository, _organisationRepository);
+        _handler = new CreateStaffUserCommandHandler(_userRepository, _organisationRepository, _identityProviderService);
     }
 
     [Fact]
@@ -25,8 +27,9 @@ public class CreateStaffUserCommandHandlerTests
         var orgId = Guid.NewGuid();
         var organisation = OrganisationEntity.Create(orgId, "Test Organisation");
         _organisationRepository.GetByIdAsync(orgId, Arg.Any<CancellationToken>()).Returns(organisation);
+        _identityProviderService.CreateUserAsync("staff@gov.eg", "Staff Member", Arg.Any<CancellationToken>()).Returns("ext-staff-1");
 
-        var command = new CreateStaffUserCommand("ext-staff-1", "staff@gov.eg", "Staff Member", orgId);
+        var command = new CreateStaffUserCommand("staff@gov.eg", "Staff Member", orgId);
 
         var result = await _handler.Handle(command, CancellationToken.None);
 
@@ -39,8 +42,9 @@ public class CreateStaffUserCommandHandlerTests
         var orgId = Guid.NewGuid();
         var organisation = OrganisationEntity.Create(orgId, "Test Organisation");
         _organisationRepository.GetByIdAsync(orgId, Arg.Any<CancellationToken>()).Returns(organisation);
+        _identityProviderService.CreateUserAsync("staff@gov.eg", "Staff Member", Arg.Any<CancellationToken>()).Returns("ext-staff-1");
 
-        var command = new CreateStaffUserCommand("ext-staff-1", "staff@gov.eg", "Staff Member", orgId);
+        var command = new CreateStaffUserCommand("staff@gov.eg", "Staff Member", orgId);
 
         await _handler.Handle(command, CancellationToken.None);
 
@@ -55,9 +59,24 @@ public class CreateStaffUserCommandHandlerTests
         var orgId = Guid.NewGuid();
         _organisationRepository.GetByIdAsync(orgId, Arg.Any<CancellationToken>()).Returns((OrganisationEntity?)null);
 
-        var command = new CreateStaffUserCommand("ext-staff-1", "staff@gov.eg", "Staff Member", orgId);
+        var command = new CreateStaffUserCommand("staff@gov.eg", "Staff Member", orgId);
 
         await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
+        await _userRepository.DidNotReceive().AddAsync(Arg.Any<UserEntity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenB2cCreationThrows_DoesNotWriteToDatabase()
+    {
+        var orgId = Guid.NewGuid();
+        var organisation = OrganisationEntity.Create(orgId, "Test Organisation");
+        _organisationRepository.GetByIdAsync(orgId, Arg.Any<CancellationToken>()).Returns(organisation);
+        _identityProviderService.CreateUserAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("B2C provisioning failed"));
+
+        var command = new CreateStaffUserCommand("staff@gov.eg", "Staff Member", orgId);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
         await _userRepository.DidNotReceive().AddAsync(Arg.Any<UserEntity>(), Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
## Description

Both command handlers now inject `IIdentityProviderService` and call `CreateUserAsync` before writing to the database. The returned `ExternalId` is passed to `User.Create`. If B2C provisioning fails, the database write is never reached. `ExternalId` has been removed from both command records — it is no longer supplied by the caller.

## Linked Issue

Closes #120

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- Updated `CreateOrganisationAdminCommandHandlerTests` and `CreateStaffUserCommandHandlerTests` to mock `IIdentityProviderService`.
- Added happy-path tests verifying B2C is called and the external ID is used.
- Added failure-case tests verifying that a B2C exception prevents any `AddAsync` call.
- All 229 tests pass.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/b2c-provisioning-in-create-user-commands`)