### PR TITLE
fix: add domainHint to skip identity provider picker on sign-in

### DIFF
--- a/frontend/portal/src/pages/public/SignInPage.tsx
+++ b/frontend/portal/src/pages/public/SignInPage.tsx
@@ -16,7 +16,7 @@ export default function SignInPage() {
 
   const handleSignIn = async () => {
     try {
-      await instance.loginRedirect({ scopes: apiScopes });
+      await instance.loginRedirect({ scopes: apiScopes, domainHint: 'google.com' });
     } catch (error) {
       console.error('[Herit] loginRedirect failed:', error);
     }


### PR DESCRIPTION
## Description

Adds `domainHint: 'google.com'` to the `loginRedirect` call in `SignInPage`. This tells MSAL to bypass the identity provider selection screen and route the user directly to Google sign-in, matching the app's Google-only auth UX.

## Type of Change

- [x] Bug fix

## Testing Notes

Manually verified that clicking "Sign in with Google" now redirects directly to the Google login page without showing an intermediate account picker or provider selection screen.

## Checklist

- [x] Branch follows naming convention (`fix/`)
- [x] Change is minimal and scoped to the reported behaviour