### PR TITLE
Display RFP tags in page header as coloured pill badges

### DIFF
--- a/docs/frontend/portal/designs/flow1/03-rfp-detail.html
+++ b/docs/frontend/portal/designs/flow1/03-rfp-detail.html
@@ -125,6 +125,30 @@
               class="font-medium text-gray-900">Ministry of Health</span></div>
           <h1 class="text-4xl font-bold text-gray-900 tracking-tight mb-4">
             Digital Health Records Infrastructure Upgrade</h1>
+          
+                    <!-- RFP Tags -->
+          <div class="flex flex-wrap items-center gap-2">
+            <span class="inline-flex items-center px-3 py-1.5 text-sm font-medium text-blue-800 bg-blue-50 border border-blue-200 rounded-full">
+              <i class="fa-solid fa-tag text-xs mr-2"></i>
+              Advisory
+            </span>
+            <span class="inline-flex items-center px-3 py-1.5 text-sm font-medium text-green-800 bg-green-50 border border-green-200 rounded-full">
+              <i class="fa-solid fa-tag text-xs mr-2"></i>
+              Java Developer
+            </span>
+            <span class="inline-flex items-center px-3 py-1.5 text-sm font-medium text-purple-800 bg-purple-50 border border-purple-200 rounded-full">
+              <i class="fa-solid fa-tag text-xs mr-2"></i>
+              AI Expert
+            </span>
+            <span class="inline-flex items-center px-3 py-1.5 text-sm font-medium text-orange-800 bg-orange-50 border border-orange-200 rounded-full">
+              <i class="fa-solid fa-tag text-xs mr-2"></i>
+              Cloud Architecture
+            </span>
+            <span class="inline-flex items-center px-3 py-1.5 text-sm font-medium text-indigo-800 bg-indigo-50 border border-indigo-200 rounded-full">
+              <i class="fa-solid fa-tag text-xs mr-2"></i>
+              Healthcare IT
+            </span>
+          </div>
         </div>
       </section><!-- Main Content Area -->
       <section id="rfp-detail-content" class="py-12 bg-white">

--- a/frontend/portal/src/pages/public/RfpDetailPage.tsx
+++ b/frontend/portal/src/pages/public/RfpDetailPage.tsx
@@ -107,7 +107,33 @@ export default function RfpDetailPage() {
               <span className="font-medium text-gray-900">{org.name}</span>
             </div>
           )}
-          <h1 className="text-4xl font-bold text-gray-900 tracking-tight">{rfp.title}</h1>
+          <h1 className="text-4xl font-bold text-gray-900 tracking-tight mb-4">{rfp.title}</h1>
+
+          {rfp.tags && (() => {
+            const tagColors = [
+              'text-blue-800 bg-blue-50 border-blue-200',
+              'text-green-800 bg-green-50 border-green-200',
+              'text-purple-800 bg-purple-50 border-purple-200',
+              'text-orange-800 bg-orange-50 border-orange-200',
+              'text-indigo-800 bg-indigo-50 border-indigo-200',
+            ];
+            const tags = rfp.tags.split(',').map((t) => t.trim()).filter(Boolean);
+            return (
+              <div className="flex flex-wrap items-center gap-2">
+                {tags.map((tag, i) => (
+                  <span
+                    key={tag}
+                    className={`inline-flex items-center px-3 py-1.5 text-sm font-medium border rounded-full ${tagColors[i % tagColors.length]}`}
+                  >
+                    <svg className="w-3 h-3 mr-2 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                      <path fillRule="evenodd" d="M17.707 9.293l-7-7A1 1 0 0010 2H4a2 2 0 00-2 2v6a1 1 0 00.293.707l7 7a1 1 0 001.414 0l6-6a1 1 0 000-1.414z" clipRule="evenodd" />
+                    </svg>
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            );
+          })()}
         </div>
       </section>
 
@@ -121,19 +147,6 @@ export default function RfpDetailPage() {
                 <h2 className="text-2xl font-bold text-gray-900 mb-6">Project Overview</h2>
                 <p className="mb-6 leading-relaxed">{rfp.longDescription}</p>
               </div>
-
-              {rfp.tags && (
-                <div className="mt-6 pt-6 border-t border-gray-100">
-                  <h3 className="text-xs font-bold text-gray-500 uppercase tracking-wider mb-2">Tags</h3>
-                  <div className="flex flex-wrap gap-2">
-                    {rfp.tags.split(',').map((tag) => tag.trim()).filter(Boolean).map((tag) => (
-                      <span key={tag} className="px-2 py-1 text-xs font-medium bg-blue-50 text-blue-700 rounded-md">
-                        {tag}
-                      </span>
-                    ))}
-                  </div>
-                </div>
-              )}
             </div>
 
             {/* Right Sidebar (30%) */}


### PR DESCRIPTION
## Description

Moves the RFP tags display from below the "Project Overview" description to the page header section, immediately below the RFP title — matching the updated design. Tags are rendered as pill badges that cycle through five colour variants (blue, green, purple, orange, indigo) with a small tag icon, reading the `tags` field directly from the backend.

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Changes

**`RfpDetailPage.tsx`**
- Tags now appear in the header section below the `<h1>` title
- Styled as coloured pill badges cycling through blue/green/purple/orange/indigo variants with a tag SVG icon
- Removed the previous tags block that appeared below the long description

**`docs/frontend/portal/designs/flow1/03-rfp-detail.html`**
- Updated design mock reflecting the same placement

## Testing Notes

- `dotnet build --configuration Release` — 0 warnings
- `dotnet test --configuration Release --no-build` — 237/237 pass

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [x] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`)