### PR TITLE
Revert CFEOI entity to PRD-defined structure

### DIFF
--- a/frontend/portal/src/components/CfeoiCard.tsx
+++ b/frontend/portal/src/components/CfeoiCard.tsx
@@ -1,7 +1,6 @@
 import { Link } from 'react-router-dom';
 import type { Cfeoi } from '../types';
 import StatusBadge from './StatusBadge';
-import SkillChips from './SkillChips';
 
 interface CfeoiCardProps {
   cfeoi: Cfeoi;
@@ -17,9 +16,6 @@ export default function CfeoiCard({ cfeoi, proposalTitle, orgName, compact }: Cf
       <Link to={`/cfeois/${cfeoi.id}`} className="block group">
         <div className="flex flex-col gap-1">
           <span className="text-xs font-medium text-brand uppercase tracking-wider">{cfeoi.title}</span>
-          <h4 className="text-sm font-bold text-gray-900 group-hover:text-brand transition-colors">
-            {cfeoi.roleTitle}
-          </h4>
           <p className="text-xs text-gray-500 line-clamp-2">{cfeoi.description}</p>
         </div>
       </Link>
@@ -34,12 +30,9 @@ export default function CfeoiCard({ cfeoi, proposalTitle, orgName, compact }: Cf
           <span className="px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider bg-gray-100 text-gray-800 rounded">
             {cfeoi.title}
           </span>
-          <span className="text-xs text-gray-500 ml-1">
-            {cfeoi.slots} {cfeoi.slots === 1 ? 'Slot' : 'Slots'}
-          </span>
         </div>
-        <h3 className="text-lg font-bold text-gray-900 mb-1">{cfeoi.roleTitle}</h3>
-        <div className="text-sm text-gray-500 mb-3 flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-4">
+        <p className="text-sm text-gray-600 mb-3">{cfeoi.description}</p>
+        <div className="text-sm text-gray-500 flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-4">
           {orgName && (
             <span className="flex items-center gap-1.5">
               <svg className="w-3.5 h-3.5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -63,29 +56,8 @@ export default function CfeoiCard({ cfeoi, proposalTitle, orgName, compact }: Cf
             </>
           )}
         </div>
-        {cfeoi.skills && <SkillChips skills={cfeoi.skills} />}
       </div>
       <div className="flex flex-col items-start sm:items-end gap-3 min-w-[140px]">
-        {(cfeoi.location || cfeoi.deadline) && (
-          <div className="text-right w-full">
-            {cfeoi.location && (
-              <p className="text-xs text-gray-500 mb-1">
-                <svg className="w-3 h-3 inline mr-1" fill="currentColor" viewBox="0 0 20 20">
-                  <path fillRule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clipRule="evenodd" />
-                </svg>
-                {cfeoi.location}
-              </p>
-            )}
-            {cfeoi.deadline && (
-              <p className="text-xs text-gray-500">
-                <svg className="w-3 h-3 inline mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                </svg>
-                Closes {new Date(cfeoi.deadline).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
-              </p>
-            )}
-          </div>
-        )}
         <Link
           to={`/cfeois/${cfeoi.id}`}
           className="w-full sm:w-auto px-4 py-2 text-sm font-medium text-white bg-brand rounded-lg hover:bg-brand-dark transition-colors text-center"

--- a/frontend/portal/src/pages/public/CfeoiDetailPage.tsx
+++ b/frontend/portal/src/pages/public/CfeoiDetailPage.tsx
@@ -7,7 +7,6 @@ import { getProposalById } from '../../api/proposals';
 import { apiScopes } from '../../auth/authScopes';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import StatusBadge from '../../components/StatusBadge';
-import SkillChips from '../../components/SkillChips';
 import SidebarCard from '../../components/SidebarCard';
 
 /** Sign In modal shown when unauthenticated user tries to express interest */
@@ -95,8 +94,8 @@ export default function CfeoiDetailPage() {
   if (isError || !cfeoi) {
     return (
       <div className="max-w-[1200px] mx-auto px-6 py-20 text-center">
-        <h2 className="text-2xl font-bold text-gray-900 mb-2">Role not found</h2>
-        <p className="text-gray-600 mb-6">This role may have been removed or is no longer available.</p>
+        <h2 className="text-2xl font-bold text-gray-900 mb-2">Opportunity not found</h2>
+        <p className="text-gray-600 mb-6">This opportunity may have been removed or is no longer available.</p>
         <Link to="/cfeois" className="text-brand hover:underline font-medium">← Back to CFEOI Directory</Link>
       </div>
     );
@@ -121,7 +120,7 @@ export default function CfeoiDetailPage() {
               <li aria-current="page">
                 <div className="flex items-center">
                   <svg className="w-3 h-3 mx-2" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" /></svg>
-                  <span className="text-gray-900 font-medium truncate max-w-[200px] md:max-w-none">{cfeoi.roleTitle}</span>
+                  <span className="text-gray-900 font-medium truncate max-w-[200px] md:max-w-none">{cfeoi.title}</span>
                 </div>
               </li>
             </ol>
@@ -131,7 +130,7 @@ export default function CfeoiDetailPage() {
 
       <div className="max-w-[1200px] mx-auto px-6 py-8">
         <div className="flex flex-col lg:flex-row gap-8">
-          {/* Main Role Column */}
+          {/* Main Column */}
           <div className="w-full lg:w-[70%]">
             <div className="bg-white rounded-xl border border-gray-200 p-8 mb-6 shadow-sm">
               <div className="flex flex-wrap items-center gap-3 mb-4">
@@ -140,59 +139,10 @@ export default function CfeoiDetailPage() {
                   {cfeoi.title}
                 </span>
               </div>
-              <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">{cfeoi.roleTitle}</h1>
-              <div className="flex flex-wrap items-center gap-6 text-sm text-gray-500 pb-6 border-b border-gray-200 mb-6">
-                {cfeoi.location && (
-                  <div className="flex items-center gap-2">
-                    <svg className="w-4 h-4 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
-                      <path fillRule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clipRule="evenodd" />
-                    </svg>
-                    <span>{cfeoi.location}</span>
-                  </div>
-                )}
-                <div className="flex items-center gap-2">
-                  <svg className="w-4 h-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-                  </svg>
-                  <span>{cfeoi.slots} {cfeoi.slots === 1 ? 'Slot' : 'Slots'} Available</span>
-                </div>
-                {cfeoi.deadline && (
-                  <div className="flex items-center gap-2">
-                    <svg className="w-4 h-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                    </svg>
-                    <span>Closes {new Date(cfeoi.deadline).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}</span>
-                  </div>
-                )}
-                {cfeoi.durationWeeks && (
-                  <div className="flex items-center gap-2">
-                    <svg className="w-4 h-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
-                    </svg>
-                    <span>{cfeoi.durationWeeks} weeks</span>
-                  </div>
-                )}
-              </div>
 
               <div className="prose prose-blue max-w-none text-gray-600">
-                <h2 className="text-xl font-bold text-gray-900 mb-4">Role Overview</h2>
+                <h2 className="text-xl font-bold text-gray-900 mb-4">Overview</h2>
                 <p className="mb-6 leading-relaxed">{cfeoi.description}</p>
-
-                {cfeoi.skills && (
-                  <>
-                    <h2 className="text-xl font-bold text-gray-900 mb-4">Required Skills &amp; Expertise</h2>
-                    <div className="mb-8">
-                      <SkillChips skills={cfeoi.skills} />
-                    </div>
-                  </>
-                )}
-
-                {cfeoi.compensation && (
-                  <>
-                    <h2 className="text-xl font-bold text-gray-900 mb-2">Compensation</h2>
-                    <p className="mb-6 leading-relaxed">{cfeoi.compensation}</p>
-                  </>
-                )}
               </div>
             </div>
           </div>

--- a/frontend/portal/src/pages/public/CfeoiDirectoryPage.tsx
+++ b/frontend/portal/src/pages/public/CfeoiDirectoryPage.tsx
@@ -29,9 +29,8 @@ export default function CfeoiDirectoryPage() {
   const filtered = (cfeois ?? []).filter((c) => {
     const query = search.toLowerCase();
     const matchesSearch =
-      c.roleTitle.toLowerCase().includes(query) ||
-      c.skills.toLowerCase().includes(query) ||
-      c.title.toLowerCase().includes(query);
+      c.title.toLowerCase().includes(query) ||
+      c.description.toLowerCase().includes(query);
     const matchesType = resourceTypeFilter === null || c.resourceType === resourceTypeFilter;
     return matchesSearch && matchesType;
   });
@@ -103,7 +102,7 @@ export default function CfeoiDirectoryPage() {
                   type="text"
                   value={search}
                   onChange={(e) => setSearch(e.target.value)}
-                  placeholder="Search by role title or skills…"
+                  placeholder="Search by title or description…"
                   className="w-full pl-10 pr-4 py-2.5 bg-gray-50 border border-transparent rounded-lg text-sm focus:bg-white focus:border-brand focus:ring-1 focus:ring-brand outline-none transition-all"
                 />
               </div>

--- a/frontend/portal/src/types/index.ts
+++ b/frontend/portal/src/types/index.ts
@@ -64,19 +64,11 @@ export interface Proposal {
 
 export interface Cfeoi {
   id: string;
-  title: string; // Short category label (e.g. "Technical Advisory")
+  title: string;
   description: string;
   resourceType: CfeoiResourceType;
   proposalId: string;
   status: CfeoiStatus;
-  roleTitle: string; // Specific role name (e.g. "Blockchain Architect")
-  skills: string; // Comma-separated
-  slots: number;
-  durationWeeks?: number;
-  location?: string;
-  compensation?: string;
-  deadline?: string; // ISO date string (DateOnly from backend)
-  externalLinks?: string;
 }
 
 export interface Eoi {
@@ -109,14 +101,6 @@ export interface PublishCfeoiRequest {
   description: string;
   resourceType: CfeoiResourceType;
   proposalId: string;
-  roleTitle: string;
-  skills: string;
-  slots: number;
-  durationWeeks?: number;
-  location?: string;
-  compensation?: string;
-  deadline?: string;
-  externalLinks?: string;
 }
 
 export interface SubmitEoiRequest {

--- a/src/Herit.Application/Features/Cfeoi/Commands/PublishCfeoi/PublishCfeoiCommand.cs
+++ b/src/Herit.Application/Features/Cfeoi/Commands/PublishCfeoi/PublishCfeoiCommand.cs
@@ -10,15 +10,7 @@ public record PublishCfeoiCommand(
     string Title,
     string Description,
     CfeoiResourceType ResourceType,
-    Guid ProposalId,
-    string RoleTitle,
-    string Skills,
-    int Slots,
-    int? DurationWeeks = null,
-    string? Location = null,
-    string? Compensation = null,
-    DateOnly? Deadline = null,
-    string? ExternalLinks = null) : IRequest<Guid>;
+    Guid ProposalId) : IRequest<Guid>;
 
 public class PublishCfeoiCommandHandler : IRequestHandler<PublishCfeoiCommand, Guid>
 {
@@ -43,15 +35,7 @@ public class PublishCfeoiCommandHandler : IRequestHandler<PublishCfeoiCommand, G
             request.Title,
             request.Description,
             request.ResourceType,
-            request.ProposalId,
-            request.RoleTitle,
-            request.Skills,
-            request.Slots,
-            request.DurationWeeks,
-            request.Location,
-            request.Compensation,
-            request.Deadline,
-            request.ExternalLinks);
+            request.ProposalId);
         await _cfeoiRepository.AddAsync(cfeoi, cancellationToken);
         return id;
     }

--- a/src/Herit.Application/Features/Cfeoi/Commands/PublishCfeoi/PublishCfeoiCommandValidator.cs
+++ b/src/Herit.Application/Features/Cfeoi/Commands/PublishCfeoi/PublishCfeoiCommandValidator.cs
@@ -9,8 +9,5 @@ public class PublishCfeoiCommandValidator : AbstractValidator<PublishCfeoiComman
         RuleFor(x => x.Title).NotEmpty().MaximumLength(256);
         RuleFor(x => x.Description).NotEmpty();
         RuleFor(x => x.ProposalId).NotEqual(Guid.Empty);
-        RuleFor(x => x.RoleTitle).NotEmpty().MaximumLength(256);
-        RuleFor(x => x.Skills).NotEmpty().MaximumLength(1024);
-        RuleFor(x => x.Slots).GreaterThan(0);
     }
 }

--- a/src/Herit.Application/Features/Cfeoi/Commands/UpdateCfeoi/UpdateCfeoiCommand.cs
+++ b/src/Herit.Application/Features/Cfeoi/Commands/UpdateCfeoi/UpdateCfeoiCommand.cs
@@ -9,15 +9,7 @@ public record UpdateCfeoiCommand(
     Guid Id,
     string Title,
     string Description,
-    CfeoiResourceType ResourceType,
-    string RoleTitle,
-    string Skills,
-    int Slots,
-    int? DurationWeeks = null,
-    string? Location = null,
-    string? Compensation = null,
-    DateOnly? Deadline = null,
-    string? ExternalLinks = null) : IRequest<Unit>;
+    CfeoiResourceType ResourceType) : IRequest<Unit>;
 
 public class UpdateCfeoiCommandHandler : IRequestHandler<UpdateCfeoiCommand, Unit>
 {
@@ -37,15 +29,7 @@ public class UpdateCfeoiCommandHandler : IRequestHandler<UpdateCfeoiCommand, Uni
         cfeoi.Update(
             request.Title,
             request.Description,
-            request.ResourceType,
-            request.RoleTitle,
-            request.Skills,
-            request.Slots,
-            request.DurationWeeks,
-            request.Location,
-            request.Compensation,
-            request.Deadline,
-            request.ExternalLinks);
+            request.ResourceType);
 
         await _cfeoiRepository.UpdateAsync(cfeoi, cancellationToken);
         return Unit.Value;

--- a/src/Herit.Application/Features/Cfeoi/Commands/UpdateCfeoi/UpdateCfeoiCommandValidator.cs
+++ b/src/Herit.Application/Features/Cfeoi/Commands/UpdateCfeoi/UpdateCfeoiCommandValidator.cs
@@ -9,8 +9,5 @@ public class UpdateCfeoiCommandValidator : AbstractValidator<UpdateCfeoiCommand>
         RuleFor(x => x.Id).NotEqual(Guid.Empty);
         RuleFor(x => x.Title).NotEmpty().MaximumLength(256);
         RuleFor(x => x.Description).NotEmpty();
-        RuleFor(x => x.RoleTitle).NotEmpty().MaximumLength(256);
-        RuleFor(x => x.Skills).NotEmpty().MaximumLength(1024);
-        RuleFor(x => x.Slots).GreaterThan(0);
     }
 }

--- a/src/Herit.Domain/Entities/Cfeoi.cs
+++ b/src/Herit.Domain/Entities/Cfeoi.cs
@@ -16,14 +16,6 @@ public class Cfeoi
     public CfeoiResourceType ResourceType { get; private set; }
     public Guid ProposalId { get; private set; }
     public CfeoiStatus Status { get; private set; }
-    public string RoleTitle { get; private set; } = default!;
-    public string Skills { get; private set; } = default!;
-    public int Slots { get; private set; }
-    public int? DurationWeeks { get; private set; }
-    public string? Location { get; private set; }
-    public string? Compensation { get; private set; }
-    public DateOnly? Deadline { get; private set; }
-    public string? ExternalLinks { get; private set; }
 
     private Cfeoi() { }
 
@@ -32,15 +24,7 @@ public class Cfeoi
         string title,
         string description,
         CfeoiResourceType resourceType,
-        Guid proposalId,
-        string roleTitle,
-        string skills,
-        int slots,
-        int? durationWeeks = null,
-        string? location = null,
-        string? compensation = null,
-        DateOnly? deadline = null,
-        string? externalLinks = null)
+        Guid proposalId)
     {
         return new Cfeoi
         {
@@ -50,41 +34,17 @@ public class Cfeoi
             ResourceType = resourceType,
             ProposalId = proposalId,
             Status = CfeoiStatus.Open,
-            RoleTitle = roleTitle,
-            Skills = skills,
-            Slots = slots,
-            DurationWeeks = durationWeeks,
-            Location = location,
-            Compensation = compensation,
-            Deadline = deadline,
-            ExternalLinks = externalLinks
         };
     }
 
     public void Update(
         string title,
         string description,
-        CfeoiResourceType resourceType,
-        string roleTitle,
-        string skills,
-        int slots,
-        int? durationWeeks = null,
-        string? location = null,
-        string? compensation = null,
-        DateOnly? deadline = null,
-        string? externalLinks = null)
+        CfeoiResourceType resourceType)
     {
         Title = title;
         Description = description;
         ResourceType = resourceType;
-        RoleTitle = roleTitle;
-        Skills = skills;
-        Slots = slots;
-        DurationWeeks = durationWeeks;
-        Location = location;
-        Compensation = compensation;
-        Deadline = deadline;
-        ExternalLinks = externalLinks;
     }
 
     public void TransitionStatus(CfeoiStatus newStatus)

--- a/src/Herit.Infrastructure/Migrations/20260413052903_RemoveCfeoiOpportunityFields.Designer.cs
+++ b/src/Herit.Infrastructure/Migrations/20260413052903_RemoveCfeoiOpportunityFields.Designer.cs
@@ -4,6 +4,7 @@ using Herit.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Herit.Infrastructure.Migrations
 {
     [DbContext(typeof(HeritDbContext))]
-    partial class HeritDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260413052903_RemoveCfeoiOpportunityFields")]
+    partial class RemoveCfeoiOpportunityFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Herit.Infrastructure/Migrations/20260413052903_RemoveCfeoiOpportunityFields.cs
+++ b/src/Herit.Infrastructure/Migrations/20260413052903_RemoveCfeoiOpportunityFields.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Herit.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveCfeoiOpportunityFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Compensation",
+                table: "Cfeois");
+
+            migrationBuilder.DropColumn(
+                name: "Deadline",
+                table: "Cfeois");
+
+            migrationBuilder.DropColumn(
+                name: "DurationWeeks",
+                table: "Cfeois");
+
+            migrationBuilder.DropColumn(
+                name: "ExternalLinks",
+                table: "Cfeois");
+
+            migrationBuilder.DropColumn(
+                name: "Location",
+                table: "Cfeois");
+
+            migrationBuilder.DropColumn(
+                name: "RoleTitle",
+                table: "Cfeois");
+
+            migrationBuilder.DropColumn(
+                name: "Skills",
+                table: "Cfeois");
+
+            migrationBuilder.DropColumn(
+                name: "Slots",
+                table: "Cfeois");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Compensation",
+                table: "Cfeois",
+                type: "nvarchar(512)",
+                maxLength: 512,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "Deadline",
+                table: "Cfeois",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "DurationWeeks",
+                table: "Cfeois",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ExternalLinks",
+                table: "Cfeois",
+                type: "nvarchar(2048)",
+                maxLength: 2048,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Location",
+                table: "Cfeois",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "RoleTitle",
+                table: "Cfeois",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Skills",
+                table: "Cfeois",
+                type: "nvarchar(1024)",
+                maxLength: 1024,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<int>(
+                name: "Slots",
+                table: "Cfeois",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+    }
+}

--- a/src/Herit.Infrastructure/Persistence/Configurations/CfeoiConfiguration.cs
+++ b/src/Herit.Infrastructure/Persistence/Configurations/CfeoiConfiguration.cs
@@ -30,26 +30,6 @@ public class CfeoiConfiguration : IEntityTypeConfiguration<Cfeoi>
             .IsRequired()
             .HasConversion<int>();
 
-        builder.Property(c => c.RoleTitle)
-            .IsRequired()
-            .HasMaxLength(256);
-
-        builder.Property(c => c.Skills)
-            .IsRequired()
-            .HasMaxLength(1024);
-
-        builder.Property(c => c.Slots)
-            .IsRequired();
-
-        builder.Property(c => c.Location)
-            .HasMaxLength(256);
-
-        builder.Property(c => c.Compensation)
-            .HasMaxLength(512);
-
-        builder.Property(c => c.ExternalLinks)
-            .HasMaxLength(2048);
-
         builder.HasOne<Proposal>()
             .WithMany()
             .HasForeignKey(c => c.ProposalId)

--- a/tests/Herit.Application.Tests/Features/Cfeoi/Commands/PublishCfeoiCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Cfeoi/Commands/PublishCfeoiCommandHandlerTests.cs
@@ -20,7 +20,7 @@ public class PublishCfeoiCommandHandlerTests
     }
 
     private static PublishCfeoiCommand BuildCommand(Guid proposalId) =>
-        new("CFEOI Title", "Description", CfeoiResourceType.Human, proposalId, "Engineer", "C#", 2);
+        new("CFEOI Title", "Description", CfeoiResourceType.Human, proposalId);
 
     [Fact]
     public async Task Handle_HappyPath_ReturnsValidGuidAndCallsAddAsync()
@@ -35,10 +35,7 @@ public class PublishCfeoiCommandHandlerTests
         await _cfeoiRepository.Received(1).AddAsync(
             Arg.Is<CfeoiEntity>(c =>
                 c.Title == "CFEOI Title" &&
-                c.ProposalId == proposalId &&
-                c.RoleTitle == "Engineer" &&
-                c.Skills == "C#" &&
-                c.Slots == 2),
+                c.ProposalId == proposalId),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/Herit.Application.Tests/Features/Cfeoi/Commands/UpdateCfeoiCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Cfeoi/Commands/UpdateCfeoiCommandHandlerTests.cs
@@ -18,7 +18,7 @@ public class UpdateCfeoiCommandHandlerTests
     }
 
     private static CfeoiEntity CreateCfeoi(Guid id) =>
