### PR TITLE
Add free-text tags to CFEOI and RFP

### DIFF
--- a/frontend/portal/src/pages/public/CfeoiDetailPage.tsx
+++ b/frontend/portal/src/pages/public/CfeoiDetailPage.tsx
@@ -144,6 +144,19 @@ export default function CfeoiDetailPage() {
                 <h2 className="text-xl font-bold text-gray-900 mb-4">Overview</h2>
                 <p className="mb-6 leading-relaxed">{cfeoi.description}</p>
               </div>
+
+              {cfeoi.tags && (
+                <div className="mt-4 pt-4 border-t border-gray-100">
+                  <h3 className="text-xs font-bold text-gray-500 uppercase tracking-wider mb-2">Tags</h3>
+                  <div className="flex flex-wrap gap-2">
+                    {cfeoi.tags.split(',').map((tag) => tag.trim()).filter(Boolean).map((tag) => (
+                      <span key={tag} className="px-2 py-1 text-xs font-medium bg-blue-50 text-blue-700 rounded-md">
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
             </div>
           </div>
 

--- a/frontend/portal/src/pages/public/RfpDetailPage.tsx
+++ b/frontend/portal/src/pages/public/RfpDetailPage.tsx
@@ -121,6 +121,19 @@ export default function RfpDetailPage() {
                 <h2 className="text-2xl font-bold text-gray-900 mb-6">Project Overview</h2>
                 <p className="mb-6 leading-relaxed">{rfp.longDescription}</p>
               </div>
+
+              {rfp.tags && (
+                <div className="mt-6 pt-6 border-t border-gray-100">
+                  <h3 className="text-xs font-bold text-gray-500 uppercase tracking-wider mb-2">Tags</h3>
+                  <div className="flex flex-wrap gap-2">
+                    {rfp.tags.split(',').map((tag) => tag.trim()).filter(Boolean).map((tag) => (
+                      <span key={tag} className="px-2 py-1 text-xs font-medium bg-blue-50 text-blue-700 rounded-md">
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
             </div>
 
             {/* Right Sidebar (30%) */}

--- a/frontend/portal/src/types/index.ts
+++ b/frontend/portal/src/types/index.ts
@@ -48,6 +48,7 @@ export interface Rfp {
   status: RfpStatus;
   organisationId: string;
   authorId: string;
+  tags?: string;
 }
 
 export interface Proposal {
@@ -69,6 +70,7 @@ export interface Cfeoi {
   resourceType: CfeoiResourceType;
   proposalId: string;
   status: CfeoiStatus;
+  tags?: string;
 }
 
 export interface Eoi {
@@ -101,6 +103,22 @@ export interface PublishCfeoiRequest {
   description: string;
   resourceType: CfeoiResourceType;
   proposalId: string;
+  tags?: string;
+}
+
+export interface CreateRfpRequest {
+  title: string;
+  shortDescription: string;
+  organisationId: string;
+  longDescription: string;
+  tags?: string;
+}
+
+export interface UpdateRfpRequest {
+  title: string;
+  shortDescription: string;
+  longDescription: string;
+  tags?: string;
 }
 
 export interface SubmitEoiRequest {

--- a/src/Herit.Application/Features/Cfeoi/Commands/PublishCfeoi/PublishCfeoiCommand.cs
+++ b/src/Herit.Application/Features/Cfeoi/Commands/PublishCfeoi/PublishCfeoiCommand.cs
@@ -10,7 +10,8 @@ public record PublishCfeoiCommand(
     string Title,
     string Description,
     CfeoiResourceType ResourceType,
-    Guid ProposalId) : IRequest<Guid>;
+    Guid ProposalId,
+    string? Tags = null) : IRequest<Guid>;
 
 public class PublishCfeoiCommandHandler : IRequestHandler<PublishCfeoiCommand, Guid>
 {
@@ -35,7 +36,8 @@ public class PublishCfeoiCommandHandler : IRequestHandler<PublishCfeoiCommand, G
             request.Title,
             request.Description,
             request.ResourceType,
-            request.ProposalId);
+            request.ProposalId,
+            request.Tags);
         await _cfeoiRepository.AddAsync(cfeoi, cancellationToken);
         return id;
     }

--- a/src/Herit.Application/Features/Cfeoi/Commands/UpdateCfeoi/UpdateCfeoiCommand.cs
+++ b/src/Herit.Application/Features/Cfeoi/Commands/UpdateCfeoi/UpdateCfeoiCommand.cs
@@ -9,7 +9,8 @@ public record UpdateCfeoiCommand(
     Guid Id,
     string Title,
     string Description,
-    CfeoiResourceType ResourceType) : IRequest<Unit>;
+    CfeoiResourceType ResourceType,
+    string? Tags = null) : IRequest<Unit>;
 
 public class UpdateCfeoiCommandHandler : IRequestHandler<UpdateCfeoiCommand, Unit>
 {
@@ -29,7 +30,8 @@ public class UpdateCfeoiCommandHandler : IRequestHandler<UpdateCfeoiCommand, Uni
         cfeoi.Update(
             request.Title,
             request.Description,
-            request.ResourceType);
+            request.ResourceType,
+            request.Tags);
 
         await _cfeoiRepository.UpdateAsync(cfeoi, cancellationToken);
         return Unit.Value;

--- a/src/Herit.Application/Features/Rfp/Commands/CreateRfp/CreateRfpCommand.cs
+++ b/src/Herit.Application/Features/Rfp/Commands/CreateRfp/CreateRfpCommand.cs
@@ -9,7 +9,8 @@ public record CreateRfpCommand(
     string Title,
     string ShortDescription,
     Guid OrganisationId,
-    string LongDescription) : IRequest<Guid>
+    string LongDescription,
+    string? Tags = null) : IRequest<Guid>
 {
     public Guid AuthorId { get; init; }
 }
@@ -41,7 +42,7 @@ public class CreateRfpCommandHandler : IRequestHandler<CreateRfpCommand, Guid>
             throw new NotFoundException($"Organisation '{request.OrganisationId}' does not exist.");
 
         var id = Guid.NewGuid();
-        var rfp = RfpEntity.Create(id, request.Title, request.ShortDescription, request.AuthorId, request.OrganisationId, request.LongDescription);
+        var rfp = RfpEntity.Create(id, request.Title, request.ShortDescription, request.AuthorId, request.OrganisationId, request.LongDescription, request.Tags);
         await _rfpRepository.AddAsync(rfp, cancellationToken);
         return id;
     }

--- a/src/Herit.Application/Features/Rfp/Commands/UpdateRfp/UpdateRfpCommand.cs
+++ b/src/Herit.Application/Features/Rfp/Commands/UpdateRfp/UpdateRfpCommand.cs
@@ -8,7 +8,8 @@ public record UpdateRfpCommand(
     Guid Id,
     string Title,
     string ShortDescription,
-    string LongDescription) : IRequest<Unit>;
+    string LongDescription,
+    string? Tags = null) : IRequest<Unit>;
 
 public class UpdateRfpCommandHandler : IRequestHandler<UpdateRfpCommand, Unit>
 {
@@ -25,7 +26,7 @@ public class UpdateRfpCommandHandler : IRequestHandler<UpdateRfpCommand, Unit>
         if (rfp is null)
             throw new NotFoundException($"Rfp '{request.Id}' does not exist.");
 
-        rfp.Update(request.Title, request.ShortDescription, request.LongDescription);
+        rfp.Update(request.Title, request.ShortDescription, request.LongDescription, request.Tags);
         await _repository.UpdateAsync(rfp, cancellationToken);
         return Unit.Value;
     }

--- a/src/Herit.Domain/Entities/Cfeoi.cs
+++ b/src/Herit.Domain/Entities/Cfeoi.cs
@@ -16,6 +16,7 @@ public class Cfeoi
     public CfeoiResourceType ResourceType { get; private set; }
     public Guid ProposalId { get; private set; }
     public CfeoiStatus Status { get; private set; }
+    public string? Tags { get; private set; }
 
     private Cfeoi() { }
 
@@ -24,7 +25,8 @@ public class Cfeoi
         string title,
         string description,
         CfeoiResourceType resourceType,
-        Guid proposalId)
+        Guid proposalId,
+        string? tags = null)
     {
         return new Cfeoi
         {
@@ -34,17 +36,20 @@ public class Cfeoi
             ResourceType = resourceType,
             ProposalId = proposalId,
             Status = CfeoiStatus.Open,
+            Tags = tags,
         };
     }
 
     public void Update(
         string title,
         string description,
-        CfeoiResourceType resourceType)
+        CfeoiResourceType resourceType,
+        string? tags = null)
     {
         Title = title;
         Description = description;
         ResourceType = resourceType;
+        Tags = tags;
     }
 
     public void TransitionStatus(CfeoiStatus newStatus)

--- a/src/Herit.Domain/Entities/Rfp.cs
+++ b/src/Herit.Domain/Entities/Rfp.cs
@@ -18,10 +18,11 @@ public class Rfp
     public Guid OrganisationId { get; private set; }
     public string LongDescription { get; private set; } = default!;
     public RfpStatus Status { get; private set; }
+    public string? Tags { get; private set; }
 
     private Rfp() { }
 
-    public static Rfp Create(Guid id, string title, string shortDescription, Guid authorId, Guid organisationId, string longDescription)
+    public static Rfp Create(Guid id, string title, string shortDescription, Guid authorId, Guid organisationId, string longDescription, string? tags = null)
     {
         return new Rfp
         {
@@ -31,15 +32,17 @@ public class Rfp
             AuthorId = authorId,
             OrganisationId = organisationId,
             LongDescription = longDescription,
-            Status = RfpStatus.Draft
+            Status = RfpStatus.Draft,
+            Tags = tags,
         };
     }
 
-    public void Update(string title, string shortDescription, string longDescription)
+    public void Update(string title, string shortDescription, string longDescription, string? tags = null)
     {
         Title = title;
         ShortDescription = shortDescription;
         LongDescription = longDescription;
+        Tags = tags;
     }
 
     public void TransitionStatus(RfpStatus newStatus)

--- a/src/Herit.Infrastructure/Migrations/20260422043813_AddTagsToCfeoiAndRfp.Designer.cs
+++ b/src/Herit.Infrastructure/Migrations/20260422043813_AddTagsToCfeoiAndRfp.Designer.cs
@@ -4,6 +4,7 @@ using Herit.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Herit.Infrastructure.Migrations
 {
     [DbContext(typeof(HeritDbContext))]
-    partial class HeritDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260422043813_AddTagsToCfeoiAndRfp")]
+    partial class AddTagsToCfeoiAndRfp
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Herit.Infrastructure/Migrations/20260422043813_AddTagsToCfeoiAndRfp.cs
+++ b/src/Herit.Infrastructure/Migrations/20260422043813_AddTagsToCfeoiAndRfp.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Herit.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTagsToCfeoiAndRfp : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Tags",
+                table: "Rfps",
+                type: "nvarchar(1024)",
+                maxLength: 1024,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Tags",
+                table: "Cfeois",
+                type: "nvarchar(1024)",
+                maxLength: 1024,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Tags",
+                table: "Rfps");
+
+            migrationBuilder.DropColumn(
+                name: "Tags",
+                table: "Cfeois");
+        }
+    }
+}

--- a/src/Herit.Infrastructure/Persistence/Configurations/CfeoiConfiguration.cs
+++ b/src/Herit.Infrastructure/Persistence/Configurations/CfeoiConfiguration.cs
@@ -30,6 +30,9 @@ public class CfeoiConfiguration : IEntityTypeConfiguration<Cfeoi>
             .IsRequired()
             .HasConversion<int>();
 
+        builder.Property(c => c.Tags)
+            .HasMaxLength(1024);
+
         builder.HasOne<Proposal>()
             .WithMany()
             .HasForeignKey(c => c.ProposalId)

--- a/src/Herit.Infrastructure/Persistence/Configurations/RfpConfiguration.cs
+++ b/src/Herit.Infrastructure/Persistence/Configurations/RfpConfiguration.cs
@@ -32,5 +32,8 @@ public class RfpConfiguration : IEntityTypeConfiguration<Rfp>
         builder.Property(r => r.Status)
             .IsRequired()
             .HasConversion<int>();
+
+        builder.Property(r => r.Tags)
+            .HasMaxLength(1024);
     }
 }

