### PR TITLE
Add [Authorize] and role-based policies to all controllers

### DIFF
--- a/src/Herit.Api/Authorization/RoleRequirement.cs
+++ b/src/Herit.Api/Authorization/RoleRequirement.cs
@@ -1,0 +1,9 @@
+using Herit.Domain.Enums;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Herit.Api.Authorization;
+
+public class RoleRequirement(params UserRole[] roles) : IAuthorizationRequirement
+{
+    public IReadOnlyList<UserRole> AllowedRoles { get; } = roles;
+}

--- a/src/Herit.Api/Authorization/RoleRequirementHandler.cs
+++ b/src/Herit.Api/Authorization/RoleRequirementHandler.cs
@@ -1,0 +1,30 @@
+using Herit.Application.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Herit.Api.Authorization;
+
+public class RoleRequirementHandler(ICurrentUserService currentUserService)
+    : AuthorizationHandler<RoleRequirement>
+{
+    protected override async Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        RoleRequirement requirement)
+    {
+        if (context.User.Identity?.IsAuthenticated != true)
+        {
+            context.Fail();
+            return;
+        }
+
+        try
+        {
+            var user = await currentUserService.GetCurrentUserAsync();
+            if (requirement.AllowedRoles.Contains(user.Role))
+                context.Succeed(requirement);
+        }
+        catch
+        {
+            context.Fail();
+        }
+    }
+}

--- a/src/Herit.Api/Controllers/CfeoiController.cs
+++ b/src/Herit.Api/Controllers/CfeoiController.cs
@@ -5,12 +5,14 @@ using Herit.Application.Features.Cfeoi.Queries.GetCfeoiById;
 using Herit.Application.Features.Cfeoi.Queries.ListCfeois;
 using Herit.Domain.Enums;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Herit.Api.Controllers;
 
 [ApiController]
 [Route("api/v1/[controller]")]
