### PR TITLE
Fix MSAL endpoints_resolution_error for Entra External ID (CIAM)

### DIFF
--- a/frontend/portal/src/auth/msalConfig.ts
+++ b/frontend/portal/src/auth/msalConfig.ts
@@ -4,6 +4,7 @@ export const msalConfig: Configuration = {
   auth: {
     clientId: import.meta.env.VITE_AZURE_CLIENT_ID,
     authority: `https://${import.meta.env.VITE_AZURE_TENANT_NAME}.ciamlogin.com/${import.meta.env.VITE_AZURE_TENANT_NAME}.onmicrosoft.com/`,
+    knownAuthorities: [`${import.meta.env.VITE_AZURE_TENANT_NAME}.ciamlogin.com`],
     redirectUri: import.meta.env.VITE_REDIRECT_URI,
     postLogoutRedirectUri: '/',
   },


### PR DESCRIPTION
## Description

MSAL was throwing `ClientAuthError: endpoints_resolution_error` when attempting `loginRedirect` because it could not resolve the OpenID Connect discovery endpoints for the `.ciamlogin.com` authority. This happens because MSAL does not automatically trust non-standard authority domains — it needs an explicit `knownAuthorities` hint to skip validation and fetch the metadata directly.

Added `knownAuthorities: [\`${VITE_AZURE_TENANT_NAME}.ciamlogin.com\`]` to the MSAL config.

## Type of Change

- [x] Bug fix

## Testing Notes

Reproduced locally: without the fix, `loginRedirect` fails immediately with `endpoints_resolution_error`. With the fix, MSAL resolves the authority and proceeds to redirect the user to the Google sign-in page via Entra External ID.

## Checklist

- [x] Code builds cleanly
- [x] Branch follows naming convention (`fix/`)