### PR TITLE
Fix CIAM authority path using subdomain from entraAuthority

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -62,6 +62,12 @@ param entraTenant string
 var abbrs = loadJsonContent('./abbreviations.json')
 var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
 var tags = { 'azd-env-name': environmentName }
+// Derive the CIAM subdomain from entraAuthority (e.g. "heritdomain" from
+// "https://heritdomain.ciamlogin.com"). This is the ground truth for the
+// CIAM tenant name. entraTenant may use a GUID-based onmicrosoft.com domain
+// (e.g. "72b4b7c4-…onmicrosoft.com") rather than the friendly subdomain,
+// so we must NOT use entraTenant to derive the CIAM subdomain.
+var ciamSubdomain = split(split(entraAuthority, '//')[1], '.')[0]
 
 // Organize resources in a resource group
 resource rg 'Microsoft.Resources/resourceGroups@2021-04-01' = {
@@ -299,6 +305,6 @@ output SERVICE_API_ENDPOINTS array = useAPIM ? [apimApi.outputs.serviceApiUri, a
 output VITE_API_BASE_URL string = '${api.outputs.SERVICE_API_URI}/api/v1'
 output VITE_REDIRECT_URI string = web.outputs.SERVICE_WEB_URI
 output VITE_AZURE_CLIENT_ID string = entraClientId
-output VITE_AZURE_TENANT_NAME string = split(entraTenant, '.')[0]
-output VITE_AZURE_AUTHORITY string = '${entraAuthority}/${entraTenant}/'
+output VITE_AZURE_TENANT_NAME string = ciamSubdomain
+output VITE_AZURE_AUTHORITY string = '${entraAuthority}/${ciamSubdomain}.onmicrosoft.com/'
 output VITE_API_SCOPE string = 'api://${entraClientId}/access_as_user'


### PR DESCRIPTION
## Description

The Network tab revealed the exact broken URL MSAL was trying to reach:

```
https://heritdomain.ciamlogin.com/72b4b7c4-cf1b-45c6-923b-771539cb809c.onmicrosoft.com/v2.0/.well-known/openid-configuration
```

The GUID in the path is the Entra tenant's raw onmicrosoft.com domain (the value of `ENTRA_TENANT` / `entraTenant`). Azure CIAM's OIDC endpoint requires the **friendly subdomain name** in the path, not the GUID form — so the correct URL is:

```
https://heritdomain.ciamlogin.com/heritdomain.onmicrosoft.com/v2.0/.well-known/openid-configuration
```

**Root cause**: `VITE_AZURE_AUTHORITY` and `VITE_AZURE_TENANT_NAME` were both derived from `entraTenant`, which can (and does in this environment) hold a GUID-based domain. The authoritative source for the CIAM subdomain is `entraAuthority` itself — it must already contain the correct friendly subdomain in order for any CIAM URL to work.

**Fix**: Add a `ciamSubdomain` variable that splits the subdomain out of `entraAuthority` (`"heritdomain"` from `"https://heritdomain.ciamlogin.com"`), then use that for both `VITE_AZURE_TENANT_NAME` and the path in `VITE_AZURE_AUTHORITY`.

## Linked Issue

Closes #179

## Type of Change

- [x] Bug fix

## Testing Notes

- `npm run build` ✓
- `npm test -- --run` ✓ (5/5)
- Verified by inspecting the OIDC discovery URL in the browser Network tab.

## Checklist

- [x] Code builds cleanly
- [x] Tests pass
- [x] Branch follows naming convention (`fix/`)