--- a/tests/Herit.Application.Tests/Features/Cfeoi/Commands/PublishCfeoiCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Cfeoi/Commands/PublishCfeoiCommandHandlerTests.cs
@@ -19,8 +19,8 @@ public class PublishCfeoiCommandHandlerTests
         _handler = new PublishCfeoiCommandHandler(_cfeoiRepository, _proposalRepository);
     }
 
-    private static PublishCfeoiCommand BuildCommand(Guid proposalId) =>
-        new("CFEOI Title", "Description", CfeoiResourceType.Human, proposalId);
+    private static PublishCfeoiCommand BuildCommand(Guid proposalId, string? tags = null) =>
+        new("CFEOI Title", "Description", CfeoiResourceType.Human, proposalId, tags);
 
     [Fact]
     public async Task Handle_HappyPath_ReturnsValidGuidAndCallsAddAsync()
@@ -29,13 +29,14 @@ public class PublishCfeoiCommandHandlerTests
         _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>())
             .Returns(ProposalEntity.Create(proposalId, "Title", "Short", Guid.NewGuid(), Guid.NewGuid(), "Long"));
 
-        var result = await _handler.Handle(BuildCommand(proposalId), CancellationToken.None);
+        var result = await _handler.Handle(BuildCommand(proposalId, "heritage,culture"), CancellationToken.None);
 
         Assert.NotEqual(Guid.Empty, result);
         await _cfeoiRepository.Received(1).AddAsync(
             Arg.Is<CfeoiEntity>(c =>
                 c.Title == "CFEOI Title" &&
-                c.ProposalId == proposalId),
+                c.ProposalId == proposalId &&
+                c.Tags == "heritage,culture"),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/Herit.Application.Tests/Features/Cfeoi/Commands/UpdateCfeoiCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Cfeoi/Commands/UpdateCfeoiCommandHandlerTests.cs
@@ -27,7 +27,7 @@ public class UpdateCfeoiCommandHandlerTests
         var cfeoi = CreateCfeoi(id);
         _cfeoiRepository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(cfeoi);
 
