### PR TITLE
Add unique index on Users.ExternalId

### DIFF
--- a/src/Herit.Infrastructure/Migrations/20260423003634_AddUniqueIndexToUserExternalId.Designer.cs
+++ b/src/Herit.Infrastructure/Migrations/20260423003634_AddUniqueIndexToUserExternalId.Designer.cs
@@ -4,6 +4,7 @@ using Herit.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Herit.Infrastructure.Migrations
 {
     [DbContext(typeof(HeritDbContext))]
-    partial class HeritDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260423003634_AddUniqueIndexToUserExternalId")]
+    partial class AddUniqueIndexToUserExternalId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Herit.Infrastructure/Migrations/20260423003634_AddUniqueIndexToUserExternalId.cs
+++ b/src/Herit.Infrastructure/Migrations/20260423003634_AddUniqueIndexToUserExternalId.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Herit.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUniqueIndexToUserExternalId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_Users_ExternalId",
+                table: "Users",
+                column: "ExternalId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Users_ExternalId",
+                table: "Users");
+        }
+    }
+}

--- a/src/Herit.Infrastructure/Persistence/Configurations/UserConfiguration.cs
+++ b/src/Herit.Infrastructure/Persistence/Configurations/UserConfiguration.cs
@@ -17,6 +17,9 @@ public class UserConfiguration : IEntityTypeConfiguration<User>
             .IsRequired()
             .HasMaxLength(256);
 
+        builder.HasIndex(u => u.ExternalId)
+            .IsUnique();
+
         builder.Property(u => u.Email)
             .IsRequired()
             .HasMaxLength(256);


### PR DESCRIPTION
## Description

A stale row with an empty `ExternalId` caused `CurrentUserService` to fail to recognise the logged-in user on every request (lookup by OID returned nothing, then re-registration was attempted in a loop). The unique index enforces that each Azure AD OID maps to exactly one user record, making this class of bug impossible to reproduce going forward.

Changes:
- `UserConfiguration`: declare `HasIndex(u => u.ExternalId).IsUnique()`
- EF migration: `IX_Users_ExternalId` unique index

The stale dev row was patched directly in the local DB (`ExternalId` set to the correct Azure AD OID).

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- Build passes: `dotnet build --configuration Release`
- All 237 tests pass: `dotnet test --configuration Release --no-build`
- Migration applied cleanly to local SQL Server

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`fix/unique-index-user-external-id`)