### PR TITLE
Update delete commands to remove B2C accounts

### DIFF
--- a/src/Herit.Application/Features/User/Commands/DeleteOrganisationAdmin/DeleteOrganisationAdminCommand.cs
+++ b/src/Herit.Application/Features/User/Commands/DeleteOrganisationAdmin/DeleteOrganisationAdminCommand.cs
@@ -10,10 +10,12 @@ public record DeleteOrganisationAdminCommand(Guid Id) : IRequest<Unit>;
 public class DeleteOrganisationAdminCommandHandler : IRequestHandler<DeleteOrganisationAdminCommand, Unit>
 {
     private readonly IUserRepository _userRepository;
+    private readonly IIdentityProviderService _identityProviderService;
 
-    public DeleteOrganisationAdminCommandHandler(IUserRepository userRepository)
+    public DeleteOrganisationAdminCommandHandler(IUserRepository userRepository, IIdentityProviderService identityProviderService)
     {
         _userRepository = userRepository;
+        _identityProviderService = identityProviderService;
     }
 
     public async Task<Unit> Handle(DeleteOrganisationAdminCommand request, CancellationToken cancellationToken)
@@ -25,6 +27,7 @@ public class DeleteOrganisationAdminCommandHandler : IRequestHandler<DeleteOrgan
         if (user.Role != UserRole.OrganisationAdmin)
             throw new InvalidOperationException($"User with ID '{request.Id}' is not an OrganisationAdmin.");
 
+        await _identityProviderService.DeleteUserAsync(user.ExternalId, cancellationToken);
         await _userRepository.DeleteAsync(request.Id, cancellationToken);
 
         return Unit.Value;

--- a/src/Herit.Application/Features/User/Commands/DeleteStaffUser/DeleteStaffUserCommand.cs
+++ b/src/Herit.Application/Features/User/Commands/DeleteStaffUser/DeleteStaffUserCommand.cs
@@ -10,10 +10,12 @@ public record DeleteStaffUserCommand(Guid Id) : IRequest<Unit>;
 public class DeleteStaffUserCommandHandler : IRequestHandler<DeleteStaffUserCommand, Unit>
 {
     private readonly IUserRepository _userRepository;
+    private readonly IIdentityProviderService _identityProviderService;
 
-    public DeleteStaffUserCommandHandler(IUserRepository userRepository)
+    public DeleteStaffUserCommandHandler(IUserRepository userRepository, IIdentityProviderService identityProviderService)
     {
         _userRepository = userRepository;
+        _identityProviderService = identityProviderService;
     }
 
     public async Task<Unit> Handle(DeleteStaffUserCommand request, CancellationToken cancellationToken)
@@ -25,6 +27,7 @@ public class DeleteStaffUserCommandHandler : IRequestHandler<DeleteStaffUserComm
         if (user.Role != UserRole.Staff)
             throw new InvalidOperationException($"User with ID '{request.Id}' is not a Staff user.");
 
+        await _identityProviderService.DeleteUserAsync(user.ExternalId, cancellationToken);
         await _userRepository.DeleteAsync(request.Id, cancellationToken);
 
         return Unit.Value;

--- a/tests/Herit.Application.Tests/Features/User/Commands/DeleteOrganisationAdminCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/User/Commands/DeleteOrganisationAdminCommandHandlerTests.cs
@@ -3,6 +3,7 @@ using Herit.Application.Features.User.Commands.DeleteOrganisationAdmin;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using UserEntity = Herit.Domain.Entities.User;
 
 namespace Herit.Application.Tests.Features.User.Commands;
@@ -10,15 +11,16 @@ namespace Herit.Application.Tests.Features.User.Commands;
 public class DeleteOrganisationAdminCommandHandlerTests
 {
     private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly IIdentityProviderService _identityProviderService = Substitute.For<IIdentityProviderService>();
     private readonly DeleteOrganisationAdminCommandHandler _handler;
 
     public DeleteOrganisationAdminCommandHandlerTests()
     {
-        _handler = new DeleteOrganisationAdminCommandHandler(_userRepository);
+        _handler = new DeleteOrganisationAdminCommandHandler(_userRepository, _identityProviderService);
     }
 
     [Fact]
-    public async Task Handle_WithExistingOrganisationAdmin_CallsDeleteAsyncOnce()
+    public async Task Handle_WithExistingOrganisationAdmin_CallsDeleteB2cThenDeleteAsync()
     {
         var userId = Guid.NewGuid();
         var user = UserEntity.Create(userId, "ext-admin", "admin@gov.eg", "Org Admin", UserRole.OrganisationAdmin, Guid.NewGuid());
@@ -27,6 +29,7 @@ public class DeleteOrganisationAdminCommandHandlerTests
         var command = new DeleteOrganisationAdminCommand(userId);
         await _handler.Handle(command, CancellationToken.None);
 
+        await _identityProviderService.Received(1).DeleteUserAsync("ext-admin", Arg.Any<CancellationToken>());
         await _userRepository.Received(1).DeleteAsync(userId, Arg.Any<CancellationToken>());
     }
 
@@ -40,6 +43,7 @@ public class DeleteOrganisationAdminCommandHandlerTests
 
         await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _userRepository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        await _identityProviderService.DidNotReceive().DeleteUserAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -48,6 +52,22 @@ public class DeleteOrganisationAdminCommandHandlerTests
         var userId = Guid.NewGuid();
         var user = UserEntity.Create(userId, "ext-staff", "staff@gov.eg", "Staff User", UserRole.Staff, Guid.NewGuid());
         _userRepository.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+
+        var command = new DeleteOrganisationAdminCommand(userId);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await _userRepository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        await _identityProviderService.DidNotReceive().DeleteUserAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenB2cDeletionThrows_DoesNotDeleteFromDatabase()
+    {
+        var userId = Guid.NewGuid();
+        var user = UserEntity.Create(userId, "ext-admin", "admin@gov.eg", "Org Admin", UserRole.OrganisationAdmin, Guid.NewGuid());
+        _userRepository.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+        _identityProviderService.DeleteUserAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("B2C deletion failed"));
 
         var command = new DeleteOrganisationAdminCommand(userId);
 

--- a/tests/Herit.Application.Tests/Features/User/Commands/DeleteStaffUserCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/User/Commands/DeleteStaffUserCommandHandlerTests.cs
@@ -3,6 +3,7 @@ using Herit.Application.Features.User.Commands.DeleteStaffUser;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using UserEntity = Herit.Domain.Entities.User;
 
 namespace Herit.Application.Tests.Features.User.Commands;
@@ -10,15 +11,16 @@ namespace Herit.Application.Tests.Features.User.Commands;
 public class DeleteStaffUserCommandHandlerTests
 {
     private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly IIdentityProviderService _identityProviderService = Substitute.For<IIdentityProviderService>();
     private readonly DeleteStaffUserCommandHandler _handler;
 
     public DeleteStaffUserCommandHandlerTests()
     {
-        _handler = new DeleteStaffUserCommandHandler(_userRepository);
+        _handler = new DeleteStaffUserCommandHandler(_userRepository, _identityProviderService);
     }
 
     [Fact]
-    public async Task Handle_WithExistingStaffUser_CallsDeleteAsyncOnce()
+    public async Task Handle_WithExistingStaffUser_CallsDeleteB2cThenDeleteAsync()
     {
         var userId = Guid.NewGuid();
         var user = UserEntity.Create(userId, "ext-staff", "staff@gov.eg", "Staff User", UserRole.Staff, Guid.NewGuid());
@@ -27,6 +29,7 @@ public class DeleteStaffUserCommandHandlerTests
         var command = new DeleteStaffUserCommand(userId);
         await _handler.Handle(command, CancellationToken.None);
 
+        await _identityProviderService.Received(1).DeleteUserAsync("ext-staff", Arg.Any<CancellationToken>());
         await _userRepository.Received(1).DeleteAsync(userId, Arg.Any<CancellationToken>());
     }
 
@@ -40,6 +43,7 @@ public class DeleteStaffUserCommandHandlerTests
 
         await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _userRepository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        await _identityProviderService.DidNotReceive().DeleteUserAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -48,6 +52,22 @@ public class DeleteStaffUserCommandHandlerTests
         var userId = Guid.NewGuid();
         var user = UserEntity.Create(userId, "ext-admin", "admin@gov.eg", "Org Admin", UserRole.OrganisationAdmin, Guid.NewGuid());
         _userRepository.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+
+        var command = new DeleteStaffUserCommand(userId);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await _userRepository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        await _identityProviderService.DidNotReceive().DeleteUserAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenB2cDeletionThrows_DoesNotDeleteFromDatabase()
+    {
+        var userId = Guid.NewGuid();
+        var user = UserEntity.Create(userId, "ext-staff", "staff@gov.eg", "Staff User", UserRole.Staff, Guid.NewGuid());
+        _userRepository.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+        _identityProviderService.DeleteUserAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("B2C deletion failed"));
 
         var command = new DeleteStaffUserCommand(userId);
 


### PR DESCRIPTION
## Description

Injects `IIdentityProviderService` into `DeleteOrganisationAdminCommandHandler` and `DeleteStaffUserCommandHandler`. After confirming the user exists and has the correct role, `DeleteUserAsync` is called with the user's `ExternalId` before the database delete. If the B2C call throws, the database delete is not executed.

## Linked Issue

Closes #121

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Updated both test files to mock `IIdentityProviderService`. Each handler now has four tests: happy path (verifies B2C delete called before DB delete), not found, wrong role, and B2C failure (verifies DB delete is not called).

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)