### PR TITLE
Add super admin bootstrap CLI command

### DIFF
--- a/docs/ops/super-admin-bootstrap.md
+++ b/docs/ops/super-admin-bootstrap.md
@@ -1,0 +1,54 @@
+# Super Admin Bootstrap
+
+One-time CLI command to seed the first super admin user into both Azure AD B2C and the database.
+
+## Command
+
+```bash
+dotnet run --project src/Herit.API -- --seed-super-admin --email admin@example.com --display-name "Super Admin"
+```
+
+Both `--email` and `--display-name` are required.
+
+## Expected Output
+
+### Super admin created
+
+```
+info: Herit.Application.Seeding.SuperAdminSeeder[0]
+      Super admin created: admin@example.com (ExternalId: <b2c-object-id>)
+```
+
+Process exits with code `0`.
+
+### Super admin already exists
+
+```
+info: Herit.Application.Seeding.SuperAdminSeeder[0]
+      Super admin already exists. No action taken.
+```
+
+Process exits with code `0`. The command is idempotent — running it again is safe.
+
+### Missing required arguments
+
+```
+Error: missing required argument(s): --email
+Usage: dotnet run --project Herit.API -- --seed-super-admin --email <email> --display-name <name>
+```
+
+Process exits with code `1`.
+
+## Verification
+
+**B2C:** In the Azure portal, navigate to the B2C tenant → Users and confirm the account exists with the email provided.
+
+**Database:** Run the following query against the application database:
+
+```sql
+SELECT Id, ExternalId, Email, FullName, Role
+FROM Users
+WHERE Role = 0; -- 0 = SuperAdmin
+```
+
+Confirm one row is returned with the expected email and a non-null `ExternalId` matching the B2C object ID.

--- a/src/Herit.Api/Program.cs
+++ b/src/Herit.Api/Program.cs
@@ -6,6 +6,7 @@ using Herit.Api.Services;
 using Herit.Application.Behaviours;
 using Herit.Application.Features.Rfp.Commands.CreateRfp;
 using Herit.Application.Interfaces;
+using Herit.Application.Seeding;
 using Herit.Domain.Enums;
 using Herit.Infrastructure;
 using Herit.Infrastructure.Persistence;
@@ -14,6 +15,9 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Identity.Web;
 using Microsoft.OpenApi.Models;
+
+if (args.Contains("--seed-super-admin"))
+    return await RunSeedSuperAdminAsync(args);
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -91,3 +95,53 @@ app.UseAuthorization();
 app.MapControllers();
 
 app.Run();
+return 0;
+
+static async Task<int> RunSeedSuperAdminAsync(string[] args)
+{
+    var email = GetArg(args, "--email");
+    var displayName = GetArg(args, "--display-name");
+
+    var missing = new List<string>();
+    if (string.IsNullOrWhiteSpace(email)) missing.Add("--email");
+    if (string.IsNullOrWhiteSpace(displayName)) missing.Add("--display-name");
+
+    if (missing.Count > 0)
+    {
+        await Console.Error.WriteLineAsync($"Error: missing required argument(s): {string.Join(", ", missing)}");
+        await Console.Error.WriteLineAsync("Usage: dotnet run --project Herit.API -- --seed-super-admin --email <email> --display-name <name>");
+        return 1;
+    }
+
+    var seedBuilder = WebApplication.CreateBuilder(args);
+
+    var kvEndpoint = seedBuilder.Configuration["AZURE_KEY_VAULT_ENDPOINT"];
+    if (!string.IsNullOrEmpty(kvEndpoint) && !seedBuilder.Environment.IsDevelopment())
+        seedBuilder.Configuration.AddAzureKeyVault(new Uri(kvEndpoint), new DefaultAzureCredential());
+
+    var seedConnectionStringKey = seedBuilder.Configuration["AZURE_SQL_CONNECTION_STRING_KEY"];
+    var seedConnectionString = (!string.IsNullOrEmpty(seedConnectionStringKey)
+        ? seedBuilder.Configuration[seedConnectionStringKey]
+        : null)
+        ?? seedBuilder.Configuration.GetConnectionString("DefaultConnection")!;
+
+    seedBuilder.Services.AddInfrastructure(seedConnectionString);
+    seedBuilder.Services.AddScoped<SuperAdminSeeder>();
+
+    var seedApp = seedBuilder.Build();
+
+    await using var scope = seedApp.Services.CreateAsyncScope();
+    var db = scope.ServiceProvider.GetRequiredService<HeritDbContext>();
+    await db.Database.MigrateAsync();
+
+    var seeder = scope.ServiceProvider.GetRequiredService<SuperAdminSeeder>();
+    await seeder.SeedAsync(email!, displayName!);
+
+    return 0;
+}
+
+static string? GetArg(string[] args, string name)
+{
+    var idx = Array.IndexOf(args, name);
+    return idx >= 0 && idx + 1 < args.Length ? args[idx + 1] : null;
+}

