### PR TITLE
Fix ProtectedRoute falling through on non-404 errors

### DIFF
--- a/frontend/portal/src/routes/ProtectedRoute.tsx
+++ b/frontend/portal/src/routes/ProtectedRoute.tsx
@@ -23,5 +23,10 @@ export default function ProtectedRoute({ children }: ProtectedRouteProps) {
     return <Navigate to="/auth/complete-profile" replace />;
   }
 
+  // Any other error (e.g. 422, 500) means we cannot verify the user — send to error page
+  if (error) {
+    return <Navigate to="/auth/error" replace />;
+  }
+
   return <>{children}</>;
 }

--- a/frontend/portal/src/routes/ProtectedRoute.tsx
+++ b/frontend/portal/src/routes/ProtectedRoute.tsx
@@ -8,7 +8,7 @@ interface ProtectedRouteProps {
 
 export default function ProtectedRoute({ children }: ProtectedRouteProps) {
   const isAuthenticated = useIsAuthenticated();
-  const { user, isLoading, isNotFound } = useCurrentUser();
+  const { user, isLoading, isNotFound, error } = useCurrentUser();
 
   if (!isAuthenticated) {
     return <Navigate to="/sign-in" replace />;

--- a/src/Herit.Api/Services/CurrentUserService.cs
+++ b/src/Herit.Api/Services/CurrentUserService.cs
@@ -30,10 +30,12 @@ public class CurrentUserService : ICurrentUserService
         var claimsPrincipal = _httpContextAccessor.HttpContext?.User
             ?? throw new UnauthorizedAccessException("No HTTP context available.");
 
+        static string? NonEmpty(string? s) => string.IsNullOrWhiteSpace(s) ? null : s;
+
         var externalId =
-            claimsPrincipal.FindFirst("oid")?.Value
-            ?? claimsPrincipal.FindFirst("http://schemas.microsoft.com/identity/claims/objectidentifier")?.Value
-            ?? claimsPrincipal.FindFirst("sub")?.Value
+            NonEmpty(claimsPrincipal.FindFirst("oid")?.Value)
+            ?? NonEmpty(claimsPrincipal.FindFirst("http://schemas.microsoft.com/identity/claims/objectidentifier")?.Value)
+            ?? NonEmpty(claimsPrincipal.FindFirst("sub")?.Value)
             ?? throw new UnauthorizedAccessException("Subject claim could not be determined.");
 
         var user = await _userRepository.GetByExternalIdAsync(externalId, ct);


### PR DESCRIPTION
## Description

`ProtectedRoute` only handled the 404 case (user not registered). When `GET /Users/me` returned any other error (e.g. 422 Unprocessable Entity from a bad `ExternalId`), `isNotFound` was false and `user` was undefined — so the guard silently fell through and rendered the protected content, producing a blank page with no user data.

Root-cause context: the `AddExternalIdToUser` migration set `defaultValue: ""` for existing rows, and `CurrentUserService` did not filter out empty-string claim values before using them as `ExternalId`. A blank string passed to `RegisterExpatCommand` fails the `NotEmpty` validator with a 422, which `ProtectedRoute` did not handle.

**Changes:**
- `ProtectedRoute`: redirect to `/auth/error` when `useCurrentUser` returns any non-404 error, instead of rendering children
- `CurrentUserService`: treat empty-string claim values as absent when extracting the OID, so an empty `oid`/`sub` claim falls through correctly and throws `UnauthorizedAccessException` rather than being used as `ExternalId`

## Type of Change

- [x] Bug fix

## Testing Notes

- Build passes: `dotnet build --configuration Release`
- All 237 tests pass: `dotnet test --configuration Release --no-build`

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [x] Branch follows naming convention (`fix/protected-route-error-handling`)