### PR TITLE
Align CFEOI detail page with backend: proper title heading and tags section

### DIFF
--- a/docs/frontend/portal/designs/flow1/07-cfeoi-detail.html
+++ b/docs/frontend/portal/designs/flow1/07-cfeoi-detail.html
@@ -127,8 +127,7 @@
             <div
               class="bg-white rounded-xl border border-border p-8 mb-6 shadow-sm">
               <div class="flex flex-wrap items-center gap-3 mb-4"><span
-                  class="px-3 py-1 text-xs font-bold uppercase tracking-wider bg-blue-100 text-blue-800 rounded-md">Open</span><span
-                  class="px-3 py-1 text-xs font-bold uppercase tracking-wider bg-gray-100 text-gray-800 rounded-md">Technical</span>
+                  class="px-3 py-1 text-xs font-bold uppercase tracking-wider bg-blue-100 text-blue-800 rounded-md">Open</span>
               </div>
               <h1 class="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
                 Blockchain Architect</h1>
@@ -138,15 +137,6 @@
                     class="fa-regular fa-building text-gray-400"></i><span
                     class="font-medium text-gray-700">Ministry of Health</span>
                 </div>
-                <div class="flex items-center gap-2"><i
-                    class="fa-solid fa-location-dot text-gray-400"></i><span>Remote</span>
-                </div>
-                <div class="flex items-center gap-2"><i
-                    class="fa-regular fa-clock text-gray-400"></i><span>2 Slots
-                    Available</span></div>
-                <div class="flex items-center gap-2"><i
-                    class="fa-regular fa-calendar text-gray-400"></i><span>Closes
-                    Oct 30, 2024</span></div>
               </div><!-- Rich Text Content -->
               <div class="prose prose-blue max-w-none text-gray-600">
                 <h2 class="text-xl font-bold text-gray-900 mb-4">Role Overview
@@ -177,8 +167,7 @@
                   <li>Ensure compliance with national data protection
                     regulations and healthcare data standards.</li>
                 </ul>
-                <h2 class="text-xl font-bold text-gray-900 mb-4">Required Skills
-                  &amp; Expertise</h2>
+                <h2 class="text-xl font-bold text-gray-900 mb-4">Tags</h2>
                 <div class="flex flex-wrap gap-3 mb-8"><span
                     class="px-4 py-2 bg-surface border border-border rounded-full text-sm font-medium text-gray-700">Blockchain
                     Architecture</span><span

--- a/frontend/portal/src/pages/public/CfeoiDetailPage.tsx
+++ b/frontend/portal/src/pages/public/CfeoiDetailPage.tsx
@@ -135,28 +135,30 @@ export default function CfeoiDetailPage() {
             <div className="bg-white rounded-xl border border-gray-200 p-8 mb-6 shadow-sm">
               <div className="flex flex-wrap items-center gap-3 mb-4">
                 <StatusBadge type="cfeoi" status={cfeoi.status} />
-                <span className="px-3 py-1 text-xs font-bold uppercase tracking-wider bg-gray-100 text-gray-800 rounded-md">
-                  {cfeoi.title}
-                </span>
               </div>
+
+              <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-6">{cfeoi.title}</h1>
 
               <div className="prose prose-blue max-w-none text-gray-600">
-                <h2 className="text-xl font-bold text-gray-900 mb-4">Overview</h2>
-                <p className="mb-6 leading-relaxed">{cfeoi.description}</p>
-              </div>
+                <h2 className="text-xl font-bold text-gray-900 mb-4">Role Overview</h2>
+                <p className="mb-8 leading-relaxed">{cfeoi.description}</p>
 
-              {cfeoi.tags && (
-                <div className="mt-4 pt-4 border-t border-gray-100">
-                  <h3 className="text-xs font-bold text-gray-500 uppercase tracking-wider mb-2">Tags</h3>
-                  <div className="flex flex-wrap gap-2">
-                    {cfeoi.tags.split(',').map((tag) => tag.trim()).filter(Boolean).map((tag) => (
-                      <span key={tag} className="px-2 py-1 text-xs font-medium bg-blue-50 text-blue-700 rounded-md">
-                        {tag}
-                      </span>
-                    ))}
-                  </div>
-                </div>
-              )}
+                {cfeoi.tags && (() => {
+                  const tags = cfeoi.tags.split(',').map((t) => t.trim()).filter(Boolean);
+                  return tags.length > 0 ? (
+                    <>
+                      <h2 className="text-xl font-bold text-gray-900 mb-4">Tags</h2>
+                      <div className="flex flex-wrap gap-3 mb-8">
+                        {tags.map((tag) => (
+                          <span key={tag} className="px-4 py-2 bg-gray-50 border border-gray-200 rounded-full text-sm font-medium text-gray-700">
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    </>
+                  ) : null;
+                })()}
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION
## Description

Updates the CFEOI detail page to match the revised design and the current backend data model, removing components that had no backend backing and repurposing the skills/expertise area as a Tags section.

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Changes

**`CfeoiDetailPage.tsx`**
- Replaced title-as-gray-badge with a proper `<h1>` heading
- Removed the redundant title badge from the status badge row
- Renamed "Overview" section heading to "Role Overview"
- Tags section elevated to an `<h2>` heading at prose level, rendered as larger rounded pill chips (`px-4 py-2`, `text-sm`) matching the design — was previously small `text-xs` blue chips in a separate below-the-fold section

**`docs/frontend/portal/designs/flow1/07-cfeoi-detail.html`**
- Updated design mock reflecting the same changes

## Testing Notes

- `dotnet build --configuration Release` — 0 warnings
- `dotnet test --configuration Release --no-build` — 237/237 pass

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [x] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`)