--- a/src/Herit.Application/Seeding/SuperAdminSeeder.cs
+++ b/src/Herit.Application/Seeding/SuperAdminSeeder.cs
@@ -1,0 +1,39 @@
+using Herit.Application.Interfaces;
+using Herit.Domain.Enums;
+using Microsoft.Extensions.Logging;
+using UserEntity = Herit.Domain.Entities.User;
+
+namespace Herit.Application.Seeding;
+
+public class SuperAdminSeeder
+{
+    private readonly IUserRepository _userRepository;
+    private readonly IIdentityProviderService _identityProviderService;
+    private readonly ILogger<SuperAdminSeeder> _logger;
+
+    public SuperAdminSeeder(
+        IUserRepository userRepository,
+        IIdentityProviderService identityProviderService,
+        ILogger<SuperAdminSeeder> logger)
+    {
+        _userRepository = userRepository;
+        _identityProviderService = identityProviderService;
+        _logger = logger;
+    }
+
+    public async Task SeedAsync(string email, string displayName, CancellationToken ct = default)
+    {
+        var users = await _userRepository.ListAsync(ct);
+        if (users.Any(u => u.Role == UserRole.SuperAdmin))
+        {
+            _logger.LogInformation("Super admin already exists. No action taken.");
+            return;
+        }
+
+        var externalId = await _identityProviderService.CreateUserAsync(email, displayName, ct);
+        var user = UserEntity.Create(Guid.NewGuid(), externalId, email, displayName, UserRole.SuperAdmin);
+        await _userRepository.AddAsync(user, ct);
+
+        _logger.LogInformation("Super admin created: {Email} (ExternalId: {ExternalId})", email, externalId);
+    }
+}

--- a/tests/Herit.Application.Tests/Seeding/SuperAdminSeederTests.cs
+++ b/tests/Herit.Application.Tests/Seeding/SuperAdminSeederTests.cs
@@ -1,0 +1,66 @@
+using Herit.Application.Interfaces;
+using Herit.Application.Seeding;
+using Herit.Domain.Enums;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using UserEntity = Herit.Domain.Entities.User;
+
+namespace Herit.Application.Tests.Seeding;
+
+public class SuperAdminSeederTests
+{
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly IIdentityProviderService _identityProviderService = Substitute.For<IIdentityProviderService>();
+    private readonly SuperAdminSeeder _seeder;
+
+    public SuperAdminSeederTests()
+    {
+        _seeder = new SuperAdminSeeder(_userRepository, _identityProviderService, NullLogger<SuperAdminSeeder>.Instance);
+    }
+
+    [Fact]
+    public async Task SeedAsync_WhenNoSuperAdminExists_CreatesB2cAccountAndDbRecord()
+    {
+        _userRepository.ListAsync(Arg.Any<CancellationToken>()).Returns([]);
+        _identityProviderService.CreateUserAsync("admin@example.com", "Super Admin", Arg.Any<CancellationToken>())
+            .Returns("ext-super-1");
+
+        await _seeder.SeedAsync("admin@example.com", "Super Admin");
+
+        await _identityProviderService.Received(1).CreateUserAsync("admin@example.com", "Super Admin", Arg.Any<CancellationToken>());
+        await _userRepository.Received(1).AddAsync(
+            Arg.Is<UserEntity>(u =>
+                u.Email == "admin@example.com" &&
+                u.FullName == "Super Admin" &&
+                u.Role == UserRole.SuperAdmin &&
+                u.ExternalId == "ext-super-1"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SeedAsync_WhenSuperAdminAlreadyExists_DoesNothing()
+    {
+        var existing = UserEntity.Create(Guid.NewGuid(), "ext-existing", "admin@example.com", "Super Admin", UserRole.SuperAdmin);
+        _userRepository.ListAsync(Arg.Any<CancellationToken>()).Returns([existing]);
+
+        await _seeder.SeedAsync("admin@example.com", "Super Admin");
+
+        await _identityProviderService.DidNotReceive().CreateUserAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _userRepository.DidNotReceive().AddAsync(Arg.Any<UserEntity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SeedAsync_WhenOtherUsersExistButNoSuperAdmin_CreatesNewSuperAdmin()
+    {
+        var staff = UserEntity.Create(Guid.NewGuid(), "ext-staff", "staff@example.com", "Staff User", UserRole.Staff);
+        _userRepository.ListAsync(Arg.Any<CancellationToken>()).Returns([staff]);
+        _identityProviderService.CreateUserAsync("admin@example.com", "Super Admin", Arg.Any<CancellationToken>())
+            .Returns("ext-super-1");
+
+        await _seeder.SeedAsync("admin@example.com", "Super Admin");
+
+        await _userRepository.Received(1).AddAsync(
+            Arg.Is<UserEntity>(u => u.Role == UserRole.SuperAdmin),
+            Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Description

Adds a `--seed-super-admin` CLI flag to `Program.cs`. When present the process seeds the first super admin user (B2C account + DB record) and exits without starting the web host. The command is idempotent — if a super admin already exists it logs and exits cleanly.

## Linked Issue

Closes #123

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

3 unit tests in `SuperAdminSeederTests`:
- Super admin does not exist → creates B2C account and DB record.
- Super admin already exists → does nothing (no calls to identity provider or repository).
- Other users exist but no super admin → still creates the super admin.

All 234 tests pass.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [x] Relevant documentation updated (`docs/ops/super-admin-bootstrap.md`)
- [x] Branch follows naming convention (`feature/super-admin-bootstrap`)