### PR TITLE
Fix CI: use checkout@v4 and add portal build/test steps

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -34,6 +34,25 @@ jobs:
 
       - name: Test
         run: dotnet test --configuration Release --no-build
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: frontend/portal/package-lock.json
+
+      - name: Install portal dependencies
+        run: npm ci
+        working-directory: frontend/portal
+
+      - name: Build portal
+        run: npm run build
+        working-directory: frontend/portal
+
+      - name: Test portal
+        run: npm test -- --run
+        working-directory: frontend/portal
 
   cd:
     runs-on: ubuntu-latest
@@ -47,7 +66,7 @@ jobs:
       AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Install azd
         uses: Azure/setup-azd@v2


### PR DESCRIPTION
## Description

The CI workflow was silently failing on every push to `main` due to two issues:

1. **`actions/checkout@v6` does not exist** — both the `ci` and `cd` jobs referenced this non-existent version, causing GitHub Actions to error out before running any steps. Fixed to `@v4`.
2. **No frontend CI** — the `ci` job only ran `dotnet build` / `dotnet test`, so the Vite/React portal was never built or tested in CI. Added Node 22 setup, `npm ci`, `npm run build`, and `npm test -- --run` steps after the .NET steps.

## Linked Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

After merging, the next push to `main` should trigger both the backend and portal CI steps successfully.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [x] Branch follows naming convention (`fix/`)