### PR TITLE
Fix 404 on Azure web app by registering frontend as azd service

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -8,3 +8,8 @@ services:
     project: ./src/Herit.Api
     language: csharp
     host: appservice
+  web:
+    project: ./frontend/portal
+    language: js
+    host: appservice
+    dist: dist


### PR DESCRIPTION
## Description

The React/Vite frontend (`frontend/portal`) was missing from `azure.yaml`, so `azd deploy` only pushed the .NET API — never the frontend. The web App Service (`app-web-*`) was provisioned by Bicep with `pm2 serve --spa` as its startup command but had no content, resulting in a 404 on every route.

This PR adds the `web` service entry to `azure.yaml` so that `azd deploy` builds and deploys the frontend bundle to the web App Service alongside the API.

## Linked Issue

N/A — diagnosed and fixed directly.

## Type of Change

- [x] Bug fix

## Testing Notes

Reproduced locally: browsing the deployed URL returned 404 before this change. After adding the service entry and running `azd deploy web`, the app loads correctly at all routes (`/`, `/rfps`, `/proposals`, etc.).

## Checklist

- [x] Code builds cleanly
- [x] Branch follows naming convention (`fix/`)
- [x] Only `azure.yaml` touched — no application code changed