### PR TITLE
Extend RFP list search to include tags

### DIFF
--- a/docs/frontend/portal/designs/flow1/02-rfp-list.html
+++ b/docs/frontend/portal/designs/flow1/02-rfp-list.html
@@ -84,7 +84,7 @@
                 <div class="flex flex-col md:flex-row gap-4 items-center justify-between bg-surface p-4 rounded-xl border border-border">
                     <div class="relative w-full md:w-2/3">
                         <i class="fa-solid fa-magnifying-glass absolute left-4 top-1/2 -translate-y-1/2 text-gray-400"></i>
-                        <input type="text" placeholder="Search by title or organisation…" class="w-full pl-11 pr-4 py-3 bg-white border border-border rounded-lg text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-shadow">
+                        <input type="text" placeholder="Search by title, organisation, or tags…" class="w-full pl-11 pr-4 py-3 bg-white border border-border rounded-lg text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-shadow">
                     </div>
                     <div class="w-full md:w-auto flex items-center gap-3">
                         <span class="text-sm font-medium text-gray-600 whitespace-nowrap">Sort By:</span>

--- a/frontend/portal/src/pages/public/RfpListPage.tsx
+++ b/frontend/portal/src/pages/public/RfpListPage.tsx
@@ -34,7 +34,8 @@ export default function RfpListPage() {
     const query = search.toLowerCase();
     const matchesSearch =
       rfp.title.toLowerCase().includes(query) ||
-      (orgMap[rfp.organisationId] ?? '').toLowerCase().includes(query);
+      (orgMap[rfp.organisationId] ?? '').toLowerCase().includes(query) ||
+      (rfp.tags ?? '').toLowerCase().includes(query);
     const matchesOrg =
       selectedOrgs.length === 0 || selectedOrgs.includes(orgMap[rfp.organisationId]);
     return matchesSearch && matchesOrg;
@@ -60,7 +61,7 @@ export default function RfpListPage() {
                 type="text"
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
-                placeholder="Search by title or organisation…"
+                placeholder="Search by title, organisation, or tags…"
                 className="w-full pl-11 pr-4 py-3 bg-white border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-brand focus:ring-1 focus:ring-brand transition-shadow"
               />
             </div>


### PR DESCRIPTION
## Description

Extends the client-side search on the RFP List page to match against an RFP's `tags` field in addition to title and organisation name. Also updates the search input placeholder and design mock to reflect the new capability.

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Changes

- `RfpListPage.tsx`: filter predicate now includes `rfp.tags` in the search match; placeholder updated to "Search by title, organisation, or tags…"
- `docs/frontend/portal/designs/flow1/02-rfp-list.html`: design updated to match new placeholder

## Testing Notes

- `dotnet build` — clean, 0 warnings
- `dotnet test` — 237/237 tests pass

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [x] Relevant documentation updated
- [x] Branch follows naming convention (`feature/rfp-search-by-tags`)