### PR TITLE
Align CFEOI directory with backend: search by tags, remove resource type filter

### DIFF
--- a/docs/frontend/portal/designs/flow1/06-cfeoi-directory.html
+++ b/docs/frontend/portal/designs/flow1/06-cfeoi-directory.html
@@ -180,7 +180,7 @@
                   class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                   <i class="fa-solid fa-magnifying-glass text-gray-400"></i>
                 </div><input type="text"
-                  placeholder="Search by role title or skills…"
+                  placeholder="Search by title or tags…"
                   class="w-full pl-10 pr-4 py-2.5 bg-surface border border-transparent rounded-lg text-sm focus:bg-white focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all">
               </div>
               <div class="flex items-center gap-3 w-full sm:w-auto"><span
@@ -206,10 +206,7 @@
                 class="bg-white rounded-xl border border-border p-5 hover:shadow-card transition-shadow flex flex-col sm:flex-row gap-6 items-start sm:items-center justify-between">
                 <div class="flex-grow">
                   <div class="flex flex-wrap items-center gap-2 mb-3"><span
-                      class="px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider bg-blue-100 text-blue-800 rounded">Open</span><span
-                      class="px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider bg-gray-100 text-gray-800 rounded">Technical</span><span
-                      class="text-xs text-text-muted ml-2"><i
-                        class="fa-regular fa-clock mr-1"></i>2 Slots</span>
+                      class="px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider bg-blue-100 text-blue-800 rounded">Open</span>
                   </div>
                   <h3 class="text-lg font-bold text-gray-900 mb-1">Blockchain
                     Architect</h3>
@@ -247,10 +244,7 @@
                 class="bg-white rounded-xl border border-border p-5 hover:shadow-card transition-shadow flex flex-col sm:flex-row gap-6 items-start sm:items-center justify-between">
                 <div class="flex-grow">
                   <div class="flex flex-wrap items-center gap-2 mb-3"><span
-                      class="px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider bg-blue-100 text-blue-800 rounded">Open</span><span
-                      class="px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider bg-gray-100 text-gray-800 rounded">Advisory</span><span
-                      class="text-xs text-text-muted ml-2"><i
-                        class="fa-regular fa-clock mr-1"></i>1 Slot</span></div>
+                      class="px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider bg-blue-100 text-blue-800 rounded">Open</span></div>
                   <h3 class="text-lg font-bold text-gray-900 mb-1">Healthcare
                     Policy Expert</h3>
                   <div
@@ -285,10 +279,7 @@
                 class="bg-white rounded-xl border border-border p-5 hover:shadow-card transition-shadow flex flex-col sm:flex-row gap-6 items-start sm:items-center justify-between">
                 <div class="flex-grow">
                   <div class="flex flex-wrap items-center gap-2 mb-3"><span
-                      class="px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider bg-blue-100 text-blue-800 rounded">Open</span><span
-                      class="px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider bg-gray-100 text-gray-800 rounded">Technical</span><span
-                      class="text-xs text-text-muted ml-2"><i
-                        class="fa-regular fa-clock mr-1"></i>0 Slots</span>
+                      class="px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider bg-blue-100 text-blue-800 rounded">Open</span>
                   </div>
                   <h3 class="text-lg font-bold text-gray-500 mb-1">Data Engineer
                   </h3>

--- a/frontend/portal/src/components/CfeoiCard.tsx
+++ b/frontend/portal/src/components/CfeoiCard.tsx
@@ -22,17 +22,18 @@ export default function CfeoiCard({ cfeoi, proposalTitle, orgName, compact }: Cf
     );
   }
 