-        var command = new UpdateCfeoiCommand(id, "New Title", "New Desc", CfeoiResourceType.NonHuman);
+        var command = new UpdateCfeoiCommand(id, "New Title", "New Desc", CfeoiResourceType.NonHuman, "music,dance");
 
         var result = await _handler.Handle(command, CancellationToken.None);
 
@@ -35,6 +35,7 @@ public class UpdateCfeoiCommandHandlerTests
         Assert.Equal("New Title", cfeoi.Title);
         Assert.Equal("New Desc", cfeoi.Description);
         Assert.Equal(CfeoiResourceType.NonHuman, cfeoi.ResourceType);
+        Assert.Equal("music,dance", cfeoi.Tags);
         await _cfeoiRepository.Received(1).UpdateAsync(cfeoi, Arg.Any<CancellationToken>());
     }
 

--- a/tests/Herit.Application.Tests/Features/Rfp/Commands/CreateRfpCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Rfp/Commands/CreateRfpCommandHandlerTests.cs
@@ -31,13 +31,13 @@ public class CreateRfpCommandHandlerTests
         _organisationRepository.GetByIdAsync(organisationId, Arg.Any<CancellationToken>())
             .Returns(OrganisationEntity.Create(organisationId, "Test Org"));
 
-        var command = new CreateRfpCommand("Title", "Short", organisationId, "Long") with { AuthorId = authorId };
+        var command = new CreateRfpCommand("Title", "Short", organisationId, "Long", "heritage,culture") with { AuthorId = authorId };
 
         var result = await _handler.Handle(command, CancellationToken.None);
 
         Assert.NotEqual(Guid.Empty, result);
         await _rfpRepository.Received(1).AddAsync(
-            Arg.Is<RfpEntity>(r => r.Title == "Title" && r.AuthorId == authorId && r.OrganisationId == organisationId),
+            Arg.Is<RfpEntity>(r => r.Title == "Title" && r.AuthorId == authorId && r.OrganisationId == organisationId && r.Tags == "heritage,culture"),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/Herit.Application.Tests/Features/Rfp/Commands/UpdateRfpCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Rfp/Commands/UpdateRfpCommandHandlerTests.cs
@@ -23,13 +23,14 @@ public class UpdateRfpCommandHandlerTests
         var rfp = RfpEntity.Create(id, "Old Title", "Old Short", Guid.NewGuid(), Guid.NewGuid(), "Old Long");
         _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(rfp);
 
-        var command = new UpdateRfpCommand(id, "New Title", "New Short", "New Long");
+        var command = new UpdateRfpCommand(id, "New Title", "New Short", "New Long", "music,dance");
         var result = await _handler.Handle(command, CancellationToken.None);
 
         Assert.Equal(MediatR.Unit.Value, result);
         Assert.Equal("New Title", rfp.Title);
         Assert.Equal("New Short", rfp.ShortDescription);
         Assert.Equal("New Long", rfp.LongDescription);
+        Assert.Equal("music,dance", rfp.Tags);
         await _repository.Received(1).UpdateAsync(rfp, Arg.Any<CancellationToken>());
     }
 

