### PR TITLE
Reduce Azure dev environment costs (serverless SQL + B1 App Service)

### DIFF
--- a/infra/app/db-avm.bicep
+++ b/infra/app/db-avm.bicep
@@ -37,6 +37,13 @@ module sqlServer 'br/public:avm/res/sql/server:0.2.0' = {
     databases: [
       {
         name: actualDatabaseName
+        sku: {
+          name: 'GP_S_Gen5_1'
+          tier: 'GeneralPurpose'
+        }
+        kind: 'v12.0,user,vcore,serverless'
+        autoPauseDelay: 60
+        minCapacity: '0.5'
       }
     ]
     firewallRules: [

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -202,7 +202,7 @@ module appServicePlan 'br/public:avm/res/web/serverfarm:0.1.0' = {
   params: {
     name: !empty(appServicePlanName) ? appServicePlanName : '${abbrs.webServerFarms}${resourceToken}'
     sku: {
-      name: 'B3'
+      name: 'B1'
       tier: 'Basic'
     }
     location: location


### PR DESCRIPTION
## Description

Reduces the dev environment monthly cost from ~AU\$645 to ~AU\$20–30, well within the AU\$80 budget.

**SQL Database:** Switched from default DTU-based SKU to `GP_S_Gen5_1` (General Purpose Serverless, 1 vCore) with a 60-minute auto-pause delay. Expected cost: AU\$5–15/month.

**App Service Plan:** Downgraded from `B3` to `B1` (Basic). Expected cost: ~AU\$15/month, down from ~AU\$30.

## Linked Issue

Closes #183

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Chore / refactor

## Testing Notes

After redeployment to `rg-herit-dev`, verify:
1. The API health endpoint responds successfully.
2. Azure Cost Analysis forecast is within the AU\$80 budget.

Note: The SQL database will be recreated from scratch on next deployment (in-place DTU→vCore migration is not supported by Azure; dev data loss is acceptable per the issue).

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`chore/`)