-        CfeoiEntity.Create(id, "Original Title", "Original Desc", CfeoiResourceType.Human, Guid.NewGuid(), "Dev", "C#", 1);
+        CfeoiEntity.Create(id, "Original Title", "Original Desc", CfeoiResourceType.Human, Guid.NewGuid());
 
     [Fact]
     public async Task Handle_HappyPath_UpdatesFieldsAndCallsUpdateAsync()
@@ -27,9 +27,7 @@ public class UpdateCfeoiCommandHandlerTests
         var cfeoi = CreateCfeoi(id);
         _cfeoiRepository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(cfeoi);
 
-        var command = new UpdateCfeoiCommand(
-            id, "New Title", "New Desc", CfeoiResourceType.NonHuman,
-            "Analyst", "Python", 3, DurationWeeks: 4, Location: "Remote");
+        var command = new UpdateCfeoiCommand(id, "New Title", "New Desc", CfeoiResourceType.NonHuman);
 
         var result = await _handler.Handle(command, CancellationToken.None);
 
@@ -37,11 +35,6 @@ public class UpdateCfeoiCommandHandlerTests
         Assert.Equal("New Title", cfeoi.Title);
         Assert.Equal("New Desc", cfeoi.Description);
         Assert.Equal(CfeoiResourceType.NonHuman, cfeoi.ResourceType);
