### PR TITLE
Fix local dev setup: CORS, AzureAd config, and public endpoint auth

### DIFF
--- a/src/Herit.Api/Controllers/CfeoiController.cs
+++ b/src/Herit.Api/Controllers/CfeoiController.cs
@@ -20,10 +20,12 @@ public class CfeoiController : ControllerBase
     public CfeoiController(IMediator mediator) => _mediator = mediator;
 
     [HttpGet]
+    [AllowAnonymous]
     public async Task<IActionResult> List([FromQuery] CfeoiStatus? status, [FromQuery] Guid? proposalId, CancellationToken ct)
         => Ok(await _mediator.Send(new ListCfeoisQuery(status, proposalId), ct));
 
     [HttpGet("{id:guid}")]
+    [AllowAnonymous]
     public async Task<IActionResult> GetById(Guid id, CancellationToken ct)
         => Ok(await _mediator.Send(new GetCfeoiByIdQuery(id), ct));
 

--- a/src/Herit.Api/Controllers/OrganisationController.cs
+++ b/src/Herit.Api/Controllers/OrganisationController.cs
@@ -27,10 +27,12 @@ public class OrganisationsController : ControllerBase
     }
 
     [HttpGet]
+    [AllowAnonymous]
     public async Task<IActionResult> ListOrganisations(CancellationToken ct)
         => Ok(await _mediator.Send(new ListOrganisationsQuery(), ct));
 
     [HttpGet("{id:guid}")]
+    [AllowAnonymous]
     public async Task<IActionResult> GetOrganisationById(Guid id, CancellationToken ct)
         => Ok(await _mediator.Send(new GetOrganisationByIdQuery(id), ct));
 

--- a/src/Herit.Api/Controllers/ProposalsController.cs
+++ b/src/Herit.Api/Controllers/ProposalsController.cs
@@ -28,10 +28,12 @@ public class ProposalsController : ControllerBase
     }
 
     [HttpGet]
+    [AllowAnonymous]
     public async Task<IActionResult> List(CancellationToken ct)
         => Ok(await _mediator.Send(new ListProposalsQuery(), ct));
 
     [HttpGet("{id:guid}")]
+    [AllowAnonymous]
     public async Task<IActionResult> GetById(Guid id, CancellationToken ct)
         => Ok(await _mediator.Send(new GetProposalByIdQuery(id), ct));
 

--- a/src/Herit.Api/Controllers/RfpsController.cs
+++ b/src/Herit.Api/Controllers/RfpsController.cs
@@ -26,10 +26,12 @@ public class RfpsController : ControllerBase
     }
 
     [HttpGet]
+    [AllowAnonymous]
     public async Task<IActionResult> List(CancellationToken ct)
         => Ok(await _mediator.Send(new ListRfpsQuery(), ct));
 
     [HttpGet("{id:guid}")]
+    [AllowAnonymous]
     public async Task<IActionResult> GetById(Guid id, CancellationToken ct)
         => Ok(await _mediator.Send(new GetRfpByIdQuery(id), ct));
 

--- a/src/Herit.Api/Program.cs
+++ b/src/Herit.Api/Program.cs
@@ -27,6 +27,13 @@ if (!string.IsNullOrEmpty(keyVaultEndpoint) && !builder.Environment.IsDevelopmen
 
 builder.Services.AddMicrosoftIdentityWebApiAuthentication(builder.Configuration, "AzureAd");
 
+var allowedOrigins = builder.Configuration.GetSection("AllowedOrigins").Get<string[]>() ?? [];
+builder.Services.AddCors(options =>
+    options.AddDefaultPolicy(policy =>
+        policy.WithOrigins(allowedOrigins)
+              .AllowAnyHeader()
+              .AllowAnyMethod()));
+
 builder.Services.AddControllers();
 
 builder.Services.AddMediatR(cfg =>
@@ -90,6 +97,7 @@ if (enableSwagger)
 
 app.UseExceptionHandler();
 app.UseHttpsRedirection();
+app.UseCors();
 app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();

--- a/src/Herit.Api/appsettings.Development.json
+++ b/src/Herit.Api/appsettings.Development.json
@@ -7,5 +7,12 @@
   },
   "Features": {
     "EnableSwagger": true
+  },
+  "AllowedOrigins": [ "http://localhost:5173" ],
+  "AzureAd": {
+    "Instance": "https://heritdomain.ciamlogin.com",
+    "Domain": "heritdomain.onmicrosoft.com",
+    "TenantId": "72b4b7c4-cf1b-45c6-923b-771539cb809c",
+    "ClientId": "9911dbe7-a96f-4ed8-8ec4-8f458e2cd10e"
   }
 }


### PR DESCRIPTION
## Description

Fixes several issues that prevented the frontend from communicating with the backend in a local development environment:

- **CORS**: Added CORS middleware to `Program.cs`, with allowed origins configured via `AllowedOrigins` in `appsettings.Development.json` (set to `http://localhost:5173`)
- **AzureAd config**: Populated `appsettings.Development.json` with the real Entra External ID tenant values so the auth middleware can build a valid authority URL
- **Public endpoint auth**: Added `[AllowAnonymous]` to the public `GET` (list + get-by-id) endpoints on `RfpsController`, `ProposalsController`, `CfeoiController`, and `OrganisationsController` — these back unauthenticated browsing pages in the frontend

## Type of Change

- [x] Bug fix

## Testing Notes

- Verified `curl http://localhost:5141/api/v1/rfps` returns 200 with an empty array
- Verified browser Network tab shows no CORS errors and no 401s on public browse pages
- All 232 unit/integration tests pass

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [x] Branch follows naming convention (`fix/`)