### PR TITLE
Serialize enums as strings in JSON API responses

### DIFF
--- a/src/Herit.Api/Program.cs
+++ b/src/Herit.Api/Program.cs
@@ -34,7 +34,9 @@ builder.Services.AddCors(options =>
               .AllowAnyHeader()
               .AllowAnyMethod()));
 
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+        options.JsonSerializerOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter()));
 
 builder.Services.AddMediatR(cfg =>
     cfg.RegisterServicesFromAssembly(typeof(CreateRfpCommand).Assembly));


### PR DESCRIPTION
## Description

All 8 domain enums (`RfpStatus`, `ProposalStatus`, `CfeoiStatus`, `EoiStatus`, `EoiVisibility`, `ProposalVisibility`, `CfeoiResourceType`, `UserRole`) were being serialized as integers in API responses. This caused the frontend RFP list to show no results, since it correctly filters by `status === 'Published'` but was receiving `status: 2`.

Adds `JsonStringEnumConverter` globally in `Program.cs` so all enums serialize as named strings (e.g. `"Published"` instead of `2`).

## Type of Change

- [x] Bug fix

## Testing Notes

- `curl http://localhost:5141/api/v1/rfps` now returns `"status":"Published"` instead of `"status":2`
- RFP list page now displays the seeded RFP correctly
- All 232 tests pass

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [x] Branch follows naming convention (`fix/`)