-        Assert.Equal("Analyst", cfeoi.RoleTitle);
-        Assert.Equal("Python", cfeoi.Skills);
-        Assert.Equal(3, cfeoi.Slots);
-        Assert.Equal(4, cfeoi.DurationWeeks);
-        Assert.Equal("Remote", cfeoi.Location);
         await _cfeoiRepository.Received(1).UpdateAsync(cfeoi, Arg.Any<CancellationToken>());
     }
 
@@ -51,7 +44,7 @@ public class UpdateCfeoiCommandHandlerTests
         var id = Guid.NewGuid();
         _cfeoiRepository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((CfeoiEntity?)null);
 
-        var command = new UpdateCfeoiCommand(id, "T", "D", CfeoiResourceType.Human, "R", "S", 1);
+        var command = new UpdateCfeoiCommand(id, "T", "D", CfeoiResourceType.Human);
 
         await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
         await _cfeoiRepository.DidNotReceive().UpdateAsync(Arg.Any<CfeoiEntity>(), Arg.Any<CancellationToken>());

--- a/tests/Herit.Application.Tests/Features/Cfeoi/Commands/UpdateCfeoiStatusCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Cfeoi/Commands/UpdateCfeoiStatusCommandHandlerTests.cs
@@ -18,7 +18,7 @@ public class UpdateCfeoiStatusCommandHandlerTests
     }
 
     private static CfeoiEntity CreateOpenCfeoi(Guid id)
