### PR TITLE
Upgrade checkout and setup-node actions to v6 (Node.js 24)

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -36,7 +36,7 @@ jobs:
         run: dotnet test --configuration Release --no-build
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -66,7 +66,7 @@ jobs:
       AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install azd
         uses: Azure/setup-azd@v2


### PR DESCRIPTION
## Description

Bumps `actions/checkout` and `actions/setup-node` from v4 to v6. The v4 releases run on Node.js 20, which GitHub is deprecating on runners — forced migration to Node.js 24 begins June 2, 2026.

## Type of Change

- [x] Chore / refactor

## Checklist

- [x] Code builds cleanly
- [x] Branch follows naming convention (`chore/`)
- [x] No application code changed