### PR TITLE
Fix redirect loop after completing profile

### DIFF
--- a/frontend/portal/src/pages/auth/CompleteProfilePage.tsx
+++ b/frontend/portal/src/pages/auth/CompleteProfilePage.tsx
@@ -26,7 +26,7 @@ export default function CompleteProfilePage() {
         termsAcceptedAt: new Date().toISOString(),
       }),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ['currentUser'] });
+      await queryClient.refetchQueries({ queryKey: ['currentUser'], type: 'all' });
       navigate('/dashboard', { replace: true });
     },
   });


### PR DESCRIPTION
## Description

After successfully submitting the complete-profile form, the user was redirected back to the complete-profile page instead of the dashboard.

**Root cause:** `CompleteProfilePage` doesn't observe the `currentUser` query. Calling `invalidateQueries` just marks it stale without triggering a refetch (no active observers). When `ProtectedRoute` mounted for `/dashboard`, it read the stale cached user (without `termsAcceptedAt`) and immediately redirected back to `/auth/complete-profile` before the background refetch could complete.

**Fix:** Replace `invalidateQueries` with `refetchQueries({ type: 'all' })`, which forces and awaits the refetch regardless of active observers. By the time `navigate('/dashboard')` is called, the cache holds the updated user with `termsAcceptedAt` set.

## Type of Change

- [x] Bug fix

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [x] Branch follows naming convention (`fix/complete-profile-redirect-loop`)