### PR TITLE
Fix CORS rejection on protected API routes in production

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -112,6 +112,7 @@ module api './app/api-appservice-avm.bicep' = {
       AzureAd__Domain: '@Microsoft.KeyVault(VaultName=${keyVault.outputs.name};SecretName=entra-tenant)'
       AzureAd__TenantId: '@Microsoft.KeyVault(VaultName=${keyVault.outputs.name};SecretName=entra-tenant-id)'
       AzureAd__ClientId: '@Microsoft.KeyVault(VaultName=${keyVault.outputs.name};SecretName=entra-client-id)'
+      AllowedOrigins__0: web.outputs.SERVICE_WEB_URI
     }
     appInsightResourceId: monitoring.outputs.applicationInsightsResourceId
     allowedOrigins: [web.outputs.SERVICE_WEB_URI]


### PR DESCRIPTION
## Description

Protected pages (e.g. Create Proposal) were redirecting to `/auth/error` on the Azure deployment. Root cause: `ProtectedRoute` calls `useCurrentUser` which hits `GET /Users/me`. In production, ASP.NET Core's CORS middleware had an empty `AllowedOrigins` array (the config key was never set), so it blocked all cross-origin requests from the frontend — even though Azure App Service's built-in CORS was correctly configured via Bicep.

Fix: add `AllowedOrigins__0` to the API's app settings in `main.bicep`, pointing to the web frontend URI. ASP.NET Core's config system maps `AllowedOrigins__0` to the first element of the `AllowedOrigins` array, so `Program.cs` now receives the correct origin in production.

This is an infra change — `azd provision` must run to apply it (which the CD workflow already does before `azd deploy`).

## Type of Change

- [x] Bug fix

## Testing Notes

Confirmed by inspecting CIAM sign-in logs and tracing the redirect to the empty `AllowedOrigins` config in production. Verified locally that `AllowedOrigins` is correctly read from config.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Branch follows naming convention (`fix/`)