### PR TITLE
Handle missing email claim in CIAM access tokens

### DIFF
--- a/frontend/portal/src/pages/auth/CompleteProfilePage.tsx
+++ b/frontend/portal/src/pages/auth/CompleteProfilePage.tsx
@@ -19,6 +19,7 @@ export default function CompleteProfilePage() {
   const mutation = useMutation({
     mutationFn: () =>
       updateUserProfile({
+        email: (account?.idTokenClaims?.email as string) || account?.username || undefined,
         nationality: nationality || undefined,
         location: location || undefined,
         expertiseTags: expertiseTags || undefined,

--- a/src/Herit.Application/Features/User/Commands/RegisterExpat/RegisterExpatCommandValidator.cs
+++ b/src/Herit.Application/Features/User/Commands/RegisterExpat/RegisterExpatCommandValidator.cs
@@ -7,7 +7,7 @@ public class RegisterExpatCommandValidator : AbstractValidator<RegisterExpatComm
     public RegisterExpatCommandValidator()
     {
         RuleFor(x => x.ExternalId).NotEmpty();
-        RuleFor(x => x.Email).NotEmpty().MaximumLength(256);
+        RuleFor(x => x.Email).MaximumLength(256);
         RuleFor(x => x.FullName).NotEmpty().MaximumLength(256);
     }
 }

--- a/src/Herit.Application/Features/User/Commands/UpdateUserProfile/UpdateUserProfileCommand.cs
+++ b/src/Herit.Application/Features/User/Commands/UpdateUserProfile/UpdateUserProfileCommand.cs
@@ -6,6 +6,7 @@ namespace Herit.Application.Features.User.Commands.UpdateUserProfile;
 
 public record UpdateUserProfileCommand(
     Guid Id,
+    string? Email = null,
     string? Nationality = null,
     string? Location = null,
     string? ExpertiseTags = null,
@@ -27,6 +28,7 @@ public class UpdateUserProfileCommandHandler : IRequestHandler<UpdateUserProfile
             throw new NotFoundException($"User with ID '{request.Id}' was not found.");
 
         user.UpdateProfile(
+            request.Email,
             request.Nationality,
             request.Location,
             request.ExpertiseTags,

--- a/src/Herit.Application/Features/User/Commands/UpdateUserProfile/UpdateUserProfileCommandValidator.cs
+++ b/src/Herit.Application/Features/User/Commands/UpdateUserProfile/UpdateUserProfileCommandValidator.cs
@@ -7,6 +7,7 @@ public class UpdateUserProfileCommandValidator : AbstractValidator<UpdateUserPro
     public UpdateUserProfileCommandValidator()
     {
         RuleFor(x => x.Id).NotEqual(Guid.Empty);
+        RuleFor(x => x.Email).MaximumLength(256).When(x => x.Email is not null);
         RuleFor(x => x.Nationality).MaximumLength(128).When(x => x.Nationality is not null);
         RuleFor(x => x.Location).MaximumLength(256).When(x => x.Location is not null);
         RuleFor(x => x.ExpertiseTags).MaximumLength(1024).When(x => x.ExpertiseTags is not null);

--- a/src/Herit.Domain/Entities/User.cs
+++ b/src/Herit.Domain/Entities/User.cs
@@ -51,11 +51,14 @@ public class User
     }
 
     public void UpdateProfile(
+        string? email = null,
         string? nationality = null,
         string? location = null,
         string? expertiseTags = null,
         DateTimeOffset? termsAcceptedAt = null)
     {
+        if (!string.IsNullOrWhiteSpace(email))
+            Email = email;
         Nationality = nationality;
         Location = location;
         ExpertiseTags = expertiseTags;

--- a/tests/Herit.Application.Tests/Features/User/Commands/UpdateUserProfileCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/User/Commands/UpdateUserProfileCommandHandlerTests.cs
@@ -28,7 +28,7 @@ public class UpdateUserProfileCommandHandlerTests
         _userRepository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(user);
         var termsAt = DateTimeOffset.UtcNow;
 
-        var command = new UpdateUserProfileCommand(id, "Australian", "Sydney, AU", "C#,Azure", termsAt);
+        var command = new UpdateUserProfileCommand(id, Nationality: "Australian", Location: "Sydney, AU", ExpertiseTags: "C#,Azure", TermsAcceptedAt: termsAt);
 
         var result = await _handler.Handle(command, CancellationToken.None);
 

--- a/tests/Herit.Domain.Tests/Entities/UserTests.cs
+++ b/tests/Herit.Domain.Tests/Entities/UserTests.cs
@@ -68,7 +68,7 @@ public class UserTests
         var user = User.Create(Guid.NewGuid(), "ext-1", "user@example.com", "Jane Doe", UserRole.Expat);
         var termsAt = DateTimeOffset.UtcNow;
 
-        user.UpdateProfile("Australian", "Sydney, AU", "C#,Azure", termsAt);
+        user.UpdateProfile(nationality: "Australian", location: "Sydney, AU", expertiseTags: "C#,Azure", termsAcceptedAt: termsAt);
 
         Assert.Equal("Australian", user.Nationality);
         Assert.Equal("Sydney, AU", user.Location);
@@ -95,7 +95,7 @@ public class UserTests
     {
         var user = User.Create(Guid.NewGuid(), "ext-1", "user@example.com", "Jane Doe", UserRole.Expat);
 
-        user.UpdateProfile("Australian");
+        user.UpdateProfile(nationality: "Australian");
 
         Assert.Equal("user@example.com", user.Email);
         Assert.Equal("Jane Doe", user.FullName);


### PR DESCRIPTION
## Description

CIAM access tokens do not include the `email` claim — it's only present in ID tokens. `CurrentUserService` fell back to `string.Empty` for the email, which caused `RegisterExpatCommand` to fail with a 422 Validation Failed on every first login, blocking user registration entirely.

**Root cause chain:**
1. CIAM access token has no `email` claim → `CurrentUserService` uses `string.Empty`
2. `RegisterExpatCommandValidator` requires `Email` to be non-empty → 422
3. `ProtectedRoute` treats the 422 as a non-404 error → redirect to `/auth/error`

**Changes:**
- `RegisterExpatCommandValidator`: remove `NotEmpty` from `Email` — auto-registration succeeds even without an email claim in the access token
- `UpdateUserProfileCommand` + `User.UpdateProfile`: add `Email` field so the correct email (read from the MSAL ID token in the frontend) is saved when the user completes their profile
- `CompleteProfilePage`: send `email` from `account.idTokenClaims.email` on profile submit
- Tests updated for the new `email` parameter position

## Type of Change

- [x] Bug fix

## Testing Notes

- Build passes: `dotnet build --configuration Release`
- All 237 tests pass: `dotnet test --configuration Release --no-build`

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [x] Branch follows naming convention (`fix/email-not-in-ciam-access-token`)