### PR TITLE
Add B2C configuration to Bicep and Key Vault

### DIFF
--- a/docs/ops/b2c-setup.md
+++ b/docs/ops/b2c-setup.md
@@ -1,0 +1,117 @@
+# B2C Setup
+
+One-time provisioning of the Azure AD B2C tenant resources required by the Herit API.
+
+## Prerequisites
+
+- `az` CLI installed and authenticated against the B2C tenant:
+  ```bash
+  az login --tenant <b2c-tenant-id> --allow-no-subscriptions
+  ```
+- The signed-in principal must have the following Microsoft Graph API permissions on the B2C tenant:
+  - `Application.ReadWrite.All`
+  - `IdentityProvider.ReadWrite.All`
+- A Google OAuth 2.0 client ID and secret (created in the Google Cloud Console with the B2C redirect URI whitelisted: `https://<tenant>.b2clogin.com/<tenant>.onmicrosoft.com/oauth2/authresp`).
+
+---
+
+## Step 1 — Run the setup script
+
+```bash
+./scripts/setup-b2c.sh \
+  --tenant-id <b2c-tenant-id> \
+  --google-client-id <google-oauth-client-id> \
+  --google-client-secret <google-oauth-client-secret>
+```
+
+The script will:
+1. Create the **Herit API** app registration in the B2C tenant (idempotent — safe to re-run).
+2. Generate a client secret and print it to the console.
+3. Register Google as a social identity provider.
+4. Print all Key Vault values (see Step 3).
+
+---
+
+## Step 2 — Create the sign-up/sign-in user flow (manual)
+
+The Microsoft Graph API does not support creating B2C user flows. This step must be performed in the Azure Portal.
+
+**Navigation path:**
+
+1. Open the [Azure Portal](https://portal.azure.com) and switch to the B2C tenant directory.
+2. Search for and open **Azure AD B2C**.
+3. In the left menu, select **User flows**.
+4. Click **New user flow**.
+
+**Settings:**
+
+| Field | Value |
+|---|---|
+| User flow type | **Sign up and sign in** |
+| Version | **Recommended** |
+| Name | `B2C_1_SignUpSignIn` (must match the `b2c-user-flow` Key Vault secret) |
+| Identity providers | Enable **Email signup** and **Google** |
+| Multifactor authentication | Off (or as required by your security policy) |
+| User attributes and claims | Collect: **Display Name**; Return: **Display Name**, **User's Object ID** |
+
+Click **Create**.
+
+---
+
+## Step 3 — Populate Key Vault
+
+Use the values printed by the script to set the following secrets in the Azure Key Vault provisioned by Bicep:
+
+| Secret name | Value |
+|---|---|
+| `b2c-tenant-id` | The B2C tenant ID (GUID) |
+| `b2c-client-id` | The app registration client ID |
+| `b2c-client-secret` | The generated client secret |
+| `b2c-authority` | `https://<tenant>.b2clogin.com` |
+| `b2c-tenant` | `<tenant>.onmicrosoft.com` |
+| `b2c-user-flow` | `B2C_1_SignUpSignIn` |
+
+Using the `az` CLI:
+
+```bash
+KV_NAME=<your-key-vault-name>
+
+az keyvault secret set --vault-name "$KV_NAME" --name b2c-tenant-id     --value "<value>"
+az keyvault secret set --vault-name "$KV_NAME" --name b2c-client-id     --value "<value>"
+az keyvault secret set --vault-name "$KV_NAME" --name b2c-client-secret --value "<value>"
+az keyvault secret set --vault-name "$KV_NAME" --name b2c-authority     --value "<value>"
+az keyvault secret set --vault-name "$KV_NAME" --name b2c-tenant        --value "<value>"
+az keyvault secret set --vault-name "$KV_NAME" --name b2c-user-flow     --value "B2C_1_SignUpSignIn"
+```
+
+After secrets are set, restart the API App Service so it picks up the new Key Vault references:
+
+```bash
+az webapp restart --name <api-app-service-name> --resource-group <resource-group>
+```
+
+---
+
+## Verification
+
+### App registration
+
+In the Azure Portal → **Azure AD B2C** → **App registrations**, confirm **Herit API** is listed with a non-empty Application (client) ID.
+
+### Identity provider
+
+In **Azure AD B2C** → **Identity providers**, confirm **Google** appears in the list.
+
+### User flow
+
+In **Azure AD B2C** → **User flows**, confirm `B2C_1_SignUpSignIn` is listed and its identity providers include **Email signup** and **Google**.
+
+### API authentication
+
+Send an authenticated request to the API using a token issued by the B2C tenant:
+
+```bash
+curl -H "Authorization: Bearer <token>" https://<api-hostname>/health
+```
+
+A `200 OK` response confirms the B2C JWT middleware is correctly configured.

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -42,6 +42,30 @@ param sqlAdminPassword string
 @description('Application user password')
 param appUserPassword string
 param appUser string = 'appUser'
+
+@secure()
+@description('Azure AD B2C client ID for the API app registration')
+param b2cClientId string
+
+@secure()
+@description('Azure AD B2C client secret for Graph API access')
+param b2cClientSecret string
+
+@secure()
+@description('Azure AD B2C tenant ID')
+param b2cTenantId string
+
+@secure()
+@description('Azure AD B2C authority base URL, e.g. https://<tenant>.b2clogin.com')
+param b2cAuthority string
+
+@secure()
+@description('Azure AD B2C tenant domain, e.g. <tenant>.onmicrosoft.com')
+param b2cTenant string
+
+@secure()
+@description('Azure AD B2C sign-up/sign-in user flow name')
+param b2cUserFlowName string
 var abbrs = loadJsonContent('./abbreviations.json')
 var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
 var tags = { 'azd-env-name': environmentName }
@@ -85,6 +109,10 @@ module api './app/api-appservice-avm.bicep' = {
       AZURE_KEY_VAULT_ENDPOINT: keyVault.outputs.uri
       AZURE_SQL_CONNECTION_STRING_KEY: connectionStringKey
       SCM_DO_BUILD_DURING_DEPLOYMENT: false
+      AzureAdB2C__Instance: '@Microsoft.KeyVault(VaultName=${keyVault.outputs.name};SecretName=b2c-authority)'
+      AzureAdB2C__Domain: '@Microsoft.KeyVault(VaultName=${keyVault.outputs.name};SecretName=b2c-tenant)'
+      AzureAdB2C__ClientId: '@Microsoft.KeyVault(VaultName=${keyVault.outputs.name};SecretName=b2c-client-id)'
+      AzureAdB2C__SignUpSignInPolicyId: '@Microsoft.KeyVault(VaultName=${keyVault.outputs.name};SecretName=b2c-user-flow)'
     }
     appInsightResourceId: monitoring.outputs.applicationInsightsResourceId
     allowedOrigins: [web.outputs.SERVICE_WEB_URI]
@@ -129,6 +157,30 @@ module accessKeyVault 'br/public:avm/res/key-vault/vault:0.3.5' = {
         {
           name: connectionStringKey
           value: 'Server=${sqlService.outputs.sqlServerName}${environment().suffixes.sqlServerHostname}; Database=${sqlService.outputs.databaseName}; User=${appUser}; Password=${appUserPassword}'
+        }
+        {
+          name: 'b2c-client-id'
+          value: b2cClientId
+        }
+        {
+          name: 'b2c-client-secret'
+          value: b2cClientSecret
+        }
+        {
+          name: 'b2c-tenant-id'
+          value: b2cTenantId
+        }
+        {
+          name: 'b2c-authority'
+          value: b2cAuthority
+        }
+        {
+          name: 'b2c-tenant'
+          value: b2cTenant
+        }
+        {
+          name: 'b2c-user-flow'
+          value: b2cUserFlowName
         }
       ]
     }

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -22,6 +22,24 @@
     },
     "apimSku": {
       "value": "${APIM_SKU=Consumption}"
+    },
+    "b2cClientId": {
+      "value": "${B2C_CLIENT_ID}"
+    },
+    "b2cClientSecret": {
+      "value": "${B2C_CLIENT_SECRET}"
+    },
+    "b2cTenantId": {
+      "value": "${B2C_TENANT_ID}"
+    },
+    "b2cAuthority": {
+      "value": "${B2C_AUTHORITY}"
+    },
+    "b2cTenant": {
+      "value": "${B2C_TENANT}"
+    },
+    "b2cUserFlowName": {
+      "value": "${B2C_USER_FLOW_NAME}"
     }
   }
 }

