### PR TITLE
Fix Google SSO failing with AADSTS165000 session context error

### DIFF
--- a/frontend/portal/src/auth/msalConfig.ts
+++ b/frontend/portal/src/auth/msalConfig.ts
@@ -15,7 +15,7 @@ export const msalConfig: Configuration = {
   },
   cache: {
     cacheLocation: 'sessionStorage',
-    storeAuthStateInCookie: false,
+    storeAuthStateInCookie: true,
   },
   system: {
     loggerOptions: {


### PR DESCRIPTION
## Description

Enable `storeAuthStateInCookie` in the MSAL browser config. During Google federated sign-in, the redirect chain passes through multiple origins (app → Entra CIAM → Google → Entra → app). Browsers that isolate `sessionStorage` across origins (Safari, and others with strict privacy settings) drop MSAL's stored OAuth state mid-flow, causing Entra to return `AADSTS165000: user session context is empty`. Setting `storeAuthStateInCookie: true` gives MSAL a cookie-based fallback so the nonce and PKCE verifier survive the full redirect chain.

## Linked Issue

N/A — reproduced and diagnosed locally.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

Reproduced the error locally before the fix. After applying, the Google sign-in flow completes successfully. All 232 backend unit tests continue to pass.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`fix/google-sso-msal-auth-state-cookie`)