### PR TITLE
Fix complete-profile page email display and form submission

### DIFF
--- a/frontend/portal/src/api/users.ts
+++ b/frontend/portal/src/api/users.ts
@@ -12,5 +12,5 @@ export const getUserById = (id: string): Promise<User> =>
 export const getCurrentUser = (): Promise<User> =>
   apiClient.get('/Users/me').then((r) => r.data);
 
-export const updateUserProfile = (id: string, data: Partial<RegisterExpatRequest>): Promise<void> =>
-  apiClient.patch(`/Users/${id}/profile`, data).then((r) => r.data);
+export const updateUserProfile = (data: Partial<RegisterExpatRequest>): Promise<void> =>
+  apiClient.patch('/Users/me/profile', data).then((r) => r.data);

--- a/frontend/portal/src/pages/auth/CompleteProfilePage.tsx
+++ b/frontend/portal/src/pages/auth/CompleteProfilePage.tsx
@@ -18,7 +18,7 @@ export default function CompleteProfilePage() {
 
   const mutation = useMutation({
     mutationFn: () =>
-      updateUserProfile(account?.localAccountId ?? '', {
+      updateUserProfile({
         nationality: nationality || undefined,
         location: location || undefined,
         expertiseTags: expertiseTags || undefined,
@@ -81,7 +81,7 @@ export default function CompleteProfilePage() {
                     <input
                       id="email"
                       type="email"
-                      value={account?.username ?? ''}
+                      value={(account?.idTokenClaims?.email as string) ?? account?.username ?? ''}
                       disabled
                       className="block w-full pl-10 pr-3 py-2.5 border border-gray-200 rounded-xl bg-gray-50 text-gray-500 text-sm cursor-not-allowed focus:outline-none"
                     />

--- a/src/Herit.Api/Controllers/UsersController.cs
+++ b/src/Herit.Api/Controllers/UsersController.cs
@@ -6,6 +6,7 @@ using Herit.Application.Features.User.Commands.UpdateStaffUser;
 using Herit.Application.Features.User.Commands.UpdateUserProfile;
 using Herit.Application.Features.User.Queries.GetUserById;
 using Herit.Application.Features.User.Queries.ListUsers;
+using Herit.Application.Interfaces;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -18,8 +19,25 @@ namespace Herit.Api.Controllers;
 public class UsersController : ControllerBase
 {
     private readonly IMediator _mediator;
+    private readonly ICurrentUserService _currentUserService;
 
-    public UsersController(IMediator mediator) => _mediator = mediator;
+    public UsersController(IMediator mediator, ICurrentUserService currentUserService)
+    {
+        _mediator = mediator;
+        _currentUserService = currentUserService;
+    }
+
+    [HttpGet("me")]
+    public async Task<IActionResult> GetMe(CancellationToken ct)
+        => Ok(await _currentUserService.GetCurrentUserAsync(ct));
+
+    [HttpPatch("me/profile")]
+    public async Task<IActionResult> UpdateMyProfile([FromBody] UpdateUserProfileCommand command, CancellationToken ct)
+    {
+        var user = await _currentUserService.GetCurrentUserAsync(ct);
+        await _mediator.Send(command with { Id = user.Id }, ct);
+        return NoContent();
+    }
 
     [HttpGet]
     [Authorize(Policy = "AdminOrSuperAdmin")]


### PR DESCRIPTION
## Description

Two bugs on the Complete Profile page when signing in via Google:

1. **Wrong email shown**: the email field was populated from `account.username` (MSAL), which Azure AD sets to a synthetic UPN (`{uuid}@tenant.onmicrosoft.com`) for federated Google identities. Fixed by reading the `email` claim from the ID token instead.

2. **"Something went wrong" on submit**: `updateUserProfile` was passing `account.localAccountId` (Azure AD OID) as the user ID to `PATCH /Users/{id}/profile`, but the backend looked up by internal DB GUID — a completely different value, causing a 404. Fixed by adding `GET /Users/me` and `PATCH /Users/me/profile` endpoints that resolve the caller from the JWT via `ICurrentUserService`, so the frontend never needs to pass a user ID.

## Linked Issue

Closes #203

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- Build passes: `dotnet build --configuration Release`
- All 237 tests pass: `dotnet test --configuration Release --no-build`
- Manually verified the complete-profile flow end-to-end with a Google-federated account

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`fix/complete-profile-workflow`)