+  const tags = cfeoi.tags
+    ? cfeoi.tags.split(',').map((t) => t.trim()).filter(Boolean)
+    : [];
+
   return (
     <div className="bg-white rounded-xl border border-gray-200 p-5 hover:shadow-sm transition-shadow flex flex-col sm:flex-row gap-6 items-start sm:items-center justify-between">
       <div className="flex-grow">
         <div className="flex flex-wrap items-center gap-2 mb-3">
           <StatusBadge type="cfeoi" status={cfeoi.status} />
-          <span className="px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider bg-gray-100 text-gray-800 rounded">
-            {cfeoi.title}
-          </span>
         </div>
-        <p className="text-sm text-gray-600 mb-3">{cfeoi.description}</p>
-        <div className="text-sm text-gray-500 flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-4">
+        <h3 className="text-lg font-bold text-gray-900 mb-1">{cfeoi.title}</h3>
+        <div className="text-sm text-gray-500 flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-4 mb-3">
           {orgName && (
             <span className="flex items-center gap-1.5">
               <svg className="w-3.5 h-3.5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -43,7 +44,7 @@ export default function CfeoiCard({ cfeoi, proposalTitle, orgName, compact }: Cf
           )}
           {proposalTitle && (
             <>
-              <span className="hidden sm:inline text-gray-300">|</span>
+              {orgName && <span className="hidden sm:inline text-gray-300">|</span>}
               <span className="flex items-center gap-1.5">
                 <svg className="w-3.5 h-3.5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
@@ -56,6 +57,15 @@ export default function CfeoiCard({ cfeoi, proposalTitle, orgName, compact }: Cf
             </>
           )}
         </div>
+        {tags.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {tags.map((tag) => (
+              <span key={tag} className="px-2.5 py-1 bg-gray-50 border border-gray-200 rounded-full text-xs text-gray-600">
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
       </div>
       <div className="flex flex-col items-start sm:items-end gap-3 min-w-[140px]">
         <Link

--- a/frontend/portal/src/pages/public/CfeoiDirectoryPage.tsx
+++ b/frontend/portal/src/pages/public/CfeoiDirectoryPage.tsx
@@ -3,14 +3,12 @@ import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { listCfeois } from '../../api/cfeois';
 import { listProposals } from '../../api/proposals';
-import type { CfeoiResourceType } from '../../types';
 import CfeoiCard from '../../components/CfeoiCard';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import EmptyState from '../../components/EmptyState';
 
 export default function CfeoiDirectoryPage() {
   const [search, setSearch] = useState('');
-  const [resourceTypeFilter, setResourceTypeFilter] = useState<CfeoiResourceType | null>(null);
 
   // TODO: replace with server-side filtering once backend supports query parameters
   const { data: cfeois, isLoading, isError } = useQuery({
@@ -28,11 +26,10 @@ export default function CfeoiDirectoryPage() {
 
   const filtered = (cfeois ?? []).filter((c) => {
     const query = search.toLowerCase();
-    const matchesSearch =
+    return (
       c.title.toLowerCase().includes(query) ||
-      c.description.toLowerCase().includes(query);
-    const matchesType = resourceTypeFilter === null || c.resourceType === resourceTypeFilter;
-    return matchesSearch && matchesType;
+      (c.tags ?? '').toLowerCase().includes(query)
+    );
   });
 
   return (
@@ -59,32 +56,26 @@ export default function CfeoiDirectoryPage() {
           {/* Sidebar Filters */}
           <aside className="w-full lg:w-64 flex-shrink-0">
             <div className="bg-white rounded-xl border border-gray-200 p-5 sticky top-24 shadow-sm">
-              <h2 className="text-lg font-bold text-gray-900 mb-6">Filters</h2>
-
-              {/* Resource Type Filter */}
-              <div className="mb-6">
-                <h3 className="text-sm font-semibold text-gray-900 mb-3">Resource Type</h3>
-                <div className="space-y-2">
-                  {(['Human', 'NonHuman'] as CfeoiResourceType[]).map((type) => (
-                    <label key={type} className="flex items-center gap-3 cursor-pointer group">
-                      <input
-                        type="checkbox"
-                        checked={resourceTypeFilter === type}
-                        onChange={() => setResourceTypeFilter(resourceTypeFilter === type ? null : type)}
-                        className="w-4 h-4 rounded border-gray-300 text-brand focus:ring-brand"
-                      />
-                      <span className="text-sm text-gray-700">{type === 'NonHuman' ? 'Non-Human' : type}</span>
-                    </label>
-                  ))}
-                </div>
+              <div className="mb-6 pb-4 border-b border-gray-200 flex items-center justify-between">
+                <h2 className="text-lg font-bold text-gray-900">Filters</h2>
+                <button
+                  onClick={() => setSearch('')}
+                  className="text-sm text-brand hover:underline"
+                >
+                  Clear all
+                </button>
               </div>
 
-              <button
-                onClick={() => { setSearch(''); setResourceTypeFilter(null); }}
-                className="text-sm text-gray-500 hover:text-brand transition-colors"
-              >
-                Clear All Filters
-              </button>
+              {/* Status Filter */}
+              <div>
+                <h3 className="text-sm font-semibold text-gray-900 mb-3">Status</h3>
+                <div className="space-y-2">
+                  <label className="flex items-center gap-3 cursor-pointer group">
+                    <input type="checkbox" checked readOnly className="w-4 h-4 rounded border-gray-300 text-brand focus:ring-brand" />
+                    <span className="text-sm text-gray-700">Open</span>
+                  </label>
+                </div>
+              </div>
             </div>
           </aside>
 
@@ -102,7 +93,7 @@ export default function CfeoiDirectoryPage() {
                   type="text"
                   value={search}
                   onChange={(e) => setSearch(e.target.value)}
-                  placeholder="Search by title or description…"
+                  placeholder="Search by title or tags…"
                   className="w-full pl-10 pr-4 py-2.5 bg-gray-50 border border-transparent rounded-lg text-sm focus:bg-white focus:border-brand focus:ring-1 focus:ring-brand outline-none transition-all"
                 />
               </div>


### PR DESCRIPTION
## Description

Brings the CFEOI Directory page and card into alignment with the backend data model after the Tags field was added in #195. The previous UI exposed a Resource Type ("category") filter and searched on description — neither of which matches the current backend shape.

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Changes

**`CfeoiDirectoryPage.tsx`**
- Removed `resourceTypeFilter` state and the Resource Type sidebar filter
- Updated filter predicate to match on `title` and `tags` (was `title` and `description`)
- Updated search placeholder to "Search by title or tags…"
- Sidebar now shows a Status section (Open only, reflecting current query behaviour)

**`CfeoiCard.tsx`**
- Replaced the title-as-badge pattern with a proper `<h3>` heading
- Removed description paragraph from the full-variant card
- Added tag pill chips rendered from `cfeoi.tags` when present

**`docs/frontend/portal/designs/flow1/06-cfeoi-directory.html`**
- Updated design mock reflecting the same changes

## Testing Notes

- `dotnet build --configuration Release` — 0 warnings
- `dotnet test --configuration Release --no-build` — 237/237 pass

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [x] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`)