+[Authorize]
 public class CfeoiController : ControllerBase
 {
     private readonly IMediator _mediator;
@@ -26,6 +28,7 @@ public class CfeoiController : ControllerBase
         => Ok(await _mediator.Send(new GetCfeoiByIdQuery(id), ct));
 
     [HttpPost]
+    [Authorize(Policy = "StaffOrExpat")]
     public async Task<IActionResult> Publish([FromBody] PublishCfeoiCommand command, CancellationToken ct)
     {
         var id = await _mediator.Send(command, ct);
@@ -33,6 +36,7 @@ public class CfeoiController : ControllerBase
     }
 
     [HttpPut("{id:guid}")]
+    [Authorize(Policy = "StaffOrExpat")]
     public async Task<IActionResult> Update(Guid id, [FromBody] UpdateCfeoiCommand command, CancellationToken ct)
     {
         await _mediator.Send(command with { Id = id }, ct);
@@ -40,6 +44,7 @@ public class CfeoiController : ControllerBase
     }
 
     [HttpPatch("{id:guid}/status")]
+    [Authorize(Policy = "StaffOrExpat")]
     public async Task<IActionResult> UpdateStatus(Guid id, [FromBody] UpdateCfeoiStatusCommand command, CancellationToken ct)
     {
         await _mediator.Send(command with { Id = id }, ct);

--- a/src/Herit.Api/Controllers/EoiController.cs
+++ b/src/Herit.Api/Controllers/EoiController.cs
@@ -9,12 +9,14 @@ using Herit.Application.Features.Eoi.Queries.ListEoisByUser;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Herit.Api.Controllers;
 
 [ApiController]
 [Route("api/v1/[controller]")]
+[Authorize]
 public class EoiController : ControllerBase
 {
     private readonly IMediator _mediator;
@@ -27,10 +29,12 @@ public class EoiController : ControllerBase
     }
 
     [HttpGet]
+    [Authorize(Policy = "StaffOrExpat")]
     public async Task<IActionResult> ListByCfeoi([FromQuery] Guid cfeoiId, CancellationToken ct)
         => Ok(await _mediator.Send(new ListEoisByCfeoiQuery(cfeoiId), ct));
 
     [HttpGet("my")]
+    [Authorize(Policy = "Expat")]
     public async Task<IActionResult> ListMyEois(CancellationToken ct)
     {
         var user = await _currentUserService.GetCurrentUserAsync(ct);
@@ -42,13 +46,16 @@ public class EoiController : ControllerBase
         => Ok(await _mediator.Send(new GetEoiByIdQuery(id), ct));
 
     [HttpPost]
+    [Authorize(Policy = "Expat")]
     public async Task<IActionResult> Submit([FromBody] SubmitEoiCommand command, CancellationToken ct)
     {
-        var id = await _mediator.Send(command, ct);
+        var user = await _currentUserService.GetCurrentUserAsync(ct);
+        var id = await _mediator.Send(command with { SubmittedById = user.Id }, ct);
         return CreatedAtAction(nameof(GetById), new { id }, id);
     }
 
     [HttpDelete("{id:guid}")]
+    [Authorize(Policy = "Staff")]
     public async Task<IActionResult> Delete(Guid id, CancellationToken ct)
     {
         await _mediator.Send(new DeleteEoiCommand(id), ct);
@@ -56,6 +63,7 @@ public class EoiController : ControllerBase
     }
 
     [HttpPatch("{id:guid}/withdraw")]
+    [Authorize(Policy = "Expat")]
     public async Task<IActionResult> Withdraw(Guid id, CancellationToken ct)
     {
         await _mediator.Send(new WithdrawEoiCommand(id), ct);
@@ -63,6 +71,7 @@ public class EoiController : ControllerBase
     }
 
     [HttpPatch("{id:guid}/status")]
+    [Authorize(Policy = "Staff")]
     public async Task<IActionResult> UpdateStatus(Guid id, [FromBody] UpdateEoiStatusCommand command, CancellationToken ct)
     {
         await _mediator.Send(command with { Id = id }, ct);
@@ -70,6 +79,7 @@ public class EoiController : ControllerBase
     }
 
     [HttpPatch("{id:guid}/visibility")]
+    [Authorize(Policy = "Expat")]
     public async Task<IActionResult> SetVisibility(Guid id, [FromBody] EoiVisibility visibility, CancellationToken ct)
     {
         await _mediator.Send(new SetEoiVisibilityCommand(id, visibility), ct);

--- a/src/Herit.Api/Controllers/OrganisationController.cs
+++ b/src/Herit.Api/Controllers/OrganisationController.cs
@@ -4,12 +4,14 @@ using Herit.Application.Features.Organisation.Commands.UpdateOrganisation;
 using Herit.Application.Features.Organisation.Queries.GetOrganisationById;
 using Herit.Application.Features.Organisation.Queries.ListOrganisations;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Herit.Api.Controllers;
 
 [ApiController]
 [Route("api/v1/Organisations")]
+[Authorize]
 public class OrganisationsController : ControllerBase
 {
     private readonly IMediator _mediator;
@@ -17,6 +19,7 @@ public class OrganisationsController : ControllerBase
     public OrganisationsController(IMediator mediator) => _mediator = mediator;
 
     [HttpPost]
+    [Authorize(Policy = "AdminOrSuperAdmin")]
     public async Task<IActionResult> CreateOrganisation([FromBody] CreateOrganisationCommand command, CancellationToken ct)
     {
         var id = await _mediator.Send(command, ct);
@@ -32,6 +35,7 @@ public class OrganisationsController : ControllerBase
         => Ok(await _mediator.Send(new GetOrganisationByIdQuery(id), ct));
 
     [HttpPut("{id:guid}")]
+    [Authorize(Policy = "AdminOrSuperAdmin")]
     public async Task<IActionResult> UpdateOrganisation(Guid id, [FromBody] UpdateOrganisationCommand command, CancellationToken ct)
     {
         await _mediator.Send(command with { Id = id }, ct);
@@ -39,6 +43,7 @@ public class OrganisationsController : ControllerBase
     }
 
     [HttpDelete("{id:guid}")]
+    [Authorize(Policy = "AdminOrSuperAdmin")]
     public async Task<IActionResult> DeleteOrganisation(Guid id, CancellationToken ct)
     {
         await _mediator.Send(new DeleteOrganisationCommand(id), ct);

--- a/src/Herit.Api/Controllers/ProposalsController.cs
+++ b/src/Herit.Api/Controllers/ProposalsController.cs
@@ -5,19 +5,27 @@ using Herit.Application.Features.Proposal.Commands.UpdateProposal;
 using Herit.Application.Features.Proposal.Commands.UpdateProposalStatus;
 using Herit.Application.Features.Proposal.Queries.GetProposalById;
 using Herit.Application.Features.Proposal.Queries.ListProposals;
+using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Herit.Api.Controllers;
 
 [ApiController]
 [Route("api/v1/[controller]")]
+[Authorize]
 public class ProposalsController : ControllerBase
 {
     private readonly IMediator _mediator;
+    private readonly ICurrentUserService _currentUserService;
 
-    public ProposalsController(IMediator mediator) => _mediator = mediator;
+    public ProposalsController(IMediator mediator, ICurrentUserService currentUserService)
+    {
+        _mediator = mediator;
+        _currentUserService = currentUserService;
+    }
 
     [HttpGet]
     public async Task<IActionResult> List(CancellationToken ct)
@@ -28,13 +36,16 @@ public class ProposalsController : ControllerBase
         => Ok(await _mediator.Send(new GetProposalByIdQuery(id), ct));
 
     [HttpPost]
+    [Authorize(Policy = "Expat")]
     public async Task<IActionResult> Create([FromBody] CreateProposalCommand command, CancellationToken ct)
     {
-        var id = await _mediator.Send(command, ct);
+        var user = await _currentUserService.GetCurrentUserAsync(ct);
+        var id = await _mediator.Send(command with { AuthorId = user.Id }, ct);
         return CreatedAtAction(nameof(GetById), new { id }, id);
     }
 
     [HttpPut("{id:guid}")]
+    [Authorize(Policy = "Expat")]
     public async Task<IActionResult> Update(Guid id, [FromBody] UpdateProposalCommand command, CancellationToken ct)
     {
         await _mediator.Send(command with { Id = id }, ct);
@@ -42,6 +53,7 @@ public class ProposalsController : ControllerBase
     }
 
     [HttpDelete("{id:guid}")]
+    [Authorize(Policy = "StaffOrExpat")]
     public async Task<IActionResult> Delete(Guid id, CancellationToken ct)
     {
         await _mediator.Send(new DeleteProposalCommand(id), ct);
@@ -49,6 +61,7 @@ public class ProposalsController : ControllerBase
     }
 
     [HttpPatch("{id:guid}/status")]
+    [Authorize(Policy = "StaffOrExpat")]
     public async Task<IActionResult> UpdateStatus(Guid id, [FromBody] ProposalStatus newStatus, CancellationToken ct)
     {
         await _mediator.Send(new UpdateProposalStatusCommand(id, newStatus), ct);
@@ -56,6 +69,7 @@ public class ProposalsController : ControllerBase
     }
 
     [HttpPatch("{id:guid}/visibility")]
+    [Authorize(Policy = "Expat")]
     public async Task<IActionResult> SetVisibility(Guid id, [FromBody] ProposalVisibility visibility, CancellationToken ct)
     {
         await _mediator.Send(new SetProposalVisibilityCommand(id, visibility), ct);

--- a/src/Herit.Api/Controllers/RfpsController.cs
+++ b/src/Herit.Api/Controllers/RfpsController.cs
@@ -4,18 +4,26 @@ using Herit.Application.Features.Rfp.Commands.UpdateRfp;
 using Herit.Application.Features.Rfp.Commands.UpdateRfpStatus;
 using Herit.Application.Features.Rfp.Queries.GetRfpById;
 using Herit.Application.Features.Rfp.Queries.ListRfps;
+using Herit.Application.Interfaces;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Herit.Api.Controllers;
 
 [ApiController]
 [Route("api/v1/[controller]")]
+[Authorize]
 public class RfpsController : ControllerBase
 {
     private readonly IMediator _mediator;
+    private readonly ICurrentUserService _currentUserService;
 
-    public RfpsController(IMediator mediator) => _mediator = mediator;
+    public RfpsController(IMediator mediator, ICurrentUserService currentUserService)
+    {
+        _mediator = mediator;
+        _currentUserService = currentUserService;
+    }
 
     [HttpGet]
     public async Task<IActionResult> List(CancellationToken ct)
@@ -26,13 +34,16 @@ public class RfpsController : ControllerBase
         => Ok(await _mediator.Send(new GetRfpByIdQuery(id), ct));
 
     [HttpPost]
+    [Authorize(Policy = "Staff")]
     public async Task<IActionResult> Create([FromBody] CreateRfpCommand command, CancellationToken ct)
     {
-        var id = await _mediator.Send(command, ct);
+        var user = await _currentUserService.GetCurrentUserAsync(ct);
+        var id = await _mediator.Send(command with { AuthorId = user.Id }, ct);
         return CreatedAtAction(nameof(GetById), new { id }, id);
     }
 
     [HttpPut("{id:guid}")]
+    [Authorize(Policy = "Staff")]
     public async Task<IActionResult> Update(Guid id, [FromBody] UpdateRfpCommand command, CancellationToken ct)
     {
         await _mediator.Send(command with { Id = id }, ct);
@@ -40,6 +51,7 @@ public class RfpsController : ControllerBase
     }
 
     [HttpDelete("{id:guid}")]
+    [Authorize(Policy = "Staff")]
     public async Task<IActionResult> Delete(Guid id, CancellationToken ct)
     {
         await _mediator.Send(new DeleteRfpCommand(id), ct);
@@ -47,6 +59,7 @@ public class RfpsController : ControllerBase
     }
 
     [HttpPatch("{id:guid}/status")]
+    [Authorize(Policy = "Staff")]
     public async Task<IActionResult> UpdateStatus(Guid id, [FromBody] UpdateRfpStatusCommand command, CancellationToken ct)
     {
         await _mediator.Send(command with { Id = id }, ct);

--- a/src/Herit.Api/Controllers/UsersController.cs
+++ b/src/Herit.Api/Controllers/UsersController.cs
@@ -7,12 +7,14 @@ using Herit.Application.Features.User.Commands.UpdateUserProfile;
 using Herit.Application.Features.User.Queries.GetUserById;
 using Herit.Application.Features.User.Queries.ListUsers;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Herit.Api.Controllers;
 
 [ApiController]
 [Route("api/v1/[controller]")]
+[Authorize]
 public class UsersController : ControllerBase
 {
     private readonly IMediator _mediator;
@@ -20,14 +22,17 @@ public class UsersController : ControllerBase
     public UsersController(IMediator mediator) => _mediator = mediator;
 
     [HttpGet]
+    [Authorize(Policy = "AdminOrSuperAdmin")]
     public async Task<IActionResult> List(CancellationToken ct)
         => Ok(await _mediator.Send(new ListUsersQuery(), ct));
 
     [HttpGet("{id:guid}")]
+    [Authorize(Policy = "AdminOrSuperAdmin")]
     public async Task<IActionResult> GetById(Guid id, CancellationToken ct)
         => Ok(await _mediator.Send(new GetUserByIdQuery(id), ct));
 
     [HttpPost("staff")]
+    [Authorize(Policy = "AdminOrSuperAdmin")]
     public async Task<IActionResult> CreateStaff([FromBody] CreateStaffUserCommand command, CancellationToken ct)
     {
         var id = await _mediator.Send(command, ct);
@@ -35,6 +40,7 @@ public class UsersController : ControllerBase
     }
 
     [HttpPut("staff/{id:guid}")]
+    [Authorize(Policy = "AdminOrSuperAdmin")]
     public async Task<IActionResult> UpdateStaff(Guid id, [FromBody] UpdateStaffUserCommand command, CancellationToken ct)
     {
         await _mediator.Send(command with { Id = id }, ct);
@@ -42,6 +48,7 @@ public class UsersController : ControllerBase
     }
 
     [HttpDelete("staff/{id:guid}")]
+    [Authorize(Policy = "AdminOrSuperAdmin")]
     public async Task<IActionResult> DeleteStaff(Guid id, CancellationToken ct)
     {
         await _mediator.Send(new DeleteStaffUserCommand(id), ct);
@@ -49,6 +56,7 @@ public class UsersController : ControllerBase
     }
 
     [HttpPost("organisation-admins")]
+    [Authorize(Policy = "AdminOrSuperAdmin")]
     public async Task<IActionResult> CreateOrganisationAdmin([FromBody] CreateOrganisationAdminCommand command, CancellationToken ct)
     {
         var id = await _mediator.Send(command, ct);
@@ -56,6 +64,7 @@ public class UsersController : ControllerBase
     }
 
     [HttpDelete("organisation-admins/{id:guid}")]
+    [Authorize(Policy = "AdminOrSuperAdmin")]
     public async Task<IActionResult> DeleteOrganisationAdmin(Guid id, CancellationToken ct)
     {
         await _mediator.Send(new DeleteOrganisationAdminCommand(id), ct);
@@ -68,5 +77,4 @@ public class UsersController : ControllerBase
         await _mediator.Send(command with { Id = id }, ct);
         return NoContent();
     }
-
 }

--- a/src/Herit.Api/Program.cs
+++ b/src/Herit.Api/Program.cs
@@ -1,13 +1,16 @@
 using Azure.Identity;
 using FluentValidation;
+using Herit.Api.Authorization;
 using Herit.Api.Middleware;
 using Herit.Api.Services;
 using Herit.Application.Behaviours;
 using Herit.Application.Features.Rfp.Commands.CreateRfp;
 using Herit.Application.Interfaces;
+using Herit.Domain.Enums;
 using Herit.Infrastructure;
 using Herit.Infrastructure.Persistence;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Identity.Web;
 using Microsoft.OpenApi.Models;
@@ -36,6 +39,21 @@ var connectionString = (!string.IsNullOrEmpty(connectionStringKey)
     ?? builder.Configuration.GetConnectionString("DefaultConnection")!;
 
 builder.Services.AddInfrastructure(connectionString);
+
+builder.Services.AddAuthorizationBuilder()
+    .AddPolicy("SuperAdmin", policy =>
+        policy.AddRequirements(new RoleRequirement(UserRole.SuperAdmin)))
+    .AddPolicy("OrganisationAdmin", policy =>
+        policy.AddRequirements(new RoleRequirement(UserRole.OrganisationAdmin)))
+    .AddPolicy("Staff", policy =>
+        policy.AddRequirements(new RoleRequirement(UserRole.Staff)))
+    .AddPolicy("Expat", policy =>
+        policy.AddRequirements(new RoleRequirement(UserRole.Expat)))
+    .AddPolicy("AdminOrSuperAdmin", policy =>
+        policy.AddRequirements(new RoleRequirement(UserRole.OrganisationAdmin, UserRole.SuperAdmin)))
+    .AddPolicy("StaffOrExpat", policy =>
+        policy.AddRequirements(new RoleRequirement(UserRole.Staff, UserRole.Expat)));
+builder.Services.AddScoped<IAuthorizationHandler, RoleRequirementHandler>();
 
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<ICurrentUserService, CurrentUserService>();

--- a/src/Herit.Application/Features/Eoi/Commands/SubmitEoi/SubmitEoiCommand.cs
+++ b/src/Herit.Application/Features/Eoi/Commands/SubmitEoi/SubmitEoiCommand.cs
@@ -7,9 +7,11 @@ using EoiEntity = Herit.Domain.Entities.Eoi;
 namespace Herit.Application.Features.Eoi.Commands.SubmitEoi;
 
 public record SubmitEoiCommand(
-    Guid SubmittedById,
     string Message,
-    Guid CfeoiId) : IRequest<Guid>;
+    Guid CfeoiId) : IRequest<Guid>
+{
+    public Guid SubmittedById { get; init; }
+}
 
 public class SubmitEoiCommandHandler : IRequestHandler<SubmitEoiCommand, Guid>
 {

--- a/src/Herit.Application/Features/Eoi/Commands/SubmitEoi/SubmitEoiCommandValidator.cs
+++ b/src/Herit.Application/Features/Eoi/Commands/SubmitEoi/SubmitEoiCommandValidator.cs
@@ -6,7 +6,6 @@ public class SubmitEoiCommandValidator : AbstractValidator<SubmitEoiCommand>
 {
     public SubmitEoiCommandValidator()
     {
-        RuleFor(x => x.SubmittedById).NotEqual(Guid.Empty);
         RuleFor(x => x.Message).NotEmpty();
         RuleFor(x => x.CfeoiId).NotEqual(Guid.Empty);
     }

--- a/src/Herit.Application/Features/Proposal/Commands/CreateProposal/CreateProposalCommand.cs
+++ b/src/Herit.Application/Features/Proposal/Commands/CreateProposal/CreateProposalCommand.cs
@@ -8,10 +8,12 @@ namespace Herit.Application.Features.Proposal.Commands.CreateProposal;
 public record CreateProposalCommand(
     string Title,
     string ShortDescription,
-    Guid AuthorId,
     Guid OrganisationId,
     string LongDescription,
-    Guid? RfpId = null) : IRequest<Guid>;
+    Guid? RfpId = null) : IRequest<Guid>
+{
+    public Guid AuthorId { get; init; }
+}
 
 public class CreateProposalCommandHandler : IRequestHandler<CreateProposalCommand, Guid>
 {

--- a/src/Herit.Application/Features/Proposal/Commands/CreateProposal/CreateProposalCommandValidator.cs
+++ b/src/Herit.Application/Features/Proposal/Commands/CreateProposal/CreateProposalCommandValidator.cs
@@ -9,7 +9,6 @@ public class CreateProposalCommandValidator : AbstractValidator<CreateProposalCo
         RuleFor(x => x.Title).NotEmpty().MaximumLength(256);
         RuleFor(x => x.ShortDescription).NotEmpty().MaximumLength(512);
         RuleFor(x => x.LongDescription).NotEmpty();
-        RuleFor(x => x.AuthorId).NotEqual(Guid.Empty);
         RuleFor(x => x.OrganisationId).NotEqual(Guid.Empty);
         RuleFor(x => x.RfpId).NotEqual(Guid.Empty).When(x => x.RfpId.HasValue);
     }

--- a/src/Herit.Application/Features/Rfp/Commands/CreateRfp/CreateRfpCommand.cs
+++ b/src/Herit.Application/Features/Rfp/Commands/CreateRfp/CreateRfpCommand.cs
@@ -8,9 +8,11 @@ namespace Herit.Application.Features.Rfp.Commands.CreateRfp;
 public record CreateRfpCommand(
     string Title,
     string ShortDescription,
-    Guid AuthorId,
     Guid OrganisationId,
-    string LongDescription) : IRequest<Guid>;
+    string LongDescription) : IRequest<Guid>
+{
+    public Guid AuthorId { get; init; }
+}
 
 public class CreateRfpCommandHandler : IRequestHandler<CreateRfpCommand, Guid>
 {

--- a/src/Herit.Application/Features/Rfp/Commands/CreateRfp/CreateRfpCommandValidator.cs
+++ b/src/Herit.Application/Features/Rfp/Commands/CreateRfp/CreateRfpCommandValidator.cs
@@ -9,7 +9,6 @@ public class CreateRfpCommandValidator : AbstractValidator<CreateRfpCommand>
         RuleFor(x => x.Title).NotEmpty().MaximumLength(256);
         RuleFor(x => x.ShortDescription).NotEmpty().MaximumLength(512);
         RuleFor(x => x.LongDescription).NotEmpty();
-        RuleFor(x => x.AuthorId).NotEqual(Guid.Empty);
         RuleFor(x => x.OrganisationId).NotEqual(Guid.Empty);
     }
 }

--- a/tests/Herit.Application.Tests/Features/Eoi/Commands/SubmitEoiCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Eoi/Commands/SubmitEoiCommandHandlerTests.cs
@@ -31,7 +31,7 @@ public class SubmitEoiCommandHandlerTests
         _cfeoiRepository.GetByIdAsync(cfeoiId, Arg.Any<CancellationToken>())
             .Returns(CfeoiEntity.Create(cfeoiId, "Title", "Desc", CfeoiResourceType.Human, Guid.NewGuid(), "Engineer", "C#", 1));
 
-        var command = new SubmitEoiCommand(submittedById, "My message", cfeoiId);
+        var command = new SubmitEoiCommand("My message", cfeoiId) with { SubmittedById = submittedById };
 
         var result = await _handler.Handle(command, CancellationToken.None);
 
@@ -47,7 +47,7 @@ public class SubmitEoiCommandHandlerTests
         var submittedById = Guid.NewGuid();
         _userRepository.GetByIdAsync(submittedById, Arg.Any<CancellationToken>()).Returns((UserEntity?)null);
 
-        var command = new SubmitEoiCommand(submittedById, "Message", Guid.NewGuid());
+        var command = new SubmitEoiCommand("Message", Guid.NewGuid()) with { SubmittedById = submittedById };
 
         await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _eoiRepository.DidNotReceive().AddAsync(Arg.Any<EoiEntity>(), Arg.Any<CancellationToken>());
@@ -62,7 +62,7 @@ public class SubmitEoiCommandHandlerTests
             .Returns(UserEntity.Create(submittedById, "ext-1", "user@example.com", "Test User", UserRole.Staff));
         _cfeoiRepository.GetByIdAsync(cfeoiId, Arg.Any<CancellationToken>()).Returns((CfeoiEntity?)null);
 
-        var command = new SubmitEoiCommand(submittedById, "Message", cfeoiId);
+        var command = new SubmitEoiCommand("Message", cfeoiId) with { SubmittedById = submittedById };
 
         await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _eoiRepository.DidNotReceive().AddAsync(Arg.Any<EoiEntity>(), Arg.Any<CancellationToken>());
@@ -79,7 +79,7 @@ public class SubmitEoiCommandHandlerTests
             .Returns(UserEntity.Create(submittedById, "ext-1", "user@example.com", "Test User", UserRole.Staff));
         _cfeoiRepository.GetByIdAsync(cfeoiId, Arg.Any<CancellationToken>()).Returns(closedCfeoi);
 
-        var command = new SubmitEoiCommand(submittedById, "Message", cfeoiId);
+        var command = new SubmitEoiCommand("Message", cfeoiId) with { SubmittedById = submittedById };
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
         await _eoiRepository.DidNotReceive().AddAsync(Arg.Any<EoiEntity>(), Arg.Any<CancellationToken>());

--- a/tests/Herit.Application.Tests/Features/Proposal/Commands/CreateProposalCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Proposal/Commands/CreateProposalCommandHandlerTests.cs
@@ -33,7 +33,7 @@ public class CreateProposalCommandHandlerTests
         _organisationRepository.GetByIdAsync(organisationId, Arg.Any<CancellationToken>())
             .Returns(OrganisationEntity.Create(organisationId, "Test Org"));
 
-        var command = new CreateProposalCommand("Title", "Short", authorId, organisationId, "Long");
+        var command = new CreateProposalCommand("Title", "Short", organisationId, "Long") with { AuthorId = authorId };
 
         var result = await _handler.Handle(command, CancellationToken.None);
 
@@ -56,7 +56,7 @@ public class CreateProposalCommandHandlerTests
         _rfpRepository.GetByIdAsync(rfpId, Arg.Any<CancellationToken>())
             .Returns(RfpEntity.Create(rfpId, "RFP", "Short", authorId, organisationId, "Long"));
 
-        var command = new CreateProposalCommand("Title", "Short", authorId, organisationId, "Long", rfpId);
+        var command = new CreateProposalCommand("Title", "Short", organisationId, "Long", rfpId) with { AuthorId = authorId };
 
         var result = await _handler.Handle(command, CancellationToken.None);
 
@@ -73,7 +73,7 @@ public class CreateProposalCommandHandlerTests
         var organisationId = Guid.NewGuid();
         _userRepository.GetByIdAsync(authorId, Arg.Any<CancellationToken>()).Returns((UserEntity?)null);
 
-        var command = new CreateProposalCommand("Title", "Short", authorId, organisationId, "Long");
+        var command = new CreateProposalCommand("Title", "Short", organisationId, "Long") with { AuthorId = authorId };
 
         await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _proposalRepository.DidNotReceive().AddAsync(Arg.Any<ProposalEntity>(), Arg.Any<CancellationToken>());
@@ -88,7 +88,7 @@ public class CreateProposalCommandHandlerTests
             .Returns(UserEntity.Create(authorId, "ext-1", "user@example.com", "Test User", UserRole.Staff));
         _organisationRepository.GetByIdAsync(organisationId, Arg.Any<CancellationToken>()).Returns((OrganisationEntity?)null);
 
-        var command = new CreateProposalCommand("Title", "Short", authorId, organisationId, "Long");
+        var command = new CreateProposalCommand("Title", "Short", organisationId, "Long") with { AuthorId = authorId };
 
         await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _proposalRepository.DidNotReceive().AddAsync(Arg.Any<ProposalEntity>(), Arg.Any<CancellationToken>());
@@ -106,7 +106,7 @@ public class CreateProposalCommandHandlerTests
             .Returns(OrganisationEntity.Create(organisationId, "Test Org"));
         _rfpRepository.GetByIdAsync(rfpId, Arg.Any<CancellationToken>()).Returns((RfpEntity?)null);
 
-        var command = new CreateProposalCommand("Title", "Short", authorId, organisationId, "Long", rfpId);
+        var command = new CreateProposalCommand("Title", "Short", organisationId, "Long", rfpId) with { AuthorId = authorId };
 
         await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _proposalRepository.DidNotReceive().AddAsync(Arg.Any<ProposalEntity>(), Arg.Any<CancellationToken>());

--- a/tests/Herit.Application.Tests/Features/Rfp/Commands/CreateRfpCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Rfp/Commands/CreateRfpCommandHandlerTests.cs
@@ -31,7 +31,7 @@ public class CreateRfpCommandHandlerTests
         _organisationRepository.GetByIdAsync(organisationId, Arg.Any<CancellationToken>())
             .Returns(OrganisationEntity.Create(organisationId, "Test Org"));
 
-        var command = new CreateRfpCommand("Title", "Short", authorId, organisationId, "Long");
+        var command = new CreateRfpCommand("Title", "Short", organisationId, "Long") with { AuthorId = authorId };
 
         var result = await _handler.Handle(command, CancellationToken.None);
 
@@ -48,7 +48,7 @@ public class CreateRfpCommandHandlerTests
         var organisationId = Guid.NewGuid();
         _userRepository.GetByIdAsync(authorId, Arg.Any<CancellationToken>()).Returns((UserEntity?)null);
 
-        var command = new CreateRfpCommand("Title", "Short", authorId, organisationId, "Long");
+        var command = new CreateRfpCommand("Title", "Short", organisationId, "Long") with { AuthorId = authorId };
 
         await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _rfpRepository.DidNotReceive().AddAsync(Arg.Any<RfpEntity>(), Arg.Any<CancellationToken>());
@@ -63,7 +63,7 @@ public class CreateRfpCommandHandlerTests
             .Returns(UserEntity.Create(authorId, "ext-1", "user@example.com", "Test User", UserRole.Staff));
         _organisationRepository.GetByIdAsync(organisationId, Arg.Any<CancellationToken>()).Returns((OrganisationEntity?)null);
 
-        var command = new CreateRfpCommand("Title", "Short", authorId, organisationId, "Long");
+        var command = new CreateRfpCommand("Title", "Short", organisationId, "Long") with { AuthorId = authorId };
 
         await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _rfpRepository.DidNotReceive().AddAsync(Arg.Any<RfpEntity>(), Arg.Any<CancellationToken>());


### PR DESCRIPTION
## Description

Implements role-based authorization across all API controllers using a custom policy system backed by the database-stored roles (per ADR-014).

- Introduces `RoleRequirement` and `RoleRequirementHandler` in `Herit.Api/Authorization/` — the handler resolves the caller's role via `ICurrentUserService` and succeeds if the role matches the policy's allowed set.
- Registers six named policies in `Program.cs` via `AddAuthorizationBuilder`: `SuperAdmin`, `OrganisationAdmin`, `Staff`, `Expat`, `AdminOrSuperAdmin`, `StaffOrExpat`.
- Applies `[Authorize]` at the class level on all six controllers and scopes individual actions with the appropriate policy per the PRD use-case matrix (section 6).
- Removes `AuthorId` from `CreateProposalCommand` / `CreateRfpCommand` and `SubmittedById` from `SubmitEoiCommand` as HTTP-body fields; the controller now resolves the current user via `ICurrentUserService` and sets the field before dispatching the command.
- Updates the corresponding validators to drop the now-redundant identity-field rules.
- Updates all affected command-handler tests to use the new constructor shapes.

## Linked Issue

Closes #122

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- All 231 tests pass (`dotnet test --configuration Release`).
- Authorization is enforced at the HTTP layer; the handler resolves the user from the DB on each request (same JIT mechanism already used by `CurrentUserService`).

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)