-        => CfeoiEntity.Create(id, "Title", "Description", CfeoiResourceType.Human, Guid.NewGuid(), "Engineer", "C#", 1);
+        => CfeoiEntity.Create(id, "Title", "Description", CfeoiResourceType.Human, Guid.NewGuid());
 
     [Fact]
     public async Task Handle_OpenToClosed_CallsUpdateAsyncOnce()

--- a/tests/Herit.Application.Tests/Features/Cfeoi/Queries/GetCfeoiByIdQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Cfeoi/Queries/GetCfeoiByIdQueryHandlerTests.cs
@@ -21,7 +21,7 @@ public class GetCfeoiByIdQueryHandlerTests
     public async Task Handle_CfeoiFound_ReturnsCfeoi()
     {
         var cfeoiId = Guid.NewGuid();
-        var cfeoi = CfeoiEntity.Create(cfeoiId, "Title", "Description", CfeoiResourceType.Human, Guid.NewGuid(), "Engineer", "C#", 1);
+        var cfeoi = CfeoiEntity.Create(cfeoiId, "Title", "Description", CfeoiResourceType.Human, Guid.NewGuid());
         _cfeoiRepository.GetByIdAsync(cfeoiId, Arg.Any<CancellationToken>()).Returns(cfeoi);
 
         var result = await _handler.Handle(new GetCfeoiByIdQuery(cfeoiId), CancellationToken.None);

--- a/tests/Herit.Application.Tests/Features/Cfeoi/Queries/ListCfeois/ListCfeoisQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Cfeoi/Queries/ListCfeois/ListCfeoisQueryHandlerTests.cs
@@ -21,9 +21,9 @@ public class ListCfeoisQueryHandlerTests
     {
         var cfeois = new[]
         {
-            CfeoiEntity.Create(Guid.NewGuid(), "Title 1", "Description 1", CfeoiResourceType.Human, Guid.NewGuid(), "R", "S", 1),
-            CfeoiEntity.Create(Guid.NewGuid(), "Title 2", "Description 2", CfeoiResourceType.NonHuman, Guid.NewGuid(), "R", "S", 1),
-            CfeoiEntity.Create(Guid.NewGuid(), "Title 3", "Description 3", CfeoiResourceType.Human, Guid.NewGuid(), "R", "S", 1)
+            CfeoiEntity.Create(Guid.NewGuid(), "Title 1", "Description 1", CfeoiResourceType.Human, Guid.NewGuid()),
+            CfeoiEntity.Create(Guid.NewGuid(), "Title 2", "Description 2", CfeoiResourceType.NonHuman, Guid.NewGuid()),
+            CfeoiEntity.Create(Guid.NewGuid(), "Title 3", "Description 3", CfeoiResourceType.Human, Guid.NewGuid())
         };
         _cfeoiRepository.ListAsync(null, null, Arg.Any<CancellationToken>()).Returns(cfeois);
 
@@ -38,7 +38,7 @@ public class ListCfeoisQueryHandlerTests
         var proposalId = Guid.NewGuid();
         var cfeois = new[]
         {
-            CfeoiEntity.Create(Guid.NewGuid(), "Open CFEOI", "Description", CfeoiResourceType.Human, proposalId, "R", "S", 1)
+            CfeoiEntity.Create(Guid.NewGuid(), "Open CFEOI", "Description", CfeoiResourceType.Human, proposalId)
         };
         _cfeoiRepository.ListAsync(CfeoiStatus.Open, null, Arg.Any<CancellationToken>()).Returns(cfeois);
 
@@ -54,8 +54,8 @@ public class ListCfeoisQueryHandlerTests
         var proposalId = Guid.NewGuid();
         var cfeois = new[]
         {
-            CfeoiEntity.Create(Guid.NewGuid(), "Title A", "Description", CfeoiResourceType.Human, proposalId, "R", "S", 1),
-            CfeoiEntity.Create(Guid.NewGuid(), "Title B", "Description", CfeoiResourceType.NonHuman, proposalId, "R", "S", 1)
+            CfeoiEntity.Create(Guid.NewGuid(), "Title A", "Description", CfeoiResourceType.Human, proposalId),
+            CfeoiEntity.Create(Guid.NewGuid(), "Title B", "Description", CfeoiResourceType.NonHuman, proposalId)
         };
         _cfeoiRepository.ListAsync(null, proposalId, Arg.Any<CancellationToken>()).Returns(cfeois);
 

--- a/tests/Herit.Application.Tests/Features/Cfeoi/Queries/ListCfeoisByProposalQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Cfeoi/Queries/ListCfeoisByProposalQueryHandlerTests.cs
@@ -22,8 +22,8 @@ public class ListCfeoisByProposalQueryHandlerTests
         var proposalId = Guid.NewGuid();
         var cfeois = new[]
         {
-            CfeoiEntity.Create(Guid.NewGuid(), "Title 1", "Description 1", CfeoiResourceType.Human, proposalId, "R", "S", 1),
-            CfeoiEntity.Create(Guid.NewGuid(), "Title 2", "Description 2", CfeoiResourceType.NonHuman, proposalId, "R", "S", 1)
+            CfeoiEntity.Create(Guid.NewGuid(), "Title 1", "Description 1", CfeoiResourceType.Human, proposalId),
+            CfeoiEntity.Create(Guid.NewGuid(), "Title 2", "Description 2", CfeoiResourceType.NonHuman, proposalId)
         };
         _cfeoiRepository.ListByProposalAsync(proposalId, Arg.Any<CancellationToken>()).Returns(cfeois);
 

--- a/tests/Herit.Application.Tests/Features/Eoi/Commands/SubmitEoiCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Eoi/Commands/SubmitEoiCommandHandlerTests.cs
@@ -29,7 +29,7 @@ public class SubmitEoiCommandHandlerTests
         _userRepository.GetByIdAsync(submittedById, Arg.Any<CancellationToken>())
             .Returns(UserEntity.Create(submittedById, "ext-1", "user@example.com", "Test User", UserRole.Staff));
         _cfeoiRepository.GetByIdAsync(cfeoiId, Arg.Any<CancellationToken>())
-            .Returns(CfeoiEntity.Create(cfeoiId, "Title", "Desc", CfeoiResourceType.Human, Guid.NewGuid(), "Engineer", "C#", 1));
+            .Returns(CfeoiEntity.Create(cfeoiId, "Title", "Desc", CfeoiResourceType.Human, Guid.NewGuid()));
 
         var command = new SubmitEoiCommand("My message", cfeoiId) with { SubmittedById = submittedById };
 
@@ -73,7 +73,7 @@ public class SubmitEoiCommandHandlerTests
     {
         var submittedById = Guid.NewGuid();
         var cfeoiId = Guid.NewGuid();
-        var closedCfeoi = CfeoiEntity.Create(cfeoiId, "Title", "Desc", CfeoiResourceType.Human, Guid.NewGuid(), "Engineer", "C#", 1);
+        var closedCfeoi = CfeoiEntity.Create(cfeoiId, "Title", "Desc", CfeoiResourceType.Human, Guid.NewGuid());
         closedCfeoi.TransitionStatus(CfeoiStatus.Closed);
         _userRepository.GetByIdAsync(submittedById, Arg.Any<CancellationToken>())
             .Returns(UserEntity.Create(submittedById, "ext-1", "user@example.com", "Test User", UserRole.Staff));

--- a/tests/Herit.Domain.Tests/Entities/CfeoiTests.cs
+++ b/tests/Herit.Domain.Tests/Entities/CfeoiTests.cs
@@ -6,7 +6,7 @@ namespace Herit.Domain.Tests.Entities;
 public class CfeoiTests
 {
     private static Cfeoi CreateOpenCfeoi() =>
-        Cfeoi.Create(Guid.NewGuid(), "Title", "Description", CfeoiResourceType.Human, Guid.NewGuid(), "Engineer", "C#", 2);
+        Cfeoi.Create(Guid.NewGuid(), "Title", "Description", CfeoiResourceType.Human, Guid.NewGuid());
 
     // Create tests
 
@@ -16,10 +16,7 @@ public class CfeoiTests
         var id = Guid.NewGuid();
         var proposalId = Guid.NewGuid();
 
-        var cfeoi = Cfeoi.Create(
-            id, "Title", "Description", CfeoiResourceType.Human, proposalId,
-            "Engineer", "C#, SQL", 3, durationWeeks: 8, location: "Remote",
-            compensation: "Volunteer", deadline: new DateOnly(2026, 6, 1), externalLinks: "https://example.com");
+        var cfeoi = Cfeoi.Create(id, "Title", "Description", CfeoiResourceType.Human, proposalId);
 
         Assert.Equal(id, cfeoi.Id);
         Assert.Equal("Title", cfeoi.Title);
@@ -27,26 +24,6 @@ public class CfeoiTests
         Assert.Equal(CfeoiResourceType.Human, cfeoi.ResourceType);
         Assert.Equal(proposalId, cfeoi.ProposalId);
         Assert.Equal(CfeoiStatus.Open, cfeoi.Status);
-        Assert.Equal("Engineer", cfeoi.RoleTitle);
-        Assert.Equal("C#, SQL", cfeoi.Skills);
-        Assert.Equal(3, cfeoi.Slots);
-        Assert.Equal(8, cfeoi.DurationWeeks);
-        Assert.Equal("Remote", cfeoi.Location);
-        Assert.Equal("Volunteer", cfeoi.Compensation);
-        Assert.Equal(new DateOnly(2026, 6, 1), cfeoi.Deadline);
-        Assert.Equal("https://example.com", cfeoi.ExternalLinks);
-    }
-
-    [Fact]
-    public void Create_OptionalFieldsDefault_ToNull()
-    {
-        var cfeoi = Cfeoi.Create(Guid.NewGuid(), "Title", "Description", CfeoiResourceType.Human, Guid.NewGuid(), "Engineer", "C#", 1);
-
-        Assert.Null(cfeoi.DurationWeeks);
-        Assert.Null(cfeoi.Location);
-        Assert.Null(cfeoi.Compensation);
-        Assert.Null(cfeoi.Deadline);
-        Assert.Null(cfeoi.ExternalLinks);
     }
 
     // Update tests
@@ -56,32 +33,11 @@ public class CfeoiTests
     {
         var cfeoi = CreateOpenCfeoi();
 
-        cfeoi.Update("New Title", "New Desc", CfeoiResourceType.NonHuman, "Analyst", "Python", 5,
-            durationWeeks: 12, location: "Onsite", compensation: "Paid", deadline: new DateOnly(2026, 9, 1), externalLinks: "https://link.com");
+        cfeoi.Update("New Title", "New Desc", CfeoiResourceType.NonHuman);
 
         Assert.Equal("New Title", cfeoi.Title);
         Assert.Equal("New Desc", cfeoi.Description);
         Assert.Equal(CfeoiResourceType.NonHuman, cfeoi.ResourceType);
-        Assert.Equal("Analyst", cfeoi.RoleTitle);
-        Assert.Equal("Python", cfeoi.Skills);
-        Assert.Equal(5, cfeoi.Slots);
-        Assert.Equal(12, cfeoi.DurationWeeks);
-        Assert.Equal("Onsite", cfeoi.Location);
-        Assert.Equal("Paid", cfeoi.Compensation);
-        Assert.Equal(new DateOnly(2026, 9, 1), cfeoi.Deadline);
-        Assert.Equal("https://link.com", cfeoi.ExternalLinks);
-    }
-
-    [Fact]
-    public void Update_ClearsOptionalFieldsWhenNull()
-    {
-        var cfeoi = Cfeoi.Create(Guid.NewGuid(), "T", "D", CfeoiResourceType.Human, Guid.NewGuid(),
-            "Engineer", "C#", 1, durationWeeks: 4, location: "Remote");
-
-        cfeoi.Update("T", "D", CfeoiResourceType.Human, "Engineer", "C#", 1);
-
-        Assert.Null(cfeoi.DurationWeeks);
-        Assert.Null(cfeoi.Location);
     }
 
     // TransitionStatus — legal transitions

--- a/tests/Herit.Infrastructure.Tests/Repositories/CfeoiRepositoryTests.cs
+++ b/tests/Herit.Infrastructure.Tests/Repositories/CfeoiRepositoryTests.cs
@@ -28,10 +28,7 @@ public class CfeoiRepositoryTests : IDisposable
             title,
             "Description",
             CfeoiResourceType.Human,
-            proposalId ?? Guid.NewGuid(),
-            "Engineer",
-            "C#",
-            1);
+            proposalId ?? Guid.NewGuid());
 
     [Fact]
     public async Task GetByIdAsync_ReturnsCfeoi_WhenExists()

--- a/tests/Herit.Infrastructure.Tests/Repositories/EoiRepositoryTests.cs
+++ b/tests/Herit.Infrastructure.Tests/Repositories/EoiRepositoryTests.cs
@@ -29,7 +29,7 @@ public class EoiRepositoryTests : IDisposable
         => Eoi.Create(id ?? Guid.NewGuid(), Guid.NewGuid(), "Message", cfeoiId ?? Guid.NewGuid());
 
     private static Cfeoi CreateCfeoi(Guid? id = null, Guid? proposalId = null)
-        => Cfeoi.Create(id ?? Guid.NewGuid(), "Title", "Description", CfeoiResourceType.Human, proposalId ?? Guid.NewGuid(), "Engineer", "C#", 1);
+        => Cfeoi.Create(id ?? Guid.NewGuid(), "Title", "Description", CfeoiResourceType.Human, proposalId ?? Guid.NewGuid());
 
     [Fact]
     public async Task GetByIdAsync_ReturnsEoi_WhenExists()


### PR DESCRIPTION
## Description

Reverts the `Cfeoi` entity to the five attributes defined in the PRD: `Title`, `Description`, `ResourceType`, `ProposalId`, and `Status`. Removes the non-PRD fields (`RoleTitle`, `Skills`, `Slots`, `DurationWeeks`, `Location`, `Compensation`, `Deadline`, `ExternalLinks`) from the domain entity, commands, validators, EF Core configuration, and all frontend types and components.

## Linked Issue

Closes #185

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Chore / refactor

## Testing Notes

- All 232 tests pass (`dotnet test --configuration Release`)
- EF Core migration `RemoveCfeoiOpportunityFields` drops the 8 columns
- Frontend search in `CfeoiDirectoryPage` updated to search `title` and `description` instead of the removed fields

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`chore/`)