--- a/tests/Herit.Domain.Tests/Entities/CfeoiTests.cs
+++ b/tests/Herit.Domain.Tests/Entities/CfeoiTests.cs
@@ -5,8 +5,8 @@ namespace Herit.Domain.Tests.Entities;
 
 public class CfeoiTests
 {
-    private static Cfeoi CreateOpenCfeoi() =>
-        Cfeoi.Create(Guid.NewGuid(), "Title", "Description", CfeoiResourceType.Human, Guid.NewGuid());
+    private static Cfeoi CreateOpenCfeoi(string? tags = null) =>
+        Cfeoi.Create(Guid.NewGuid(), "Title", "Description", CfeoiResourceType.Human, Guid.NewGuid(), tags);
 
     // Create tests
 
@@ -16,7 +16,7 @@ public class CfeoiTests
         var id = Guid.NewGuid();
         var proposalId = Guid.NewGuid();
 
-        var cfeoi = Cfeoi.Create(id, "Title", "Description", CfeoiResourceType.Human, proposalId);
+        var cfeoi = Cfeoi.Create(id, "Title", "Description", CfeoiResourceType.Human, proposalId, "heritage,culture");
 
         Assert.Equal(id, cfeoi.Id);
         Assert.Equal("Title", cfeoi.Title);
@@ -24,6 +24,15 @@ public class CfeoiTests
         Assert.Equal(CfeoiResourceType.Human, cfeoi.ResourceType);
         Assert.Equal(proposalId, cfeoi.ProposalId);
         Assert.Equal(CfeoiStatus.Open, cfeoi.Status);
+        Assert.Equal("heritage,culture", cfeoi.Tags);
+    }
+
+    [Fact]
+    public void Create_WithNullTags_TagsIsNull()
+    {
+        var cfeoi = CreateOpenCfeoi();
+
+        Assert.Null(cfeoi.Tags);
     }
 
     // Update tests