--- a/scripts/setup-b2c.sh
+++ b/scripts/setup-b2c.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# setup-b2c.sh
+#
+# Provisions the Azure AD B2C resources required by the Herit API:
+#   1. Creates the API app registration in the B2C tenant.
+#   2. Generates a client secret and prints it for Key Vault storage.
+#   3. Configures Google as an identity provider.
+#   4. Prints the values needed to populate Key Vault.
+#
+# Usage:
+#   ./scripts/setup-b2c.sh \
+#     --tenant-id <b2c-tenant-id> \
+#     --google-client-id <google-oauth-client-id> \
+#     --google-client-secret <google-oauth-client-secret>
+#
+# Prerequisites:
+#   - az CLI installed and logged in to the B2C tenant
+#     (az login --tenant <tenant-id> --allow-no-subscriptions)
+#   - Microsoft.Graph permission: Application.ReadWrite.All,
+#     IdentityProvider.ReadWrite.All (granted to the signed-in principal)
+# ---------------------------------------------------------------------------
+
+TENANT_ID=""
+GOOGLE_CLIENT_ID=""
+GOOGLE_CLIENT_SECRET=""
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tenant-id)
+      TENANT_ID="$2"; shift 2 ;;
+    --google-client-id)
+      GOOGLE_CLIENT_ID="$2"; shift 2 ;;
+    --google-client-secret)
+      GOOGLE_CLIENT_SECRET="$2"; shift 2 ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      echo "Usage: $0 --tenant-id <id> --google-client-id <id> --google-client-secret <secret>" >&2
+      exit 1 ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+MISSING=()
+[[ -z "$TENANT_ID" ]]           && MISSING+=("--tenant-id")
+[[ -z "$GOOGLE_CLIENT_ID" ]]    && MISSING+=("--google-client-id")
+[[ -z "$GOOGLE_CLIENT_SECRET" ]] && MISSING+=("--google-client-secret")
+
+if [[ ${#MISSING[@]} -gt 0 ]]; then
+  echo "Error: missing required parameter(s): ${MISSING[*]}" >&2
+  echo "Usage: $0 --tenant-id <id> --google-client-id <id> --google-client-secret <secret>" >&2
+  exit 1
+fi
+
+APP_DISPLAY_NAME="Herit API"
+USER_FLOW_NAME="B2C_1_SignUpSignIn"
+
+echo "==> Setting az CLI context to B2C tenant ${TENANT_ID}..."
+az account set --subscription "" 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# Step 1: Create the API app registration
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Step 1: Creating app registration '${APP_DISPLAY_NAME}'..."
+
+EXISTING_APP_ID=$(az rest \
+  --method GET \
+  --uri "https://graph.microsoft.com/v1.0/applications?\$filter=displayName eq '${APP_DISPLAY_NAME}'" \
+  --headers "Content-Type=application/json" \
+  --query "value[0].appId" \
+  --output tsv \
+  --only-show-errors 2>/dev/null || true)
+
+if [[ -n "$EXISTING_APP_ID" && "$EXISTING_APP_ID" != "None" ]]; then
+  echo "    App registration already exists (clientId: ${EXISTING_APP_ID}). Skipping creation."
+  CLIENT_ID="$EXISTING_APP_ID"
+
+  OBJECT_ID=$(az rest \
+    --method GET \
+    --uri "https://graph.microsoft.com/v1.0/applications?\$filter=appId eq '${CLIENT_ID}'" \
+    --query "value[0].id" \
+    --output tsv \
+    --only-show-errors)
+else
+  CREATE_RESPONSE=$(az rest \
+    --method POST \
+    --uri "https://graph.microsoft.com/v1.0/applications" \
+    --headers "Content-Type=application/json" \
+    --body "{
+      \"displayName\": \"${APP_DISPLAY_NAME}\",
+      \"signInAudience\": \"AzureADandPersonalMicrosoftAccount\"
+    }" \
+    --only-show-errors)
+
+  CLIENT_ID=$(echo "$CREATE_RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['appId'])")
+  OBJECT_ID=$(echo "$CREATE_RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+  echo "    Created app registration (clientId: ${CLIENT_ID}, objectId: ${OBJECT_ID})."
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2: Generate a client secret
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Step 2: Generating client secret..."
+
+SECRET_RESPONSE=$(az rest \
+  --method POST \
+  --uri "https://graph.microsoft.com/v1.0/applications/${OBJECT_ID}/addPassword" \
+  --headers "Content-Type=application/json" \
+  --body "{
+    \"passwordCredential\": {
+      \"displayName\": \"Herit API Secret\",
+      \"endDateTime\": \"2099-01-01T00:00:00Z\"
+    }
+  }" \
+  --only-show-errors)
+
+CLIENT_SECRET=$(echo "$SECRET_RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['secretText'])")
+echo "    Client secret generated."
+
+# ---------------------------------------------------------------------------
+# Step 3: Configure Google as an identity provider
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Step 3: Configuring Google as an identity provider..."
+
+az rest \
+  --method POST \
+  --uri "https://graph.microsoft.com/v1.0/identity/identityProviders" \
+  --headers "Content-Type=application/json" \
+  --body "{
+    \"@odata.type\": \"#microsoft.graph.socialIdentityProvider\",
+    \"displayName\": \"Google\",
+    \"identityProviderType\": \"Google\",
+    \"clientId\": \"${GOOGLE_CLIENT_ID}\",
+    \"clientSecret\": \"${GOOGLE_CLIENT_SECRET}\"
+  }" \
+  --only-show-errors > /dev/null
+
+echo "    Google identity provider configured."
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+B2C_DOMAIN="${TENANT_ID}.onmicrosoft.com"
+B2C_AUTHORITY="https://${TENANT_ID}.b2clogin.com"
+
+echo ""
+echo "============================================================"
+echo " B2C setup complete. Store the following in Key Vault:"
+echo "============================================================"
+echo ""
+echo "  b2c-tenant-id:     ${TENANT_ID}"
+echo "  b2c-client-id:     ${CLIENT_ID}"
+echo "  b2c-client-secret: ${CLIENT_SECRET}"
+echo "  b2c-authority:     ${B2C_AUTHORITY}"
+echo "  b2c-tenant:        ${B2C_DOMAIN}"
+echo "  b2c-user-flow:     ${USER_FLOW_NAME}"
+echo ""
+echo "  NOTE: The sign-up/sign-in user flow (${USER_FLOW_NAME}) must be"
+echo "  created manually in the Azure Portal. See docs/ops/b2c-setup.md."
+echo "============================================================"


### PR DESCRIPTION
## Description

Provisions the Azure AD B2C infrastructure and automates its setup end-to-end:

- **Bicep**: adds six B2C parameters to `main.bicep`, stores them as Key Vault secrets, and surfaces four `AzureAdB2C__*` app settings on the API App Service using `@Microsoft.KeyVault` references.
- **Script**: `scripts/setup-b2c.sh` creates the app registration, generates a client secret, and configures Google as a social identity provider via the Microsoft Graph API.
- **Docs**: `docs/ops/b2c-setup.md` covers prerequisites, running the script, the one manual step (user flow creation in the Portal), Key Vault population, and verification.

## Linked Issue

Closes #124

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

The Bicep changes follow the existing Key Vault secret pattern and were validated by inspection. The setup script should be manually run against a development B2C tenant before merging to a production environment (per issue acceptance criteria).

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [x] Relevant documentation updated (`docs/ops/b2c-setup.md`)
- [x] Branch follows naming convention (`feature/b2c-bicep-and-setup-script`)