### PR TITLE
Fix SQL serverless SKU not applied by AVM module

### DIFF
--- a/infra/app/db-avm.bicep
+++ b/infra/app/db-avm.bicep
@@ -37,13 +37,6 @@ module sqlServer 'br/public:avm/res/sql/server:0.2.0' = {
     databases: [
       {
         name: actualDatabaseName
-        sku: {
-          name: 'GP_S_Gen5_1'
-          tier: 'GeneralPurpose'
-        }
-        kind: 'v12.0,user,vcore,serverless'
-        autoPauseDelay: 60
-        minCapacity: '0.5'
       }
     ]
     firewallRules: [
@@ -54,6 +47,23 @@ module sqlServer 'br/public:avm/res/sql/server:0.2.0' = {
       }
     ]
   }
+}
+
+resource sqlDatabase 'Microsoft.Sql/servers/databases@2022-05-01-preview' = {
+  name: '${sqlServiceName}/${actualDatabaseName}'
+  location: location
+  sku: {
+    name: 'GP_S_Gen5_1'
+    tier: 'GeneralPurpose'
+    capacity: 1
+    family: 'Gen5'
+  }
+  tags: tags
+  properties: {
+    autoPauseDelay: 60
+    minCapacity: json('0.5')
+  }
+  dependsOn: [sqlServer]
 }
 
 module deploymentScript 'br/public:avm/res/resources/deployment-script:0.1.3' = {


### PR DESCRIPTION
## Description

The GP_S_Gen5_1 serverless SKU change from #184 never took effect. The AVM `sql/server:0.2.0` module does not forward database-level SKU properties (`autoPauseDelay`, `minCapacity`, etc.) from its `databases` array to the underlying ARM resource, so the database remained on the provisioned `GP_Gen5_2` tier (~$19.87/day) despite a successful deployment.

This PR adds a direct `Microsoft.Sql/servers/databases` resource to apply the serverless configuration explicitly, fixing:
- `minCapacity` was a string `'0.5'` — must be a decimal number (`json('0.5')`)
- `kind` was set — it's a computed read-only property and should not be specified
- SKU/serverless properties were silently ignored by the AVM module

## Type of Change

- [x] Bug fix

## Testing Notes

Deployment will update the existing database in-place (no data loss). Azure SQL supports SKU changes from provisioned to serverless without recreation.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [x] Branch follows naming convention (`fix/`)