@@ -33,11 +42,22 @@ public class CfeoiTests
     {
         var cfeoi = CreateOpenCfeoi();
 
-        cfeoi.Update("New Title", "New Desc", CfeoiResourceType.NonHuman);
+        cfeoi.Update("New Title", "New Desc", CfeoiResourceType.NonHuman, "music,dance");
 
         Assert.Equal("New Title", cfeoi.Title);
         Assert.Equal("New Desc", cfeoi.Description);
         Assert.Equal(CfeoiResourceType.NonHuman, cfeoi.ResourceType);
+        Assert.Equal("music,dance", cfeoi.Tags);
+    }
+
+    [Fact]
+    public void Update_WithNullTags_ClearsTags()
+    {
+        var cfeoi = CreateOpenCfeoi(tags: "old-tag");
+
+        cfeoi.Update("Title", "Desc", CfeoiResourceType.Human, null);
+
+        Assert.Null(cfeoi.Tags);
     }
 
     // TransitionStatus — legal transitions

--- a/tests/Herit.Domain.Tests/Entities/RfpTests.cs
+++ b/tests/Herit.Domain.Tests/Entities/RfpTests.cs
@@ -5,8 +5,26 @@ namespace Herit.Domain.Tests.Entities;
 
 public class RfpTests
 {
-    private static Rfp CreateDraftRfp() =>
-        Rfp.Create(Guid.NewGuid(), "Title", "Short", Guid.NewGuid(), Guid.NewGuid(), "Long");
+    private static Rfp CreateDraftRfp(string? tags = null) =>
+        Rfp.Create(Guid.NewGuid(), "Title", "Short", Guid.NewGuid(), Guid.NewGuid(), "Long", tags);
+
+    // Create tests
+
+    [Fact]
+    public void Create_WithTags_SetsTags()
+    {
+        var rfp = CreateDraftRfp(tags: "heritage,culture");
+
+        Assert.Equal("heritage,culture", rfp.Tags);
+    }
+
+    [Fact]
+    public void Create_WithNullTags_TagsIsNull()
+    {
+        var rfp = CreateDraftRfp();
+
+        Assert.Null(rfp.Tags);
+    }
 
     // Update tests
 
@@ -15,11 +33,22 @@ public class RfpTests
     {
         var rfp = CreateDraftRfp();
 
-        rfp.Update("New Title", "New Short", "New Long");
+        rfp.Update("New Title", "New Short", "New Long", "music,dance");
 
         Assert.Equal("New Title", rfp.Title);
         Assert.Equal("New Short", rfp.ShortDescription);
         Assert.Equal("New Long", rfp.LongDescription);
+        Assert.Equal("music,dance", rfp.Tags);
+    }
+
+    [Fact]
+    public void Update_WithNullTags_ClearsTags()
+    {
+        var rfp = CreateDraftRfp(tags: "old-tag");
+
+        rfp.Update("Title", "Short", "Long", null);
+
+        Assert.Null(rfp.Tags);
     }
 
     // TransitionStatus — legal transitions


### PR DESCRIPTION
## Description

Adds an optional comma-separated `Tags` field to both `Cfeoi` and `Rfp` entities, allowing contributors to label CFEOIs and RFP owners to label RFPs with free-text tags. Tags are stored as a nullable `nvarchar(1024)` column — no join table — per the MVP spec in the issue.

## Linked Issue

Closes #195

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Changes

**Domain**: `Cfeoi.Tags` and `Rfp.Tags` properties; `Create` and `Update` methods extended with optional `tags` parameter.

**Application**: `PublishCfeoiCommand`, `UpdateCfeoiCommand`, `CreateRfpCommand`, and `UpdateRfpCommand` each accept an optional `Tags` field passed through to the entity.

**Infrastructure**: `CfeoiConfiguration` and `RfpConfiguration` map `Tags` as `HasMaxLength(1024)`; new migration `AddTagsToCfeoiAndRfp` adds nullable `Tags` column to both tables.

**Frontend**: `Cfeoi`, `Rfp`, and request types in `types/index.ts` include the optional `tags` field. CFEOI and RFP detail pages render tag chips when tags are present.

**Tests**: Domain and application handler tests updated to cover the new field (237 tests, all passing).

## Testing Notes

- `dotnet build --configuration Release` — clean build, 0 warnings
- `dotnet test --configuration Release --no-build` — 237/237 tests pass across all four test projects

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/add-tags-to-cfeoi-and-rfp`)