### PR TITLE
Fix blank VITE_* env vars causing '(t ?? []).map is not a function' crash

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -13,3 +13,9 @@ services:
     language: js
     host: appservice
     dist: dist
+    env:
+      VITE_API_BASE_URL: ${VITE_API_BASE_URL}
+      VITE_REDIRECT_URI: ${VITE_REDIRECT_URI}
+      VITE_AZURE_CLIENT_ID: ${VITE_AZURE_CLIENT_ID}
+      VITE_AZURE_TENANT_NAME: ${VITE_AZURE_TENANT_NAME}
+      VITE_API_SCOPE: ${VITE_API_SCOPE}

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -43,7 +43,6 @@ param sqlAdminPassword string
 param appUserPassword string
 param appUser string = 'appUser'
 
-@secure()
 @description('Microsoft Entra External ID client ID for the API app registration')
 param entraClientId string
 
@@ -59,7 +58,6 @@ param entraTenantId string
 @description('Microsoft Entra External ID authority base URL, e.g. https://<tenant>.ciamlogin.com')
 param entraAuthority string
 
-@secure()
 @description('Microsoft Entra External ID tenant domain, e.g. <tenant>.onmicrosoft.com')
 param entraTenant string
 var abbrs = loadJsonContent('./abbreviations.json')
@@ -297,3 +295,10 @@ output API_BASE_URL string = useAPIM ? apimApi.outputs.serviceApiUri : api.outpu
 output REACT_APP_WEB_BASE_URL string = web.outputs.SERVICE_WEB_URI
 output USE_APIM bool = useAPIM
 output SERVICE_API_ENDPOINTS array = useAPIM ? [apimApi.outputs.serviceApiUri, api.outputs.SERVICE_API_URI] : []
+
+// Frontend build-time env vars
+output VITE_API_BASE_URL string = '${api.outputs.SERVICE_API_URI}/api/v1'
+output VITE_REDIRECT_URI string = web.outputs.SERVICE_WEB_URI
+output VITE_AZURE_CLIENT_ID string = entraClientId
+output VITE_AZURE_TENANT_NAME string = split(entraTenant, '.')[0]
+output VITE_API_SCOPE string = 'api://${entraClientId}/access_as_user'


### PR DESCRIPTION
## Description

Vite bakes `import.meta.env.*` values into the JS bundle **at build time**. The CD pipeline was running `azd deploy` (which runs `npm run build`) without any `VITE_*` variables set, so in production:

- `VITE_API_BASE_URL` was `undefined` → axios had no `baseURL` → every API call hit the web app itself → pm2's `--spa` mode returned `index.html` → an HTML string failed `.map()` → crash
- Auth config (`VITE_AZURE_CLIENT_ID`, `VITE_AZURE_TENANT_NAME`, `VITE_API_SCOPE`, `VITE_REDIRECT_URI`) was also blank

## Changes

- **`infra/main.bicep`**: Adds five `VITE_*` outputs computed from already-available values (API URI, web URI, Entra client ID/tenant). Also removes `@secure()` from `entraClientId` and `entraTenant` — they're public OAuth values that are visible in the JS bundle anyway; the linter was correctly flagging them as misclassified.
- **`azure.yaml`**: Adds an `env` section to the `web` service that maps those bicep outputs into the environment when azd runs `npm run build`.

## Linked Issue

N/A — diagnosed directly from the browser error.

## Type of Change

- [x] Bug fix

## Testing Notes

After `azd provision` + `azd deploy`, the five `VITE_*` values will be resolved from the bicep outputs and embedded in the bundle. The app should load without errors and point to the correct API.

## Checklist

- [x] Code builds cleanly
- [x] Branch follows naming convention (`fix/`)
- [x] No application logic changed — infra and deployment config only