### PR TITLE
Fix incorrect Herit brand icon

### DIFF
--- a/docs/frontend/portal/designs/flow2/01-loading.html
+++ b/docs/frontend/portal/designs/flow2/01-loading.html
@@ -71,11 +71,8 @@
 
             <!-- Brand Header -->
             <header id="brand-header" class="mb-10 relative z-10">
-                <!-- Herit Logo Mark (Civic line-art style) -->
-                <div class="w-16 h-16 mx-auto bg-primary-light rounded-2xl flex items-center justify-center mb-6 shadow-soft border border-primary-blue/10">
-                    <svg class="w-8 h-8 text-primary-blue" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 21v-4m22 4v-4m-9-4h.01M9 20h6a2 2 0 002-2v-8a2 2 0 00-2-2H9a2 2 0 00-2 2v8a2 2 0 002 2zm3-4v.01M12 8v.01M12 4v.01M4 4h16"></path>
-                    </svg>
+                <div class="w-16 h-16 mx-auto bg-brand-500 rounded-2xl flex items-center justify-center text-white font-bold text-5xl shadow-sm mb-6">
+                    H
                 </div>
                 <h1 class="text-2xl font-bold tracking-tight text-text-main">Herit</h1>
                 <p class="text-sm text-text-muted mt-1 font-medium">Civic Engagement Platform</p>

--- a/docs/frontend/portal/designs/flow2/02-auth-error.html
+++ b/docs/frontend/portal/designs/flow2/02-auth-error.html
@@ -57,10 +57,8 @@
         
         <!-- Brand Logo (Outside Card) -->
         <div class="mb-8 flex flex-col items-center">
-            <div class="w-12 h-12 bg-primary-light rounded-xl flex items-center justify-center mb-3 shadow-soft border border-primary-blue/10">
-                <svg class="w-6 h-6 text-primary-blue" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 21v-4m22 4v-4m-9-4h.01M9 20h6a2 2 0 002-2v-8a2 2 0 00-2-2H9a2 2 0 00-2 2v8a2 2 0 002 2zm3-4v.01M12 8v.01M12 4v.01M4 4h16"></path>
-                </svg>
+            <div class="w-12 h-12 bg-brand-500 rounded-xl flex items-center justify-center text-white font-bold text-3xl shadow-sm mb-3">
+                H
             </div>
             <span class="text-xl font-bold tracking-tight text-text-main">Herit</span>
         </div>

--- a/docs/frontend/portal/designs/flow2/03-jit-profile-completion.html
+++ b/docs/frontend/portal/designs/flow2/03-jit-profile-completion.html
@@ -67,10 +67,8 @@
     <header id="header" class="w-full bg-surface-main border-b border-surface-border sticky top-0 z-50">
         <div class="max-w-7xl mx-auto px-6 h-16 flex items-center justify-between">
             <div class="flex items-center gap-3">
-                <div class="w-8 h-8 bg-primary-light rounded-lg flex items-center justify-center border border-primary-blue/10">
-                    <svg class="w-4 h-4 text-primary-blue" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 21v-4m22 4v-4m-9-4h.01M9 20h6a2 2 0 002-2v-8a2 2 0 00-2-2H9a2 2 0 00-2 2v8a2 2 0 002 2zm3-4v.01M12 8v.01M12 4v.01M4 4h16"></path>
-                    </svg>
+                <div class="w-8 h-8 bg-brand-500 rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
+                    H
                 </div>
                 <span class="text-lg font-bold tracking-tight text-text-main">Herit</span>
             </div>

--- a/docs/frontend/portal/designs/flow2/04-dashboard-new-user.html
+++ b/docs/frontend/portal/designs/flow2/04-dashboard-new-user.html
@@ -61,10 +61,8 @@
         <!-- Left Nav -->
         <div class="flex items-center gap-8">
             <a href="#" class="flex items-center gap-2 group">
-                <div class="w-8 h-8 bg-primary-light rounded-lg flex items-center justify-center border border-primary-blue/10 group-hover:bg-primary-blue/10 transition-colors">
-                    <svg class="w-4 h-4 text-primary-blue" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 21v-4m22 4v-4m-9-4h.01M9 20h6a2 2 0 002-2v-8a2 2 0 00-2-2H9a2 2 0 00-2 2v8a2 2 0 002 2zm3-4v.01M12 8v.01M12 4v.01M4 4h16"></path>
-                    </svg>
+                <div class="w-8 h-8 bg-brand-500 rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
+                    H
                 </div>
                 <span class="text-lg font-bold tracking-tight text-text-main group-hover:text-primary-blue transition-colors">Herit</span>
             </a>

--- a/docs/frontend/portal/designs/flow2/05-dashboard-returning-user.html
+++ b/docs/frontend/portal/designs/flow2/05-dashboard-returning-user.html
@@ -91,16 +91,9 @@
       <!-- Left Nav -->
       <div class="flex items-center gap-8"><a href="#"
           class="flex items-center gap-2 group">
-          <div
-            class="w-8 h-8 bg-primary-light rounded-lg flex items-center justify-center border border-primary-blue/10 group-hover:bg-primary-blue/10 transition-colors">
-            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-              class="w-4 h-4 text-primary-blue">
-              <path stroke-linecap="round" stroke-linejoin="round"
-                stroke-width="2"
-                d="M3 21v-4m22 4v-4m-9-4h.01M9 20h6a2 2 0 002-2v-8a2 2 0 00-2-2H9a2 2 0 00-2 2v8a2 2 0 002 2zm3-4v.01M12 8v.01M12 4v.01M4 4h16">
-              </path>
-            </svg></div><span
+          <div class="w-8 h-8 bg-brand-500 rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
+            H
+          </div><span
             class="text-lg font-bold tracking-tight text-text-main group-hover:text-primary-blue transition-colors">Herit</span>
         </a>
         <nav class="hidden md:flex items-center gap-6"><a href="#"

--- a/docs/frontend/portal/designs/flow3c/01-cfeoi-publish-form.html
+++ b/docs/frontend/portal/designs/flow3c/01-cfeoi-publish-form.html
@@ -1,0 +1,311 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        window.FontAwesomeConfig = {
+          autoReplaceSvg: 'nest'
+        };
+      </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/js/all.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Publish CFEOI - Herit Civic Platform</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['Inter', 'sans-serif'],
+                    },
+                    colors: {
+                        background: '#F9FAFB',
+                        surface: '#FFFFFF',
+                        surfaceHover: '#F9FAFB',
+                        primary: '#3B82F6',
+                        primaryHover: '#2563EB',
+                        textMain: '#111827',
+                        textMuted: '#6B7280',
+                        border: '#E5E7EB',
+                        inputBg: '#F9FAFB',
+                        success: '#10B981',
+                        danger: '#EF4444',
+                        infoBanner: '#DBEAFE',
+                        infoBannerText: '#1E40AF',
+                        'primary-blue': '#1D4ED8',
+                        'primary-light': '#EFF6FF',
+                        'surface-main': '#FFFFFF',
+                        'surface-subtle': '#F9FAFB',
+                        'surface-border': '#E5E7EB',
+                        'text-main': '#111827',
+                        'text-muted': '#6B7280',
+                        'status-error': '#DC2626',
+                        'status-errorLight': '#FEF2F2',
+                    },
+                    boxShadow: {
+                        'soft': '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1)',
+                        'card': '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1)',
+                        'nav': '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            background-color: #F9FAFB;
+            color: #111827;
+            font-family: 'Inter', sans-serif;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .custom-scrollbar::-webkit-scrollbar {
+            height: 6px;
+            width: 6px;
+        }
+        .custom-scrollbar::-webkit-scrollbar-track {
+            background: #F3F4F6;
+            border-radius: 4px;
+        }
+        .custom-scrollbar::-webkit-scrollbar-thumb {
+            background: #E5E7EB;
+            border-radius: 4px;
+        }
+        .custom-scrollbar::-webkit-scrollbar-thumb:hover {
+            background: #D1D5DB;
+        }
+    </style>
+</head>
+<body class="relative overflow-x-hidden min-h-screen flex flex-col">
+
+    <!-- Top Navigation -->
+    <header id="header"
+      class="bg-surface-main border-b border-surface-border shadow-nav sticky top-0 z-50 h-16 flex items-center justify-between px-6">
+      <!-- Left Nav -->
+      <div class="flex items-center gap-8"><a href="#"
+          class="flex items-center gap-2 group">
+          <div class="w-8 h-8 bg-brand-500 rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
+            H
+          </div><span
+            class="text-lg font-bold tracking-tight text-text-main group-hover:text-primary-blue transition-colors">Herit</span>
+        </a>
+        <nav class="hidden md:flex items-center gap-6"><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">Browse
+            RFPs</a><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">Public
+            Proposals</a><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">CFEOI
+            Directory</a></nav>
+      </div><!-- Right Nav -->
+      <div class="flex items-center gap-4"><button
+          class="hidden sm:flex bg-primary-blue hover:bg-primary-blue/90 text-white text-sm font-medium py-2 px-4 rounded-lg transition-colors shadow-soft items-center gap-2"><i
+            class="fa-solid fa-plus text-xs"></i>
+          Create Proposal
+        </button>
+        <div class="relative group cursor-pointer">
+          <div class="flex items-center gap-2"><img
+              src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-2.jpg"
+              alt="User Avatar"
+              class="w-9 h-9 rounded-full object-cover border-2 border-surface-main shadow-sm"><i
+              class="fa-solid fa-chevron-down text-xs text-text-muted group-hover:text-text-main transition-colors"></i>
+          </div>
+          <div
+            class="absolute right-0 mt-2 w-48 bg-surface-main rounded-xl shadow-card border border-surface-border py-1 hidden group-hover:block z-50">
+            <a href="#"
+              class="block px-4 py-2 text-sm text-text-main bg-surface-subtle font-medium">My Dashboard</a>
+            <a href="#"
+              class="block px-4 py-2 text-sm text-text-main bg-surface-subtle font-medium">My Proposals</a>
+            <div class="h-px bg-surface-border my-1"></div><a href="#"
+              class="block px-4 py-2 text-sm text-status-error hover:bg-status-errorLight transition-colors">Sign
+              Out</a>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <main class="relative z-10 flex-1 w-full max-w-[1440px] mx-auto px-4 sm:px-6 lg:px-8 py-8 flex justify-center">
+        
+        <div class="w-full max-w-[820px] flex flex-col gap-6">
+            
+            <div id="page-header" class="flex flex-col gap-4">
+                <nav class="flex text-sm text-textMuted" aria-label="Breadcrumb">
+                    <ol class="inline-flex items-center space-x-1 md:space-x-2">
+                        <li class="inline-flex items-center">
+                            <a href="#" class="hover:text-textMain transition-colors">My Proposals</a>
+                        </li>
+                        <li>
+                            <div class="flex items-center">
+                                <i class="fa-solid fa-chevron-right text-[10px] mx-2"></i>
+                                <a href="#" class="hover:text-textMain transition-colors">Digital Health Infrastructure Upgrade</a>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="flex items-center">
+                                <i class="fa-solid fa-chevron-right text-[10px] mx-2"></i>
+                                <span class="text-primary font-medium">Publish CFEOI</span>
+                            </div>
+                        </li>
+                    </ol>
+                </nav>
+
+                <div>
+                    <h1 class="text-2xl sm:text-3xl font-bold text-textMain tracking-tight">Publish New CFEOI</h1>
+                    <p class="text-textMuted text-sm mt-1">Create a Call for Expression of Interest under the Digital Health Infrastructure Upgrade proposal.</p>
+                </div>
+            </div>
+
+            <form id="cfeoi-form" class="flex flex-col gap-8 bg-surface rounded-xl border border-border/50 shadow-lg p-6 sm:p-8 backdrop-blur-sm">
+                
+                <section id="role-identity" class="flex flex-col gap-5 border-b border-border/50 pb-8">
+                    <div>
+                        <h2 class="text-lg font-semibold text-textMain">Role Identity</h2>
+                        <p class="text-sm text-textMuted mt-1">Basic information about the role you are publishing.</p>
+                    </div>
+
+                    <div class="flex flex-col gap-4">
+                        <div class="flex flex-col gap-1.5">
+                            <label class="text-sm font-medium text-textMain">Category</label>
+                            <div class="relative">
+                                <select class="w-full bg-inputBg border border-border/50 rounded-lg py-2.5 px-4 text-sm text-textMain appearance-none focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all">
+                                    <option value="" disabled selected>Select a category...</option>
+                                    <option value="technology">Technology & IT</option>
+                                    <option value="healthcare">Healthcare Services</option>
+                                    <option value="management">Project Management</option>
+                                </select>
+                                <i class="fa-solid fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-textMuted text-xs pointer-events-none"></i>
+                            </div>
+                        </div>
+
+                        <div class="flex flex-col gap-1.5">
+                            <label class="text-sm font-medium text-textMain">Role Title</label>
+                            <input type="text" placeholder="e.g. Lead System Architect" class="w-full bg-inputBg border border-border/50 rounded-lg py-3 px-4 text-lg font-semibold text-textMain placeholder-textMuted/50 focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all">
+                        </div>
+
+                        <div class="flex flex-col gap-2">
+                            <label class="text-sm font-medium text-textMain">Resource Type</label>
+                            <div class="flex flex-wrap gap-4">
+                                <label class="flex items-center gap-2 cursor-pointer group">
+                                    <input type="radio" name="resource_type" class="hidden peer" checked>
+                                    <div class="w-4 h-4 rounded-full border border-border/50 peer-checked:border-primary peer-checked:bg-primary flex items-center justify-center transition-colors">
+                                        <div class="w-2 h-2 rounded-full bg-white opacity-0 peer-checked:opacity-100 transition-opacity"></div>
+                                    </div>
+                                    <span class="text-sm text-textMuted group-hover:text-textMain peer-checked:text-textMain transition-colors">Individual Expert</span>
+                                </label>
+                                <label class="flex items-center gap-2 cursor-pointer group">
+                                    <input type="radio" name="resource_type" class="hidden peer">
+                                    <div class="w-4 h-4 rounded-full border border-border/50 peer-checked:border-primary peer-checked:bg-primary flex items-center justify-center transition-colors">
+                                        <div class="w-2 h-2 rounded-full bg-white opacity-0 peer-checked:opacity-100 transition-opacity"></div>
+                                    </div>
+                                    <span class="text-sm text-textMuted group-hover:text-textMain peer-checked:text-textMain transition-colors">Advisory Firm</span>
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+                <section id="role-requirements" class="flex flex-col gap-5 border-b border-border/50 pb-8">
+                    <div>
+                        <h2 class="text-lg font-semibold text-textMain">Role Requirements</h2>
+                        <p class="text-sm text-textMuted mt-1">Detailed description and required skills for this role.</p>
+                    </div>
+
+                    <div class="flex flex-col gap-4">
+                        <div class="flex flex-col gap-1.5">
+                            <label class="text-sm font-medium text-textMain">Description</label>
+                            <div class="border border-border/50 rounded-lg overflow-hidden bg-inputBg focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition-all">
+                                <div class="bg-surface border-b border-border/50 px-3 py-2 flex items-center gap-2">
+                                    <button type="button" class="p-1.5 text-textMuted hover:text-textMain hover:bg-surfaceHover rounded transition-colors"><i class="fa-solid fa-bold text-xs"></i></button>
+                                    <button type="button" class="p-1.5 text-textMuted hover:text-textMain hover:bg-surfaceHover rounded transition-colors"><i class="fa-solid fa-italic text-xs"></i></button>
+                                    <div class="w-px h-4 bg-border mx-1"></div>
+                                    <button type="button" class="p-1.5 text-textMuted hover:text-textMain hover:bg-surfaceHover rounded transition-colors"><i class="fa-solid fa-list-ul text-xs"></i></button>
+                                    <button type="button" class="p-1.5 text-textMuted hover:text-textMain hover:bg-surfaceHover rounded transition-colors"><i class="fa-solid fa-list-ol text-xs"></i></button>
+                                </div>
+                                <textarea rows="6" placeholder="Describe the responsibilities and expectations..." class="w-full bg-transparent p-4 text-sm text-textMain placeholder-textMuted/50 focus:outline-none resize-y"></textarea>
+                            </div>
+                        </div>
+
+                        <div class="flex flex-col gap-1.5">
+                            <label class="text-sm font-medium text-textMain">Skills (comma separated)</label>
+                            <div class="bg-inputBg border border-border/50 rounded-lg p-2 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition-all flex flex-wrap gap-2">
+                                <div class="flex items-center gap-1.5 bg-surfaceHover px-2.5 py-1 rounded-md border border-border">
+                                    <span class="text-xs text-textMain">System Architecture</span>
+                                    <button type="button" class="text-textMuted hover:text-danger transition-colors"><i class="fa-solid fa-xmark text-[10px]"></i></button>
+                                </div>
+                                <div class="flex items-center gap-1.5 bg-surfaceHover px-2.5 py-1 rounded-md border border-border">
+                                    <span class="text-xs text-textMain">HL7 Integration</span>
+                                    <button type="button" class="text-textMuted hover:text-danger transition-colors"><i class="fa-solid fa-xmark text-[10px]"></i></button>
+                                </div>
+                                <input type="text" placeholder="Type a skill and press comma..." class="flex-1 bg-transparent border-none text-sm text-textMain placeholder-textMuted/50 focus:outline-none min-w-[150px] py-1 px-2">
+                            </div>
+                        </div>
+
+                        <div class="flex flex-col gap-1.5 w-full sm:w-1/3">
+                            <label class="text-sm font-medium text-textMain">Slots</label>
+                            <input type="number" min="1" value="1" class="w-full bg-inputBg border border-border/50 rounded-lg py-2.5 px-4 text-sm text-textMain focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all">
+                        </div>
+                    </div>
+                </section>
+
+                <section id="optional-details" class="flex flex-col gap-5">
+                    <div>
+                        <h2 class="text-lg font-semibold text-textMain">Optional Details</h2>
+                        <p class="text-sm text-textMuted mt-1">Additional parameters for the expression of interest.</p>
+                    </div>
+
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <div class="flex flex-col gap-1.5">
+                            <label class="text-sm font-medium text-textMain">Duration (weeks)</label>
+                            <input type="number" placeholder="e.g. 24" class="w-full bg-inputBg border border-border/50 rounded-lg py-2.5 px-4 text-sm text-textMain placeholder-textMuted/50 focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all">
+                        </div>
+
+                        <div class="flex flex-col gap-1.5">
+                            <label class="text-sm font-medium text-textMain">Location</label>
+                            <input type="text" placeholder="e.g. Remote / Capital City" class="w-full bg-inputBg border border-border/50 rounded-lg py-2.5 px-4 text-sm text-textMain placeholder-textMuted/50 focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all">
+                        </div>
+
+                        <div class="flex flex-col gap-1.5">
+                            <label class="text-sm font-medium text-textMain">Compensation</label>
+                            <input type="text" placeholder="e.g. $50,000 - $70,000" class="w-full bg-inputBg border border-border/50 rounded-lg py-2.5 px-4 text-sm text-textMain placeholder-textMuted/50 focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all">
+                        </div>
+
+                        <div class="flex flex-col gap-1.5">
+                            <label class="text-sm font-medium text-textMain">Application Deadline</label>
+                            <div class="relative">
+                                <input type="date" class="w-full bg-inputBg border border-border/50 rounded-lg py-2.5 pl-4 pr-10 text-sm text-textMain focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all [color-scheme:dark]">
+                                <i class="fa-regular fa-calendar absolute right-4 top-1/2 -translate-y-1/2 text-textMuted text-sm pointer-events-none"></i>
+                            </div>
+                        </div>
+
+                        <div class="flex flex-col gap-1.5 sm:col-span-2">
+                            <label class="text-sm font-medium text-textMain">External Links</label>
+                            <textarea rows="3" placeholder="https://example.com/reference..." class="w-full bg-inputBg border border-border/50 rounded-lg py-2.5 px-4 text-sm text-textMain placeholder-textMuted/50 focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all resize-y"></textarea>
+                        </div>
+                    </div>
+                </section>
+
+                <div class="flex flex-col items-center gap-4 pt-4 mt-2 border-t border-border/50">
+                    <button type="button" class="w-full bg-primary hover:bg-primaryHover text-white font-medium py-3 px-6 rounded-lg transition-all shadow-[0_0_15px_rgba(59,130,246,0.3)] hover:shadow-[0_0_20px_rgba(59,130,246,0.5)] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-surface focus:ring-primary">
+                        Publish CFEOI
+                    </button>
+                    <a href="#" class="text-sm text-textMuted hover:text-textMain transition-colors">Cancel and return to proposal</a>
+                </div>
+
+            </form>
+        </div>
+
+    </main>
+
+    <footer id="footer" class="w-full text-center text-xs text-textMuted/50 py-6 mt-auto relative z-10">
+        &copy; 2026 Herit Civic Platform. All rights reserved.
+    </footer>
+
+</body>
+</html>

--- a/docs/frontend/portal/designs/flow3c/02-cfeoi-publish-success.html
+++ b/docs/frontend/portal/designs/flow3c/02-cfeoi-publish-success.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        window.FontAwesomeConfig = {
+          autoReplaceSvg: 'nest'
+        };
+      </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/js/all.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Publish Success - Herit Civic Platform</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['Inter', 'sans-serif'],
+                    },
+                    colors: {
+                        background: '#F9FAFB',
+                        surface: '#FFFFFF',
+                        surfaceHover: '#F9FAFB',
+                        primary: '#3B82F6',
+                        primaryHover: '#2563EB',
+                        textMain: '#111827',
+                        textMuted: '#6B7280',
+                        border: '#E5E7EB',
+                        inputBg: '#F9FAFB',
+                        success: '#10B981',
+                        danger: '#EF4444',
+                        infoBanner: '#DBEAFE',
+                        infoBannerText: '#1E40AF',
+                        'primary-blue': '#1D4ED8',
+                        'primary-light': '#EFF6FF',
+                        'surface-main': '#FFFFFF',
+                        'surface-subtle': '#F9FAFB',
+                        'surface-border': '#E5E7EB',
+                        'text-main': '#111827',
+                        'text-muted': '#6B7280',
+                        'status-error': '#DC2626',
+                        'status-errorLight': '#FEF2F2',
+                    },
+                    boxShadow: {
+                        'soft': '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1)',
+                        'card': '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1)',
+                        'nav': '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            background-color: #F9FAFB;
+            color: #111827;
+            font-family: 'Inter', sans-serif;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .custom-scrollbar::-webkit-scrollbar {
+            height: 6px;
+            width: 6px;
+        }
+        .custom-scrollbar::-webkit-scrollbar-track {
+            background: #F3F4F6;
+            border-radius: 4px;
+        }
+        .custom-scrollbar::-webkit-scrollbar-thumb {
+            background: #E5E7EB;
+            border-radius: 4px;
+        }
+        .custom-scrollbar::-webkit-scrollbar-thumb:hover {
+            background: #D1D5DB;
+        }
+    </style>
+</head>
+<body class="relative overflow-x-hidden min-h-screen flex flex-col">
+
+    <!-- Top Navigation -->
+    <header id="header"
+      class="bg-surface-main border-b border-surface-border shadow-nav sticky top-0 z-50 h-16 flex items-center justify-between px-6">
+      <!-- Left Nav -->
+      <div class="flex items-center gap-8"><a href="#"
+          class="flex items-center gap-2 group">
+          <div class="w-8 h-8 bg-brand-500 rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
+            H
+          </div><span
+            class="text-lg font-bold tracking-tight text-text-main group-hover:text-primary-blue transition-colors">Herit</span>
+        </a>
+        <nav class="hidden md:flex items-center gap-6"><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">Browse
+            RFPs</a><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">Public
+            Proposals</a><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">CFEOI
+            Directory</a></nav>
+      </div><!-- Right Nav -->
+      <div class="flex items-center gap-4"><button
+          class="hidden sm:flex bg-primary-blue hover:bg-primary-blue/90 text-white text-sm font-medium py-2 px-4 rounded-lg transition-colors shadow-soft items-center gap-2"><i
+            class="fa-solid fa-plus text-xs"></i>
+          Create Proposal
+        </button>
+        <div class="relative group cursor-pointer">
+          <div class="flex items-center gap-2"><img
+              src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-2.jpg"
+              alt="User Avatar"
+              class="w-9 h-9 rounded-full object-cover border-2 border-surface-main shadow-sm"><i
+              class="fa-solid fa-chevron-down text-xs text-text-muted group-hover:text-text-main transition-colors"></i>
+          </div>
+          <div
+            class="absolute right-0 mt-2 w-48 bg-surface-main rounded-xl shadow-card border border-surface-border py-1 hidden group-hover:block z-50">
+            <a href="#"
+              class="block px-4 py-2 text-sm text-text-main bg-surface-subtle font-medium">My Dashboard</a>
+            <a href="#"
+              class="block px-4 py-2 text-sm text-text-main bg-surface-subtle font-medium">My Proposals</a>
+            <div class="h-px bg-surface-border my-1"></div><a href="#"
+              class="block px-4 py-2 text-sm text-status-error hover:bg-status-errorLight transition-colors">Sign
+              Out</a>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <main class="relative z-10 flex-1 w-full max-w-[1440px] mx-auto px-4 sm:px-6 lg:px-8 py-12 flex flex-col items-center justify-center min-h-[calc(100vh-140px)]">
+        
+        <div class="w-full max-w-[640px] flex flex-col items-center text-center gap-8">
+            
+            <div id="success-icon" class="w-20 h-20 bg-success/10 rounded-full flex items-center justify-center border border-success/20 shadow-[0_0_30px_rgba(16,185,129,0.2)]">
+                <i class="fa-solid fa-check text-3xl text-success"></i>
+            </div>
+
+            <div id="success-header" class="flex flex-col gap-3">
+                <h1 class="text-3xl sm:text-4xl font-bold text-textMain tracking-tight">CFEOI Published Successfully</h1>
+                <p class="text-textMuted text-base max-w-md mx-auto">Your Call for Expression of Interest is now live and accepting applications from the diaspora network.</p>
+            </div>
+
+            <div id="summary-banner" class="w-full bg-infoBanner rounded-xl p-6 text-left border border-infoBannerText/20 shadow-lg mt-4">
+                <div class="flex items-center justify-between mb-4">
+                    <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-success/20 border border-success/30 text-success text-xs font-semibold">
+                        <span class="w-1.5 h-1.5 rounded-full bg-success"></span>
+                        Open
+                    </span>
+                    <span class="text-infoBannerText font-medium text-sm">ID: CFE-2026-089</span>
+                </div>
+                
+                <h2 class="text-xl font-bold text-infoBannerText mb-2">Lead System Architect</h2>
+                
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-4 pt-4 border-t border-infoBannerText/10">
+                    <div>
+                        <p class="text-infoBannerText/70 text-xs uppercase tracking-wider font-semibold mb-1">Category</p>
+                        <p class="text-infoBannerText font-medium text-sm">Technology & IT</p>
+                    </div>
+                    <div>
+                        <p class="text-infoBannerText/70 text-xs uppercase tracking-wider font-semibold mb-1">Application Deadline</p>
+                        <p class="text-infoBannerText font-medium text-sm">October 15, 2026</p>
+                    </div>
+                </div>
+            </div>
+
+            <div id="action-footer" class="flex flex-col sm:flex-row items-center gap-4 w-full mt-4">
+                <a href="#" class="w-full sm:w-auto flex-1 flex items-center justify-center gap-2 bg-primary hover:bg-primaryHover text-white font-medium py-3 px-6 rounded-lg transition-all shadow-[0_0_15px_rgba(59,130,246,0.3)] hover:shadow-[0_0_20px_rgba(59,130,246,0.5)] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-surface focus:ring-primary">
+                    View CFEOI Details
+                    <i class="fa-solid fa-arrow-right text-sm"></i>
+                </a>
+                <a href="#" class="w-full sm:w-auto flex-1 flex items-center justify-center gap-2 bg-surface hover:bg-surfaceHover text-textMain font-medium py-3 px-6 rounded-lg border border-border/50 transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-surface focus:ring-primary">
+                    Return to Proposal
+                </a>
+            </div>
+
+            <nav class="flex text-sm text-textMuted mt-8" aria-label="Breadcrumb">
+                <ol class="inline-flex items-center space-x-1 md:space-x-2">
+                    <li class="inline-flex items-center">
+                        <a href="#" class="hover:text-textMain transition-colors">My Proposals</a>
+                    </li>
+                    <li>
+                        <div class="flex items-center">
+                            <i class="fa-solid fa-chevron-right text-[10px] mx-2"></i>
+                            <a href="#" class="hover:text-textMain transition-colors">Digital Health Infrastructure Upgrade</a>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="flex items-center">
+                            <i class="fa-solid fa-chevron-right text-[10px] mx-2"></i>
+                            <span class="text-textMuted">Publish CFEOI</span>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="flex items-center">
+                            <i class="fa-solid fa-chevron-right text-[10px] mx-2"></i>
+                            <span class="text-success font-medium">Success</span>
+                        </div>
+                    </li>
+                </ol>
+            </nav>
+
+        </div>
+
+    </main>
+
+    <footer id="footer" class="w-full text-center text-xs text-textMuted/50 py-6 mt-auto relative z-10">
+        &copy; 2026 Herit Civic Platform. All rights reserved.
+    </footer>
+
+</body>
+</html>

--- a/docs/frontend/portal/designs/flow3c/03-cfeoi-detail-open-owner.html
+++ b/docs/frontend/portal/designs/flow3c/03-cfeoi-detail-open-owner.html
@@ -1,0 +1,344 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        window.FontAwesomeConfig = {
+          autoReplaceSvg: 'nest'
+        };
+      </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/js/all.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CFEOI Detail - Herit Civic Platform</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['Inter', 'sans-serif'],
+                    },
+                    colors: {
+                        background: '#F9FAFB',
+                        surface: '#FFFFFF',
+                        surfaceHover: '#F9FAFB',
+                        primary: '#3B82F6',
+                        primaryHover: '#2563EB',
+                        textMain: '#111827',
+                        textMuted: '#6B7280',
+                        border: '#E5E7EB',
+                        inputBg: '#F9FAFB',
+                        success: '#10B981',
+                        danger: '#EF4444',
+                        infoBanner: '#DBEAFE',
+                        infoBannerText: '#1E40AF',
+                        'primary-blue': '#1D4ED8',
+                        'primary-light': '#EFF6FF',
+                        'surface-main': '#FFFFFF',
+                        'surface-subtle': '#F9FAFB',
+                        'surface-border': '#E5E7EB',
+                        'text-main': '#111827',
+                        'text-muted': '#6B7280',
+                        'status-error': '#DC2626',
+                        'status-errorLight': '#FEF2F2',
+                    },
+                    boxShadow: {
+                        'soft': '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1)',
+                        'card': '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1)',
+                        'nav': '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            background-color: #F9FAFB;
+            color: #111827;
+            font-family: 'Inter', sans-serif;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .custom-scrollbar::-webkit-scrollbar {
+            height: 6px;
+            width: 6px;
+        }
+        .custom-scrollbar::-webkit-scrollbar-track {
+            background: #F3F4F6;
+            border-radius: 4px;
+        }
+        .custom-scrollbar::-webkit-scrollbar-thumb {
+            background: #E5E7EB;
+            border-radius: 4px;
+        }
+        .custom-scrollbar::-webkit-scrollbar-thumb:hover {
+            background: #D1D5DB;
+        }
+    </style>
+</head>
+<body class="relative overflow-x-hidden min-h-screen flex flex-col">
+
+    <!-- Top Navigation -->
+    <header id="header"
+      class="bg-surface-main border-b border-surface-border shadow-nav sticky top-0 z-50 h-16 flex items-center justify-between px-6">
+      <!-- Left Nav -->
+      <div class="flex items-center gap-8"><a href="#"
+          class="flex items-center gap-2 group">
+          <div class="w-8 h-8 bg-brand-500 rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
+            H
+          </div><span
+            class="text-lg font-bold tracking-tight text-text-main group-hover:text-primary-blue transition-colors">Herit</span>
+        </a>
+        <nav class="hidden md:flex items-center gap-6"><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">Browse
+            RFPs</a><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">Public
+            Proposals</a><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">CFEOI
+            Directory</a></nav>
+      </div><!-- Right Nav -->
+      <div class="flex items-center gap-4"><button
+          class="hidden sm:flex bg-primary-blue hover:bg-primary-blue/90 text-white text-sm font-medium py-2 px-4 rounded-lg transition-colors shadow-soft items-center gap-2"><i
+            class="fa-solid fa-plus text-xs"></i>
+          Create Proposal
+        </button>
+        <div class="relative group cursor-pointer">
+          <div class="flex items-center gap-2"><img
+              src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-2.jpg"
+              alt="User Avatar"
+              class="w-9 h-9 rounded-full object-cover border-2 border-surface-main shadow-sm"><i
+              class="fa-solid fa-chevron-down text-xs text-text-muted group-hover:text-text-main transition-colors"></i>
+          </div>
+          <div
+            class="absolute right-0 mt-2 w-48 bg-surface-main rounded-xl shadow-card border border-surface-border py-1 hidden group-hover:block z-50">
+            <a href="#"
+              class="block px-4 py-2 text-sm text-text-main bg-surface-subtle font-medium">My Dashboard</a>
+            <a href="#"
+              class="block px-4 py-2 text-sm text-text-main bg-surface-subtle font-medium">My Proposals</a>
+            <div class="h-px bg-surface-border my-1"></div><a href="#"
+              class="block px-4 py-2 text-sm text-status-error hover:bg-status-errorLight transition-colors">Sign
+              Out</a>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <main class="relative z-10 flex-1 w-full max-w-[1440px] mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        
+        <!-- Breadcrumb -->
+        <nav class="flex text-sm text-textMuted mb-8" aria-label="Breadcrumb">
+            <ol class="inline-flex items-center space-x-1 md:space-x-2">
+                <li class="inline-flex items-center">
+                    <a href="#" class="hover:text-textMain transition-colors">My Proposals</a>
+                </li>
+                <li>
+                    <div class="flex items-center">
+                        <i class="fa-solid fa-chevron-right text-[10px] mx-2"></i>
+                        <a href="#" class="hover:text-textMain transition-colors">Digital Health Infrastructure Upgrade</a>
+                    </div>
+                </li>
+                <li>
+                    <div class="flex items-center">
+                        <i class="fa-solid fa-chevron-right text-[10px] mx-2"></i>
+                        <span class="text-textMain font-medium">Lead System Architect</span>
+                    </div>
+                </li>
+            </ol>
+        </nav>
+
+        <div class="flex flex-col lg:flex-row gap-8">
+            <!-- Left Column: Main Content (2/3) -->
+            <div class="w-full lg:w-2/3 flex flex-col gap-8">
+                
+                <!-- Header Section -->
+                <div class="flex flex-col gap-4">
+                    <div class="flex items-center gap-3">
+                        <span class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-success/10 border border-success/20 text-success text-sm font-medium">
+                            <span class="w-2 h-2 rounded-full bg-success"></span>
+                            Open
+                        </span>
+                        <span class="text-textMuted text-sm">ID: CFE-2026-089</span>
+                    </div>
+                    
+                    <h1 class="text-3xl sm:text-4xl font-bold text-textMain tracking-tight">Lead System Architect</h1>
+                    
+                    <div class="flex flex-wrap items-center gap-2 mt-2">
+                        <span class="inline-flex items-center px-3 py-1 rounded-md bg-surface border border-border/50 text-textMain text-sm font-medium">
+                            <i class="fa-solid fa-layer-group text-textMuted mr-2"></i>
+                            Technology & IT
+                        </span>
+                        <span class="inline-flex items-center px-3 py-1 rounded-md bg-surface border border-border/50 text-textMain text-sm font-medium">
+                            <i class="fa-regular fa-user text-textMuted mr-2"></i>
+                            Individual Consultant
+                        </span>
+                    </div>
+                </div>
+
+                <!-- Description Section -->
+                <div class="bg-surface rounded-xl border border-border/50 p-6 sm:p-8 flex flex-col gap-6">
+                    <h2 class="text-xl font-bold text-textMain">Role Description</h2>
+                    
+                    <div class="prose prose-invert max-w-none text-textMuted leading-relaxed">
+                        <p class="mb-4">We are seeking an experienced Lead System Architect to design and oversee the implementation of our new national digital health infrastructure. This role involves working closely with the Ministry of Health and international tech partners to ensure a robust, scalable, and secure system.</p>
+                        
+                        <p class="mb-4"><strong>Key Responsibilities:</strong></p>
+                        <ul class="list-disc pl-5 mb-4 space-y-2">
+                            <li>Design end-to-end architecture for the national health data exchange.</li>
+                            <li>Ensure compliance with international healthcare data standards (HL7, FHIR).</li>
+                            <li>Lead a team of senior developers and data engineers.</li>
+                            <li>Evaluate and select appropriate cloud infrastructure providers.</li>
+                        </ul>
+                        
+                        <p>The ideal candidate will have a strong background in public sector IT transformations and a deep understanding of healthcare informatics.</p>
+                    </div>
+
+                    <!-- Skills -->
+                    <div class="mt-4 pt-6 border-t border-border/50">
+                        <h3 class="text-sm font-semibold text-textMain uppercase tracking-wider mb-3">Required Skills</h3>
+                        <div class="flex flex-wrap gap-2">
+                            <span class="px-3 py-1.5 bg-inputBg border border-border/50 rounded-full text-sm text-textMuted hover:text-textMain hover:border-border transition-colors cursor-default">System Architecture</span>
+                            <span class="px-3 py-1.5 bg-inputBg border border-border/50 rounded-full text-sm text-textMuted hover:text-textMain hover:border-border transition-colors cursor-default">Cloud Infrastructure</span>
+                            <span class="px-3 py-1.5 bg-inputBg border border-border/50 rounded-full text-sm text-textMuted hover:text-textMain hover:border-border transition-colors cursor-default">HL7/FHIR</span>
+                            <span class="px-3 py-1.5 bg-inputBg border border-border/50 rounded-full text-sm text-textMuted hover:text-textMain hover:border-border transition-colors cursor-default">Team Leadership</span>
+                            <span class="px-3 py-1.5 bg-inputBg border border-border/50 rounded-full text-sm text-textMuted hover:text-textMain hover:border-border transition-colors cursor-default">Healthcare Informatics</span>
+                        </div>
+                    </div>
+                    
+                    <!-- External Links -->
+                    <div class="mt-2 pt-6 border-t border-border/50">
+                        <h3 class="text-sm font-semibold text-textMain uppercase tracking-wider mb-3">Reference Documents</h3>
+                        <div class="flex flex-col gap-2">
+                            <a href="#" class="inline-flex items-center gap-2 text-primary hover:text-primaryHover transition-colors text-sm w-fit">
+                                <i class="fa-solid fa-link text-xs"></i>
+                                Preliminary Architecture Draft (PDF)
+                            </a>
+                            <a href="#" class="inline-flex items-center gap-2 text-primary hover:text-primaryHover transition-colors text-sm w-fit">
+                                <i class="fa-solid fa-link text-xs"></i>
+                                Ministry of Health Digital Strategy 2025-2030
+                            </a>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Details Grid -->
+                <div class="bg-surface rounded-xl border border-border/50 p-6 sm:p-8">
+                    <h2 class="text-xl font-bold text-textMain mb-6">Role Details</h2>
+                    
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-y-8 gap-x-6">
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs font-semibold text-textMuted uppercase tracking-wider">Available Slots</span>
+                            <span class="text-textMain font-medium text-lg">1 Position</span>
+                        </div>
+                        
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs font-semibold text-textMuted uppercase tracking-wider">Duration</span>
+                            <span class="text-textMain font-medium text-lg">24 Weeks</span>
+                        </div>
+                        
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs font-semibold text-textMuted uppercase tracking-wider">Location</span>
+                            <span class="text-textMain font-medium text-lg">Hybrid (Capital City / Remote)</span>
+                        </div>
+                        
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs font-semibold text-textMuted uppercase tracking-wider">Compensation</span>
+                            <span class="text-textMain font-medium text-lg">$120,000 - $150,000 USD</span>
+                        </div>
+                        
+                        <div class="flex flex-col gap-1 sm:col-span-2 pt-4 border-t border-border/50">
+                            <span class="text-xs font-semibold text-textMuted uppercase tracking-wider">Application Deadline</span>
+                            <div class="flex items-center gap-2 mt-1">
+                                <i class="fa-regular fa-calendar text-primary"></i>
+                                <span class="text-textMain font-medium text-lg">October 15, 2026</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+            </div>
+
+            <!-- Right Column: Sidebar (1/3) -->
+            <div class="w-full lg:w-1/3 flex flex-col gap-6">
+                
+                <!-- Owner Actions Card -->
+                <div class="bg-surface rounded-xl border border-border/50 p-6 shadow-lg relative overflow-hidden">
+                    <div class="absolute top-0 left-0 w-full h-1 bg-primary"></div>
+                    <h3 class="text-lg font-bold text-textMain mb-4">Manage CFEOI</h3>
+                    
+                    <div class="flex flex-col gap-3">
+                        <button class="w-full flex items-center justify-center gap-2 bg-transparent hover:bg-surfaceHover text-textMain font-medium py-2.5 px-4 rounded-lg border border-border/50 transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-surface focus:ring-border">
+                            <i class="fa-solid fa-pen text-sm"></i>
+                            Edit Details
+                        </button>
+                        
+                        <button class="w-full flex items-center justify-center gap-2 bg-transparent hover:bg-danger/10 text-danger font-medium py-2.5 px-4 rounded-lg border border-danger/50 transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-surface focus:ring-danger">
+                            <i class="fa-solid fa-ban text-sm"></i>
+                            Close CFEOI
+                        </button>
+                    </div>
+                    <p class="text-xs text-textMuted mt-4 text-center">Closing is irreversible and stops new applications.</p>
+                </div>
+
+                <!-- EOI Stats Card -->
+                <div class="bg-surface rounded-xl border border-border/50 p-6 shadow-lg">
+                    <h3 class="text-lg font-bold text-textMain mb-2">Expressions of Interest</h3>
+                    <p class="text-sm text-textMuted mb-6">Current applications received for this role.</p>
+                    
+                    <div class="flex items-end justify-between mb-6">
+                        <div class="flex flex-col">
+                            <span class="text-4xl font-bold text-textMain leading-none">12</span>
+                            <span class="text-sm text-textMuted mt-1">Total Received</span>
+                        </div>
+                        <div class="flex -space-x-2">
+                            <img class="w-8 h-8 rounded-full border-2 border-surface object-cover" src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-1.jpg" alt="Applicant">
+                            <img class="w-8 h-8 rounded-full border-2 border-surface object-cover" src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-2.jpg" alt="Applicant">
+                            <img class="w-8 h-8 rounded-full border-2 border-surface object-cover" src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-3.jpg" alt="Applicant">
+                            <div class="w-8 h-8 rounded-full border-2 border-surface bg-inputBg flex items-center justify-center text-xs font-medium text-textMuted">+9</div>
+                        </div>
+                    </div>
+                    
+                    <a href="#" class="w-full flex items-center justify-center gap-2 bg-primary hover:bg-primaryHover text-white font-medium py-2.5 px-4 rounded-lg transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-surface focus:ring-primary">
+                        View All EOIs
+                        <i class="fa-solid fa-arrow-right text-sm"></i>
+                    </a>
+                </div>
+
+                <!-- Parent Proposal Card -->
+                <div class="bg-surface rounded-xl border border-border/50 p-6 shadow-lg">
+                    <h3 class="text-sm font-semibold text-textMuted uppercase tracking-wider mb-4">Part of Proposal</h3>
+                    
+                    <div class="flex flex-col gap-3">
+                        <div class="w-10 h-10 rounded-lg bg-inputBg border border-border/50 flex items-center justify-center text-primary">
+                            <i class="fa-solid fa-folder-open"></i>
+                        </div>
+                        <div>
+                            <h4 class="text-base font-bold text-textMain mb-1">Digital Health Infrastructure Upgrade</h4>
+                            <p class="text-sm text-textMuted mb-4">Ministry of Health • Ref: PRJ-2026-04</p>
+                        </div>
+                        
+                        <a href="#" class="inline-flex items-center gap-2 text-primary hover:text-primaryHover transition-colors text-sm font-medium w-fit">
+                            View Parent Proposal
+                            <i class="fa-solid fa-arrow-up-right-from-square text-xs"></i>
+                        </a>
+                    </div>
+                </div>
+
+            </div>
+        </div>
+
+    </main>
+
+    <footer id="footer" class="w-full text-center text-xs text-textMuted/50 py-6 mt-auto relative z-10 border-t border-border/50 bg-background">
+        &copy; 2026 Herit Civic Platform. All rights reserved.
+    </footer>
+
+</body>
+</html>

--- a/docs/frontend/portal/designs/flow3c/04-cfeoi-edit-form.html
+++ b/docs/frontend/portal/designs/flow3c/04-cfeoi-edit-form.html
@@ -1,0 +1,338 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        window.FontAwesomeConfig = {
+          autoReplaceSvg: 'nest'
+        };
+      </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/js/all.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Edit CFEOI - Herit Civic Platform</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['Inter', 'sans-serif'],
+                    },
+                    colors: {
+                        background: '#F9FAFB',
+                        surface: '#FFFFFF',
+                        surfaceHover: '#F9FAFB',
+                        primary: '#3B82F6',
+                        primaryHover: '#2563EB',
+                        textMain: '#111827',
+                        textMuted: '#6B7280',
+                        border: '#E5E7EB',
+                        inputBg: '#F9FAFB',
+                        success: '#10B981',
+                        danger: '#EF4444',
+                        infoBanner: '#DBEAFE',
+                        infoBannerText: '#1E40AF',
+                        'primary-blue': '#1D4ED8',
+                        'primary-light': '#EFF6FF',
+                        'surface-main': '#FFFFFF',
+                        'surface-subtle': '#F9FAFB',
+                        'surface-border': '#E5E7EB',
+                        'text-main': '#111827',
+                        'text-muted': '#6B7280',
+                        'status-error': '#DC2626',
+                        'status-errorLight': '#FEF2F2',
+                    },
+                    boxShadow: {
+                        'soft': '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1)',
+                        'card': '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1)',
+                        'nav': '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            background-color: #F9FAFB;
+            color: #111827;
+            font-family: 'Inter', sans-serif;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .custom-scrollbar::-webkit-scrollbar {
+            height: 6px;
+            width: 6px;
+        }
+        .custom-scrollbar::-webkit-scrollbar-track {
+            background: #F3F4F6;
+            border-radius: 4px;
+        }
+        .custom-scrollbar::-webkit-scrollbar-thumb {
+            background: #E5E7EB;
+            border-radius: 4px;
+        }
+        .custom-scrollbar::-webkit-scrollbar-thumb:hover {
+            background: #D1D5DB;
+        }
+    </style>
+</head>
+<body class="relative overflow-x-hidden min-h-screen flex flex-col">
+
+    <!-- Top Navigation -->
+    <header id="header"
+      class="bg-surface-main border-b border-surface-border shadow-nav sticky top-0 z-50 h-16 flex items-center justify-between px-6">
+      <!-- Left Nav -->
+      <div class="flex items-center gap-8"><a href="#"
+          class="flex items-center gap-2 group">
+          <div class="w-8 h-8 bg-brand-500 rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
+            H
+          </div><span
+            class="text-lg font-bold tracking-tight text-text-main group-hover:text-primary-blue transition-colors">Herit</span>
+        </a>
+        <nav class="hidden md:flex items-center gap-6"><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">Browse
+            RFPs</a><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">Public
+            Proposals</a><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">CFEOI
+            Directory</a></nav>
+      </div><!-- Right Nav -->
+      <div class="flex items-center gap-4"><button
+          class="hidden sm:flex bg-primary-blue hover:bg-primary-blue/90 text-white text-sm font-medium py-2 px-4 rounded-lg transition-colors shadow-soft items-center gap-2"><i
+            class="fa-solid fa-plus text-xs"></i>
+          Create Proposal
+        </button>
+        <div class="relative group cursor-pointer">
+          <div class="flex items-center gap-2"><img
+              src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-2.jpg"
+              alt="User Avatar"
+              class="w-9 h-9 rounded-full object-cover border-2 border-surface-main shadow-sm"><i
+              class="fa-solid fa-chevron-down text-xs text-text-muted group-hover:text-text-main transition-colors"></i>
+          </div>
+          <div
+            class="absolute right-0 mt-2 w-48 bg-surface-main rounded-xl shadow-card border border-surface-border py-1 hidden group-hover:block z-50">
+            <a href="#"
+              class="block px-4 py-2 text-sm text-text-main bg-surface-subtle font-medium">My Dashboard</a>
+            <a href="#"
+              class="block px-4 py-2 text-sm text-text-main bg-surface-subtle font-medium">My Proposals</a>
+            <div class="h-px bg-surface-border my-1"></div><a href="#"
+              class="block px-4 py-2 text-sm text-status-error hover:bg-status-errorLight transition-colors">Sign
+              Out</a>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <main id="main-content" class="relative z-10 flex-1 w-full max-w-[820px] mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        
+        <!-- Breadcrumb -->
+        <nav id="breadcrumb" class="flex text-sm text-textMuted mb-8" aria-label="Breadcrumb">
+            <ol class="inline-flex items-center space-x-1 md:space-x-2">
+                <li class="inline-flex items-center">
+                    <a href="#" class="hover:text-textMain transition-colors">My Proposals</a>
+                </li>
+                <li>
+                    <div class="flex items-center">
+                        <i class="fa-solid fa-chevron-right text-[10px] mx-2"></i>
+                        <a href="#" class="hover:text-textMain transition-colors">Digital Health Infrastructure Upgrade</a>
+                    </div>
+                </li>
+                <li>
+                    <div class="flex items-center">
+                        <i class="fa-solid fa-chevron-right text-[10px] mx-2"></i>
+                        <a href="#" class="hover:text-textMain transition-colors">Lead System Architect</a>
+                    </div>
+                </li>
+                <li>
+                    <div class="flex items-center">
+                        <i class="fa-solid fa-chevron-right text-[10px] mx-2"></i>
+                        <span class="text-textMain font-medium">Edit</span>
+                    </div>
+                </li>
+            </ol>
+        </nav>
+
+        <div class="flex flex-col gap-6">
+            <h1 class="text-2xl sm:text-3xl font-bold text-textMain tracking-tight">Edit CFEOI</h1>
+            <p class="text-textMuted text-sm mb-2">Update the details for the Call for Expression of Interest.</p>
+        </div>
+
+        <form id="edit-cfeoi-form" class="flex flex-col gap-8 mt-6">
+            
+            <!-- Section 1: Role Identity -->
+            <div id="section-role-identity" class="bg-surface rounded-xl border border-border/50 overflow-hidden shadow-lg">
+                <div class="px-6 py-4 border-b border-border/50 bg-surface flex items-center justify-between">
+                    <h2 class="text-base font-semibold text-textMain">Role Identity</h2>
+                    <button type="button" class="text-textMuted hover:text-textMain transition-colors"><i class="fa-solid fa-chevron-down text-sm"></i></button>
+                </div>
+                <div class="p-6 flex flex-col gap-6">
+                    
+                    <div class="flex flex-col gap-2">
+                        <label for="category" class="text-sm font-medium text-textMain">Category <span class="text-danger">*</span></label>
+                        <div class="relative">
+                            <select id="category" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent appearance-none">
+                                <option value="technology" selected>Technology & IT</option>
+                                <option value="healthcare">Healthcare</option>
+                                <option value="infrastructure">Infrastructure</option>
+                            </select>
+                            <i class="fa-solid fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-textMuted text-xs pointer-events-none"></i>
+                        </div>
+                    </div>
+
+                    <div class="flex flex-col gap-2">
+                        <label for="role-title" class="text-sm font-medium text-textMain">Role Title <span class="text-danger">*</span></label>
+                        <input type="text" id="role-title" value="Lead System Architect" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">
+                    </div>
+
+                    <div class="flex flex-col gap-3">
+                        <span class="text-sm font-medium text-textMain">Resource Type <span class="text-danger">*</span></span>
+                        <div class="flex flex-col sm:flex-row gap-4">
+                            <label class="flex items-center gap-3 cursor-pointer group">
+                                <div class="relative flex items-center justify-center w-5 h-5">
+                                    <input type="radio" name="resource-type" value="individual" class="peer sr-only" checked>
+                                    <div class="w-5 h-5 rounded-full border border-border/50 bg-inputBg peer-checked:border-primary peer-checked:bg-primary transition-colors"></div>
+                                    <div class="absolute w-2 h-2 rounded-full bg-white opacity-0 peer-checked:opacity-100 transition-opacity"></div>
+                                </div>
+                                <span class="text-sm text-textMuted group-hover:text-textMain transition-colors">Individual Consultant</span>
+                            </label>
+                            <label class="flex items-center gap-3 cursor-pointer group">
+                                <div class="relative flex items-center justify-center w-5 h-5">
+                                    <input type="radio" name="resource-type" value="firm" class="peer sr-only">
+                                    <div class="w-5 h-5 rounded-full border border-border/50 bg-inputBg peer-checked:border-primary peer-checked:bg-primary transition-colors"></div>
+                                    <div class="absolute w-2 h-2 rounded-full bg-white opacity-0 peer-checked:opacity-100 transition-opacity"></div>
+                                </div>
+                                <span class="text-sm text-textMuted group-hover:text-textMain transition-colors">Firm / Organization</span>
+                            </label>
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+
+            <!-- Section 2: Role Requirements -->
+            <div id="section-role-requirements" class="bg-surface rounded-xl border border-border/50 overflow-hidden shadow-lg">
+                <div class="px-6 py-4 border-b border-border/50 bg-surface flex items-center justify-between">
+                    <h2 class="text-base font-semibold text-textMain">Role Requirements</h2>
+                    <button type="button" class="text-textMuted hover:text-textMain transition-colors"><i class="fa-solid fa-chevron-down text-sm"></i></button>
+                </div>
+                <div class="p-6 flex flex-col gap-6">
+                    
+                    <div class="flex flex-col gap-2">
+                        <label for="description" class="text-sm font-medium text-textMain">Description <span class="text-danger">*</span></label>
+                        <div class="border border-border/50 rounded-lg overflow-hidden bg-inputBg">
+                            <!-- Toolbar -->
+                            <div class="flex items-center gap-1 p-2 border-b border-border/50 bg-surface">
+                                <button type="button" class="p-1.5 rounded text-textMuted hover:text-textMain hover:bg-surfaceHover transition-colors"><i class="fa-solid fa-bold text-sm"></i></button>
+                                <button type="button" class="p-1.5 rounded text-textMuted hover:text-textMain hover:bg-surfaceHover transition-colors"><i class="fa-solid fa-italic text-sm"></i></button>
+                                <button type="button" class="p-1.5 rounded text-textMuted hover:text-textMain hover:bg-surfaceHover transition-colors"><i class="fa-solid fa-underline text-sm"></i></button>
+                                <div class="w-px h-4 bg-border/50 mx-1"></div>
+                                <button type="button" class="p-1.5 rounded text-textMuted hover:text-textMain hover:bg-surfaceHover transition-colors"><i class="fa-solid fa-list-ul text-sm"></i></button>
+                                <button type="button" class="p-1.5 rounded text-textMuted hover:text-textMain hover:bg-surfaceHover transition-colors"><i class="fa-solid fa-list-ol text-sm"></i></button>
+                                <div class="w-px h-4 bg-border/50 mx-1"></div>
+                                <button type="button" class="p-1.5 rounded text-textMuted hover:text-textMain hover:bg-surfaceHover transition-colors"><i class="fa-solid fa-link text-sm"></i></button>
+                            </div>
+                            <textarea id="description" rows="8" class="w-full bg-transparent p-4 text-textMain text-sm focus:outline-none resize-y custom-scrollbar">We are seeking an experienced Lead System Architect to design and oversee the implementation of our new national digital health infrastructure. This role involves working closely with the Ministry of Health and international tech partners to ensure a robust, scalable, and secure system.
+
+Key Responsibilities:
+- Design end-to-end architecture for the national health data exchange.
+- Ensure compliance with international healthcare data standards (HL7, FHIR).
+- Lead a team of senior developers and data engineers.
+- Evaluate and select appropriate cloud infrastructure providers.
+
+The ideal candidate will have a strong background in public sector IT transformations and a deep understanding of healthcare informatics.</textarea>
+                        </div>
+                    </div>
+
+                    <div class="flex flex-col gap-2">
+                        <label for="skills" class="text-sm font-medium text-textMain">Skills (comma separated) <span class="text-danger">*</span></label>
+                        <input type="text" id="skills" value="System Architecture, Cloud Infrastructure, HL7/FHIR, Team Leadership, Healthcare Informatics" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">
+                        <div class="flex flex-wrap gap-2 mt-2">
+                            <span class="inline-flex items-center gap-1.5 px-3 py-1 bg-surface border border-border/50 rounded-full text-xs text-textMuted">
+                                System Architecture <button type="button" class="hover:text-danger transition-colors"><i class="fa-solid fa-xmark"></i></button>
+                            </span>
+                            <span class="inline-flex items-center gap-1.5 px-3 py-1 bg-surface border border-border/50 rounded-full text-xs text-textMuted">
+                                Cloud Infrastructure <button type="button" class="hover:text-danger transition-colors"><i class="fa-solid fa-xmark"></i></button>
+                            </span>
+                            <span class="inline-flex items-center gap-1.5 px-3 py-1 bg-surface border border-border/50 rounded-full text-xs text-textMuted">
+                                HL7/FHIR <button type="button" class="hover:text-danger transition-colors"><i class="fa-solid fa-xmark"></i></button>
+                            </span>
+                        </div>
+                    </div>
+
+                    <div class="flex flex-col sm:flex-row gap-6">
+                        <div class="flex flex-col gap-2 flex-1">
+                            <label for="slots" class="text-sm font-medium text-textMain">Available Slots <span class="text-danger">*</span></label>
+                            <input type="number" id="slots" value="1" min="1" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">
+                        </div>
+                        <div class="flex flex-col gap-2 flex-1">
+                            <label for="duration" class="text-sm font-medium text-textMain">Duration (Weeks)</label>
+                            <input type="number" id="duration" value="24" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+
+            <!-- Section 3: Optional Details -->
+            <div id="section-optional-details" class="bg-surface rounded-xl border border-border/50 overflow-hidden shadow-lg">
+                <div class="px-6 py-4 border-b border-border/50 bg-surface flex items-center justify-between">
+                    <h2 class="text-base font-semibold text-textMain">Optional Details</h2>
+                    <button type="button" class="text-textMuted hover:text-textMain transition-colors"><i class="fa-solid fa-chevron-down text-sm"></i></button>
+                </div>
+                <div class="p-6 flex flex-col gap-6">
+                    
+                    <div class="flex flex-col sm:flex-row gap-6">
+                        <div class="flex flex-col gap-2 flex-1">
+                            <label for="location" class="text-sm font-medium text-textMain">Location</label>
+                            <input type="text" id="location" value="Hybrid (Capital City / Remote)" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">
+                        </div>
+                        <div class="flex flex-col gap-2 flex-1">
+                            <label for="compensation" class="text-sm font-medium text-textMain">Compensation</label>
+                            <input type="text" id="compensation" value="$120,000 - $150,000 USD" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">
+                        </div>
+                    </div>
+
+                    <div class="flex flex-col gap-2">
+                        <label for="deadline" class="text-sm font-medium text-textMain">Application Deadline</label>
+                        <div class="relative w-full sm:w-1/2">
+                            <input type="date" id="deadline" value="2026-10-15" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent [color-scheme:dark]">
+                        </div>
+                    </div>
+
+                    <div class="flex flex-col gap-2">
+                        <label for="external-links" class="text-sm font-medium text-textMain">External Links (One per line)</label>
+                        <textarea id="external-links" rows="3" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent resize-y custom-scrollbar">https://example.gov/preliminary-architecture.pdf
+https://example.gov/digital-strategy-2025</textarea>
+                    </div>
+
+                </div>
+            </div>
+
+            <!-- Actions -->
+            <div id="form-actions" class="flex flex-col gap-4 mt-4 mb-12">
+                <button type="submit" class="w-full bg-primary hover:bg-primaryHover text-white font-medium py-3 px-4 rounded-lg transition-all shadow-[0_0_15px_rgba(59,130,246,0.2)] hover:shadow-[0_0_20px_rgba(59,130,246,0.4)] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-background focus:ring-primary text-center">
+                    Save Changes
+                </button>
+                <div class="text-center">
+                    <a href="#" class="text-sm text-textMuted hover:text-textMain transition-colors">Cancel and return to CFEOI Details</a>
+                </div>
+            </div>
+
+        </form>
+
+    </main>
+
+    <footer id="footer" class="w-full text-center text-xs text-textMuted/50 py-6 mt-auto relative z-10 border-t border-border/50 bg-background">
+        &copy; 2026 Herit Civic Platform. All rights reserved.
+    </footer>
+
+</body>
+</html>

--- a/docs/frontend/portal/designs/flow3c/05-close-cfeoi-modal.html
+++ b/docs/frontend/portal/designs/flow3c/05-close-cfeoi-modal.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        window.FontAwesomeConfig = {
+          autoReplaceSvg: 'nest'
+        };
+      </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/js/all.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Close CFEOI Confirmation - Herit Civic Platform</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['Inter', 'sans-serif'],
+                    },
+                    colors: {
+                        background: '#F9FAFB',
+                        surface: '#FFFFFF',
+                        surfaceHover: '#F9FAFB',
+                        primary: '#3B82F6',
+                        primaryHover: '#2563EB',
+                        textMain: '#111827',
+                        textMuted: '#6B7280',
+                        border: '#E5E7EB',
+                        inputBg: '#F9FAFB',
+                        success: '#10B981',
+                        danger: '#EF4444',
+                        infoBanner: '#DBEAFE',
+                        infoBannerText: '#1E40AF',
+                        'primary-blue': '#1D4ED8',
+                        'primary-light': '#EFF6FF',
+                        'surface-main': '#FFFFFF',
+                        'surface-subtle': '#F9FAFB',
+                        'surface-border': '#E5E7EB',
+                        'text-main': '#111827',
+                        'text-muted': '#6B7280',
+                        'status-error': '#DC2626',
+                        'status-errorLight': '#FEF2F2',
+                    },
+                    boxShadow: {
+                        'soft': '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1)',
+                        'card': '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1)',
+                        'nav': '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            background-color: #F9FAFB;
+            color: #111827;
+            font-family: 'Inter', sans-serif;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .custom-scrollbar::-webkit-scrollbar {
+            height: 6px;
+            width: 6px;
+        }
+        .custom-scrollbar::-webkit-scrollbar-track {
+            background: #F3F4F6;
+            border-radius: 4px;
+        }
+        .custom-scrollbar::-webkit-scrollbar-thumb {
+            background: #E5E7EB;
+            border-radius: 4px;
+        }
+        .custom-scrollbar::-webkit-scrollbar-thumb:hover {
+            background: #D1D5DB;
+        }
+    </style>
+</head>
+<body class="relative overflow-x-hidden min-h-screen flex flex-col">
+
+    <!-- Top Navigation -->
+    <header id="header"
+      class="bg-surface-main border-b border-surface-border shadow-nav sticky top-0 z-50 h-16 flex items-center justify-between px-6">
+      <!-- Left Nav -->
+      <div class="flex items-center gap-8"><a href="#"
+          class="flex items-center gap-2 group">
+          <div class="w-8 h-8 bg-brand-500 rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
+            H
+          </div><span
+            class="text-lg font-bold tracking-tight text-text-main group-hover:text-primary-blue transition-colors">Herit</span>
+        </a>
+        <nav class="hidden md:flex items-center gap-6"><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">Browse
+            RFPs</a><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">Public
+            Proposals</a><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">CFEOI
+            Directory</a></nav>
+      </div><!-- Right Nav -->
+      <div class="flex items-center gap-4"><button
+          class="hidden sm:flex bg-primary-blue hover:bg-primary-blue/90 text-white text-sm font-medium py-2 px-4 rounded-lg transition-colors shadow-soft items-center gap-2"><i
+            class="fa-solid fa-plus text-xs"></i>
+          Create Proposal
+        </button>
+        <div class="relative group cursor-pointer">
+          <div class="flex items-center gap-2"><img
+              src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-2.jpg"
+              alt="User Avatar"
+              class="w-9 h-9 rounded-full object-cover border-2 border-surface-main shadow-sm"><i
+              class="fa-solid fa-chevron-down text-xs text-text-muted group-hover:text-text-main transition-colors"></i>
+          </div>
+          <div
+            class="absolute right-0 mt-2 w-48 bg-surface-main rounded-xl shadow-card border border-surface-border py-1 hidden group-hover:block z-50">
+            <a href="#"
+              class="block px-4 py-2 text-sm text-text-main bg-surface-subtle font-medium">My Dashboard</a>
+            <a href="#"
+              class="block px-4 py-2 text-sm text-text-main bg-surface-subtle font-medium">My Proposals</a>
+            <div class="h-px bg-surface-border my-1"></div><a href="#"
+              class="block px-4 py-2 text-sm text-status-error hover:bg-status-errorLight transition-colors">Sign
+              Out</a>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <!-- Background Content (CFEOI Detail Page behind modal) -->
+    <main id="main-content" class="relative z-10 flex-1 w-full max-w-[1440px] mx-auto px-4 sm:px-6 lg:px-8 py-8 opacity-40 pointer-events-none blur-[2px]">
+        
+        <!-- Breadcrumb -->
+        <nav id="breadcrumb" class="flex text-sm text-textMuted mb-8" aria-label="Breadcrumb">
+            <ol class="inline-flex items-center space-x-1 md:space-x-2">
+                <li class="inline-flex items-center">
+                    <span class="text-textMuted">My Proposals</span>
+                </li>
+                <li>
+                    <div class="flex items-center">
+                        <i class="fa-solid fa-chevron-right text-[10px] mx-2"></i>
+                        <span class="text-textMuted">Digital Health Infrastructure Upgrade</span>
+                    </div>
+                </li>
+                <li>
+                    <div class="flex items-center">
+                        <i class="fa-solid fa-chevron-right text-[10px] mx-2"></i>
+                        <span class="text-textMain font-medium">Lead System Architect</span>
+                    </div>
+                </li>
+            </ol>
+        </nav>
+
+        <div class="flex flex-col lg:flex-row gap-8">
+            <!-- Left Column: Details -->
+            <div class="flex-1 flex flex-col gap-8">
+                <!-- Header Area -->
+                <div class="flex flex-col gap-4">
+                    <div class="flex items-center gap-3">
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-surface border border-border/50 text-textMuted">Technology & IT</span>
+                        <span class="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium bg-success/10 text-success border border-success/20">
+                            <span class="w-1.5 h-1.5 rounded-full bg-success"></span>
+                            Open
+                        </span>
+                    </div>
+                    <h1 class="text-3xl sm:text-4xl font-bold text-textMain tracking-tight">Lead System Architect</h1>
+                    <p class="text-textMuted">Individual Consultant required for digital health infrastructure.</p>
+                </div>
+
+                <!-- Main Content Card -->
+                <div class="bg-surface rounded-xl border border-border/50 overflow-hidden shadow-lg p-6 flex flex-col gap-6">
+                    <div>
+                        <h3 class="text-base font-semibold text-textMain mb-3">Description</h3>
+                        <div class="text-sm text-textMuted space-y-3 leading-relaxed">
+                            <p>We are seeking an experienced Lead System Architect to design and oversee the implementation of our new national digital health infrastructure. This role involves working closely with the Ministry of Health and international tech partners to ensure a robust, scalable, and secure system.</p>
+                            <p class="font-medium text-textMain mt-4">Key Responsibilities:</p>
+                            <ul class="list-disc pl-5 space-y-1">
+                                <li>Design end-to-end architecture for the national health data exchange.</li>
+                                <li>Ensure compliance with international healthcare data standards (HL7, FHIR).</li>
+                                <li>Lead a team of senior developers and data engineers.</li>
+                                <li>Evaluate and select appropriate cloud infrastructure providers.</li>
+                            </ul>
+                        </div>
+                    </div>
+
+                    <div class="h-px w-full bg-border/50"></div>
+
+                    <div>
+                        <h3 class="text-base font-semibold text-textMain mb-3">Required Skills</h3>
+                        <div class="flex flex-wrap gap-2">
+                            <span class="inline-flex items-center px-3 py-1 bg-inputBg border border-border/50 rounded-full text-xs text-textMain">System Architecture</span>
+                            <span class="inline-flex items-center px-3 py-1 bg-inputBg border border-border/50 rounded-full text-xs text-textMain">Cloud Infrastructure</span>
+                            <span class="inline-flex items-center px-3 py-1 bg-inputBg border border-border/50 rounded-full text-xs text-textMain">HL7/FHIR</span>
+                            <span class="inline-flex items-center px-3 py-1 bg-inputBg border border-border/50 rounded-full text-xs text-textMain">Team Leadership</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Right Column: Sidebar -->
+            <div class="w-full lg:w-80 flex flex-col gap-6">
+                <!-- Actions Card -->
+                <div class="bg-surface rounded-xl border border-border/50 shadow-lg p-5 flex flex-col gap-3">
+                    <button class="w-full bg-surfaceHover border border-border/50 text-textMain hover:text-white font-medium py-2.5 px-4 rounded-lg transition-colors text-sm text-center">
+                        Edit CFEOI
+                    </button>
+                    <button class="w-full bg-danger/10 border border-danger/20 text-danger hover:bg-danger hover:text-white font-medium py-2.5 px-4 rounded-lg transition-colors text-sm text-center">
+                        Close CFEOI
+                    </button>
+                </div>
+
+                <!-- Stats Card -->
+                <div class="bg-surface rounded-xl border border-border/50 shadow-lg p-5">
+                    <h3 class="text-sm font-medium text-textMuted mb-4 uppercase tracking-wider">Expressions of Interest</h3>
+                    <div class="flex items-end gap-3 mb-4">
+                        <span class="text-3xl font-bold text-textMain">12</span>
+                        <span class="text-sm text-textMuted mb-1">submitted</span>
+                    </div>
+                    <button class="w-full bg-inputBg border border-border/50 text-textMain hover:bg-surfaceHover font-medium py-2 px-4 rounded-lg transition-colors text-sm text-center">
+                        View All EOIs
+                    </button>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <!-- Modal Overlay (Active Layer) -->
+    <div id="modal-overlay" class="fixed inset-0 z-[100] flex items-center justify-center p-4 sm:p-6" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+        <!-- Backdrop -->
+        <div class="absolute inset-0 bg-background/80 backdrop-blur-sm transition-opacity"></div>
+
+        <!-- Modal Panel -->
+        <div class="relative bg-surface rounded-[14px] border border-border/50 shadow-2xl w-full max-w-md transform transition-all flex flex-col overflow-hidden">
+            
+            <!-- Modal Header / Icon -->
+            <div class="px-6 pt-8 pb-4 flex flex-col items-center text-center">
+                <div class="w-16 h-16 rounded-full bg-danger/10 border border-danger/20 flex items-center justify-center mb-5 shadow-[0_0_20px_rgba(239,68,68,0.15)]">
+                    <i class="fa-solid fa-triangle-exclamation text-3xl text-danger"></i>
+                </div>
+                <h2 id="modal-title" class="text-xl font-bold text-textMain mb-2 tracking-tight">Close CFEOI?</h2>
+                <p class="text-sm text-textMuted leading-relaxed max-w-[280px]">
+                    This action is irreversible. Once closed, this role will no longer accept new expressions of interest.
+                </p>
+            </div>
+
+            <!-- Context Info Box -->
+            <div class="px-6 py-4 bg-inputBg/50 border-y border-border/50 flex items-center justify-between mx-6 rounded-lg mb-6">
+                <div class="flex flex-col">
+                    <span class="text-xs text-textMuted mb-1">Target Role</span>
+                    <span class="text-sm font-medium text-textMain">Lead System Architect</span>
+                </div>
+                <div class="flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-medium bg-success/10 text-success border border-success/20">
+                    <span class="w-1.5 h-1.5 rounded-full bg-success"></span>
+                    Currently Open
+                </div>
+            </div>
+
+            <!-- Modal Actions -->
+            <div class="px-6 pb-6 flex flex-col sm:flex-row gap-3">
+                <button type="button" class="w-full sm:w-1/2 bg-surfaceHover border border-border/50 text-textMain hover:bg-border/50 font-medium py-2.5 px-4 rounded-lg transition-colors text-sm text-center focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-surface focus:ring-border">
+                    Cancel
+                </button>
+                <button type="button" class="w-full sm:w-1/2 bg-danger hover:bg-danger/90 text-white font-medium py-2.5 px-4 rounded-lg transition-all shadow-[0_0_15px_rgba(239,68,68,0.2)] hover:shadow-[0_0_20px_rgba(239,68,68,0.4)] text-sm text-center focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-surface focus:ring-danger">
+                    Close CFEOI
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Footer Shell -->
+    <footer id="footer" class="w-full text-center text-xs text-textMuted/50 py-6 mt-auto relative z-10 border-t border-border/50 bg-background opacity-40 pointer-events-none blur-[2px]">
+        &copy; 2026 Herit Civic Platform. All rights reserved.
+    </footer>
+
+</body>
+</html>

--- a/docs/frontend/portal/designs/flow3c/06-eoi-inbox-owner.html
+++ b/docs/frontend/portal/designs/flow3c/06-eoi-inbox-owner.html
@@ -1,0 +1,549 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        window.FontAwesomeConfig = {
+          autoReplaceSvg: 'nest'
+        };
+      </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/js/all.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Expressions of Interest - Herit Civic Platform</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['Inter', 'sans-serif'],
+                    },
+                    colors: {
+                        background: '#F9FAFB',
+                        surface: '#FFFFFF',
+                        surfaceHover: '#F9FAFB',
+                        primary: '#3B82F6',
+                        primaryHover: '#2563EB',
+                        textMain: '#111827',
+                        textMuted: '#6B7280',
+                        border: '#E5E7EB',
+                        inputBg: '#F9FAFB',
+                        success: '#10B981',
+                        danger: '#EF4444',
+                        infoBanner: '#DBEAFE',
+                        infoBannerText: '#1E40AF',
+                        'primary-blue': '#1D4ED8',
+                        'primary-light': '#EFF6FF',
+                        'surface-main': '#FFFFFF',
+                        'surface-subtle': '#F9FAFB',
+                        'surface-border': '#E5E7EB',
+                        'text-main': '#111827',
+                        'text-muted': '#6B7280',
+                        'status-error': '#DC2626',
+                        'status-errorLight': '#FEF2F2',
+                    },
+                    boxShadow: {
+                        'soft': '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1)',
+                        'card': '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1)',
+                        'nav': '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            background-color: #F9FAFB;
+            color: #111827;
+            font-family: 'Inter', sans-serif;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .custom-scrollbar::-webkit-scrollbar {
+            height: 6px;
+            width: 6px;
+        }
+        .custom-scrollbar::-webkit-scrollbar-track {
+            background: #F3F4F6;
+            border-radius: 4px;
+        }
+        .custom-scrollbar::-webkit-scrollbar-thumb {
+            background: #E5E7EB;
+            border-radius: 4px;
+        }
+        .custom-scrollbar::-webkit-scrollbar-thumb:hover {
+            background: #D1D5DB;
+        }
+
+        /* Drawer animation */
+        .drawer-open {
+            transform: translateX(0);
+        }
+        .drawer-closed {
+            transform: translateX(100%);
+        }
+    </style>
+</head>
+<body class="relative overflow-x-hidden min-h-screen flex flex-col">
+
+    <!-- Top Navigation -->
+    <header id="header"
+      class="bg-surface-main border-b border-surface-border shadow-nav sticky top-0 z-50 h-16 flex items-center justify-between px-6">
+      <!-- Left Nav -->
+      <div class="flex items-center gap-8"><a href="#"
+          class="flex items-center gap-2 group">
+          <div class="w-8 h-8 bg-brand-500 rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
+            H
+          </div><span
+            class="text-lg font-bold tracking-tight text-text-main group-hover:text-primary-blue transition-colors">Herit</span>
+        </a>
+        <nav class="hidden md:flex items-center gap-6"><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">Browse
+            RFPs</a><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">Public
+            Proposals</a><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">CFEOI
+            Directory</a></nav>
+      </div><!-- Right Nav -->
+      <div class="flex items-center gap-4"><button
+          class="hidden sm:flex bg-primary-blue hover:bg-primary-blue/90 text-white text-sm font-medium py-2 px-4 rounded-lg transition-colors shadow-soft items-center gap-2"><i
+            class="fa-solid fa-plus text-xs"></i>
+          Create Proposal
+        </button>
+        <div class="relative group cursor-pointer">
+          <div class="flex items-center gap-2"><img
+              src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-2.jpg"
+              alt="User Avatar"
+              class="w-9 h-9 rounded-full object-cover border-2 border-surface-main shadow-sm"><i
+              class="fa-solid fa-chevron-down text-xs text-text-muted group-hover:text-text-main transition-colors"></i>
+          </div>
+          <div
+            class="absolute right-0 mt-2 w-48 bg-surface-main rounded-xl shadow-card border border-surface-border py-1 hidden group-hover:block z-50">
+            <a href="#"
+              class="block px-4 py-2 text-sm text-text-main bg-surface-subtle font-medium">My Dashboard</a>
+            <a href="#"
+              class="block px-4 py-2 text-sm text-text-main bg-surface-subtle font-medium">My Proposals</a>
+            <div class="h-px bg-surface-border my-1"></div><a href="#"
+              class="block px-4 py-2 text-sm text-status-error hover:bg-status-errorLight transition-colors">Sign
+              Out</a>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <!-- Main Content -->
+    <main id="main-content" class="relative z-10 flex-1 w-full max-w-[1440px] mx-auto px-4 sm:px-6 lg:px-8 py-8 flex flex-col gap-6">
+        
+        <!-- Info Banner (CFEOI Closed State) -->
+        <!-- Note: Showing banner based on prompt instruction: "Includes a light blue info banner if CFEOI is Closed." -->
+        <!-- Using the colors from the prior HTML payload (infoBanner and infoBannerText) -->
+        <div id="status-banner" class="bg-infoBanner border border-infoBannerText/30 rounded-lg p-4 flex items-start sm:items-center gap-3 shadow-sm">
+            <i class="fa-solid fa-circle-info text-infoBannerText mt-0.5 sm:mt-0"></i>
+            <div class="flex-1 text-sm text-infoBannerText">
+                <span class="font-semibold">This CFEOI is now closed.</span> It is no longer accepting new expressions of interest. You can still review submitted applications below.
+            </div>
+        </div>
+
+        <!-- Breadcrumb & Header -->
+        <div class="flex flex-col gap-4">
+            <nav id="breadcrumb" class="flex text-sm text-textMuted" aria-label="Breadcrumb">
+                <ol class="inline-flex items-center space-x-1 md:space-x-2">
+                    <li class="inline-flex items-center">
+                        <a href="#" class="hover:text-textMain transition-colors">My Proposals</a>
+                    </li>
+                    <li>
+                        <div class="flex items-center">
+                            <i class="fa-solid fa-chevron-right text-[10px] mx-2"></i>
+                            <a href="#" class="hover:text-textMain transition-colors">Digital Health Infrastructure Upgrade</a>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="flex items-center">
+                            <i class="fa-solid fa-chevron-right text-[10px] mx-2"></i>
+                            <a href="#" class="hover:text-textMain transition-colors">Lead System Architect</a>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="flex items-center">
+                            <i class="fa-solid fa-chevron-right text-[10px] mx-2"></i>
+                            <span class="text-textMain font-medium">Expressions of Interest</span>
+                        </div>
+                    </li>
+                </ol>
+            </nav>
+
+            <div class="flex flex-col sm:flex-row sm:items-end justify-between gap-4">
+                <div class="flex flex-col gap-2">
+                    <h1 class="text-3xl font-bold text-textMain tracking-tight">Expressions of Interest</h1>
+                    <p class="text-textMuted text-sm">Review and manage applicants for Lead System Architect.</p>
+                </div>
+                
+                <!-- Metrics Summary Tiles -->
+                <div class="flex items-center gap-4">
+                    <div class="bg-surface border border-border/50 rounded-lg px-4 py-2 flex flex-col items-center min-w-[100px]">
+                        <span class="text-2xl font-bold text-textMain">12</span>
+                        <span class="text-[10px] uppercase tracking-wider text-textMuted font-medium">Total</span>
+                    </div>
+                    <div class="bg-surface border border-border/50 rounded-lg px-4 py-2 flex flex-col items-center min-w-[100px]">
+                        <span class="text-2xl font-bold text-success">8</span>
+                        <span class="text-[10px] uppercase tracking-wider text-textMuted font-medium">Reviewed</span>
+                    </div>
+                    <div class="bg-surface border border-border/50 rounded-lg px-4 py-2 flex flex-col items-center min-w-[100px]">
+                        <span class="text-2xl font-bold text-primary">4</span>
+                        <span class="text-[10px] uppercase tracking-wider text-textMuted font-medium">Pending</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Filter & List Area -->
+        <div class="bg-surface rounded-xl border border-border/50 shadow-lg flex flex-col overflow-hidden mt-2">
+            
+            <!-- Toolbar -->
+            <div class="p-4 sm:p-5 border-b border-border/50 flex flex-col sm:flex-row gap-4 justify-between items-center bg-surface/50">
+                <div class="relative w-full sm:w-96">
+                    <i class="fa-solid fa-magnifying-glass absolute left-3.5 top-1/2 transform -translate-y-1/2 text-textMuted text-sm"></i>
+                    <input type="text" placeholder="Search applicant name, email, or ID..." class="w-full bg-inputBg border border-border/50 rounded-lg pl-10 pr-4 py-2 text-sm text-textMain placeholder-textMuted focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-colors">
+                </div>
+                
+                <div class="flex items-center gap-3 w-full sm:w-auto">
+                    <div class="relative flex-1 sm:flex-none">
+                        <select class="w-full sm:w-auto appearance-none bg-inputBg border border-border/50 rounded-lg pl-4 pr-10 py-2 text-sm text-textMain focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-colors cursor-pointer">
+                            <option value="">Status: All</option>
+                            <option value="pending">Pending Review</option>
+                            <option value="reviewed">Reviewed</option>
+                            <option value="shortlisted">Shortlisted</option>
+                            <option value="rejected">Rejected</option>
+                        </select>
+                        <i class="fa-solid fa-chevron-down absolute right-3.5 top-1/2 transform -translate-y-1/2 text-textMuted text-[10px] pointer-events-none"></i>
+                    </div>
+                    
+                    <button class="bg-surfaceHover border border-border/50 text-textMain hover:bg-border/50 px-4 py-2 rounded-lg text-sm font-medium transition-colors flex items-center gap-2 whitespace-nowrap">
+                        <i class="fa-solid fa-download text-xs"></i>
+                        Export CSV
+                    </button>
+                </div>
+            </div>
+
+            <!-- List Table -->
+            <div class="overflow-x-auto custom-scrollbar">
+                <table class="w-full text-left border-collapse">
+                    <thead>
+                        <tr class="border-b border-border/50 bg-inputBg/30">
+                            <th class="py-4 px-6 text-xs font-semibold text-textMuted uppercase tracking-wider w-12">
+                                <div class="flex items-center justify-center">
+                                    <input type="checkbox" class="rounded border-border/50 bg-inputBg text-primary focus:ring-primary focus:ring-offset-surface">
+                                </div>
+                            </th>
+                            <th class="py-4 px-6 text-xs font-semibold text-textMuted uppercase tracking-wider cursor-pointer hover:text-textMain group">
+                                Applicant <i class="fa-solid fa-sort ml-1 text-border group-hover:text-textMuted"></i>
+                            </th>
+                            <th class="py-4 px-6 text-xs font-semibold text-textMuted uppercase tracking-wider cursor-pointer hover:text-textMain group">
+                                Status <i class="fa-solid fa-sort ml-1 text-border group-hover:text-textMuted"></i>
+                            </th>
+                            <th class="py-4 px-6 text-xs font-semibold text-textMuted uppercase tracking-wider">
+                                ID #
+                            </th>
+                            <th class="py-4 px-6 text-xs font-semibold text-textMuted uppercase tracking-wider cursor-pointer hover:text-textMain group">
+                                Submitted Date <i class="fa-solid fa-sort ml-1 text-border group-hover:text-textMuted"></i>
+                            </th>
+                            <th class="py-4 px-6 text-xs font-semibold text-textMuted uppercase tracking-wider text-right">
+                                Action
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-border/50">
+                        <!-- Row 1 -->
+                        <tr class="hover:bg-surfaceHover/50 transition-colors group">
+                            <td class="py-4 px-6">
+                                <div class="flex items-center justify-center">
+                                    <input type="checkbox" class="rounded border-border/50 bg-inputBg text-primary focus:ring-primary focus:ring-offset-surface">
+                                </div>
+                            </td>
+                            <td class="py-4 px-6">
+                                <div class="flex items-center gap-3">
+                                    <img src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-2.jpg" alt="Applicant" class="w-8 h-8 rounded-full border border-border/50 object-cover">
+                                    <div class="flex flex-col">
+                                        <span class="text-sm font-medium text-textMain">Marcus Johnson</span>
+                                        <span class="text-xs text-textMuted">marcus.j@example.com</span>
+                                    </div>
+                                </div>
+                            </td>
+                            <td class="py-4 px-6">
+                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-medium bg-primary/10 text-primary border border-primary/20">
+                                    Pending Review
+                                </span>
+                            </td>
+                            <td class="py-4 px-6">
+                                <span class="text-sm text-textMuted font-mono">EOI-25678</span>
+                            </td>
+                            <td class="py-4 px-6">
+                                <div class="flex flex-col">
+                                    <span class="text-sm text-textMain">Oct 12, 2026</span>
+                                    <span class="text-xs text-textMuted">10:45 AM</span>
+                                </div>
+                            </td>
+                            <td class="py-4 px-6 text-right">
+                                <button class="bg-primary/10 hover:bg-primary/20 text-primary border border-primary/20 hover:border-primary/40 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors" onclick="document.getElementById('detail-drawer').classList.remove('drawer-closed'); document.getElementById('drawer-backdrop').classList.remove('hidden');">
+                                    View Details
+                                </button>
+                            </td>
+                        </tr>
+
+                        <!-- Row 2 -->
+                        <tr class="hover:bg-surfaceHover/50 transition-colors group">
+                            <td class="py-4 px-6">
+                                <div class="flex items-center justify-center">
+                                    <input type="checkbox" class="rounded border-border/50 bg-inputBg text-primary focus:ring-primary focus:ring-offset-surface">
+                                </div>
+                            </td>
+                            <td class="py-4 px-6">
+                                <div class="flex items-center gap-3">
+                                    <img src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-6.jpg" alt="Applicant" class="w-8 h-8 rounded-full border border-border/50 object-cover">
+                                    <div class="flex flex-col">
+                                        <span class="text-sm font-medium text-textMain">Elena Rodriguez</span>
+                                        <span class="text-xs text-textMuted">elena.r@example.com</span>
+                                    </div>
+                                </div>
+                            </td>
+                            <td class="py-4 px-6">
+                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-medium bg-success/10 text-success border border-success/20">
+                                    Shortlisted
+                                </span>
+                            </td>
+                            <td class="py-4 px-6">
+                                <span class="text-sm text-textMuted font-mono">EOI-56585</span>
+                            </td>
+                            <td class="py-4 px-6">
+                                <div class="flex flex-col">
+                                    <span class="text-sm text-textMain">Oct 11, 2026</span>
+                                    <span class="text-xs text-textMuted">02:30 PM</span>
+                                </div>
+                            </td>
+                            <td class="py-4 px-6 text-right">
+                                <button class="bg-primary/10 hover:bg-primary/20 text-primary border border-primary/20 hover:border-primary/40 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors" onclick="document.getElementById('detail-drawer').classList.remove('drawer-closed'); document.getElementById('drawer-backdrop').classList.remove('hidden');">
+                                    View Details
+                                </button>
+                            </td>
+                        </tr>
+
+                        <!-- Row 3 -->
+                        <tr class="hover:bg-surfaceHover/50 transition-colors group">
+                            <td class="py-4 px-6">
+                                <div class="flex items-center justify-center">
+                                    <input type="checkbox" class="rounded border-border/50 bg-inputBg text-primary focus:ring-primary focus:ring-offset-surface">
+                                </div>
+                            </td>
+                            <td class="py-4 px-6">
+                                <div class="flex items-center gap-3">
+                                    <img src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-3.jpg" alt="Applicant" class="w-8 h-8 rounded-full border border-border/50 object-cover">
+                                    <div class="flex flex-col">
+                                        <span class="text-sm font-medium text-textMain">David Chen</span>
+                                        <span class="text-xs text-textMuted">d.chen@example.com</span>
+                                    </div>
+                                </div>
+                            </td>
+                            <td class="py-4 px-6">
+                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-medium bg-surfaceHover text-textMuted border border-border">
+                                    Reviewed
+                                </span>
+                            </td>
+                            <td class="py-4 px-6">
+                                <span class="text-sm text-textMuted font-mono">EOI-23588</span>
+                            </td>
+                            <td class="py-4 px-6">
+                                <div class="flex flex-col">
+                                    <span class="text-sm text-textMain">Oct 10, 2026</span>
+                                    <span class="text-xs text-textMuted">09:15 AM</span>
+                                </div>
+                            </td>
+                            <td class="py-4 px-6 text-right">
+                                <button class="bg-primary/10 hover:bg-primary/20 text-primary border border-primary/20 hover:border-primary/40 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors" onclick="document.getElementById('detail-drawer').classList.remove('drawer-closed'); document.getElementById('drawer-backdrop').classList.remove('hidden');">
+                                    View Details
+                                </button>
+                            </td>
+                        </tr>
+
+                         <!-- Row 4 -->
+                         <tr class="hover:bg-surfaceHover/50 transition-colors group">
+                            <td class="py-4 px-6">
+                                <div class="flex items-center justify-center">
+                                    <input type="checkbox" class="rounded border-border/50 bg-inputBg text-primary focus:ring-primary focus:ring-offset-surface">
+                                </div>
+                            </td>
+                            <td class="py-4 px-6">
+                                <div class="flex items-center gap-3">
+                                    <img src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-7.jpg" alt="Applicant" class="w-8 h-8 rounded-full border border-border/50 object-cover">
+                                    <div class="flex flex-col">
+                                        <span class="text-sm font-medium text-textMain">Aisha Patel</span>
+                                        <span class="text-xs text-textMuted">apatel@example.com</span>
+                                    </div>
+                                </div>
+                            </td>
+                            <td class="py-4 px-6">
+                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-medium bg-danger/10 text-danger border border-danger/20">
+                                    Rejected
+                                </span>
+                            </td>
+                            <td class="py-4 px-6">
+                                <span class="text-sm text-textMuted font-mono">EOI-45533</span>
+                            </td>
+                            <td class="py-4 px-6">
+                                <div class="flex flex-col">
+                                    <span class="text-sm text-textMain">Oct 08, 2026</span>
+                                    <span class="text-xs text-textMuted">11:20 AM</span>
+                                </div>
+                            </td>
+                            <td class="py-4 px-6 text-right">
+                                <button class="bg-primary/10 hover:bg-primary/20 text-primary border border-primary/20 hover:border-primary/40 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors" onclick="document.getElementById('detail-drawer').classList.remove('drawer-closed'); document.getElementById('drawer-backdrop').classList.remove('hidden');">
+                                    View Details
+                                </button>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            
+            <!-- Pagination -->
+            <div class="p-4 border-t border-border/50 bg-surface/50 flex items-center justify-between">
+                <span class="text-sm text-textMuted">Showing 1 to 4 of 12 entries</span>
+                <div class="flex items-center gap-1">
+                    <button class="w-8 h-8 rounded flex items-center justify-center text-textMuted hover:bg-surfaceHover hover:text-textMain transition-colors disabled:opacity-50 disabled:cursor-not-allowed" disabled>
+                        <i class="fa-solid fa-chevron-left text-xs"></i>
+                    </button>
+                    <button class="w-8 h-8 rounded flex items-center justify-center bg-primary text-white text-sm font-medium">1</button>
+                    <button class="w-8 h-8 rounded flex items-center justify-center text-textMuted hover:bg-surfaceHover hover:text-textMain text-sm font-medium transition-colors">2</button>
+                    <button class="w-8 h-8 rounded flex items-center justify-center text-textMuted hover:bg-surfaceHover hover:text-textMain text-sm font-medium transition-colors">3</button>
+                    <button class="w-8 h-8 rounded flex items-center justify-center text-textMuted hover:bg-surfaceHover hover:text-textMain transition-colors">
+                        <i class="fa-solid fa-chevron-right text-xs"></i>
+                    </button>
+                </div>
+            </div>
+        </div>
+
+    </main>
+
+    <!-- Detail Drawer Overlay -->
+    <div id="drawer-backdrop" class="fixed inset-0 z-[100] bg-background/80 backdrop-blur-sm transition-opacity hidden" onclick="document.getElementById('detail-drawer').classList.add('drawer-closed'); this.classList.add('hidden');"></div>
+    
+    <div id="detail-drawer" class="fixed inset-y-0 right-0 z-[110] w-full max-w-md bg-surface border-l border-border/50 shadow-2xl flex flex-col transform transition-transform duration-300 ease-in-out drawer-closed">
+        
+        <!-- Drawer Header -->
+        <div class="px-6 py-4 border-b border-border/50 flex items-center justify-between bg-surface/80 backdrop-blur-md sticky top-0 z-10">
+            <h2 class="text-lg font-bold text-textMain">EOI Details</h2>
+            <button class="w-8 h-8 rounded-full flex items-center justify-center text-textMuted hover:text-textMain hover:bg-surfaceHover transition-colors" onclick="document.getElementById('detail-drawer').classList.add('drawer-closed'); document.getElementById('drawer-backdrop').classList.add('hidden');">
+                <i class="fa-solid fa-xmark"></i>
+            </button>
+        </div>
+
+        <!-- Drawer Content -->
+        <div class="flex-1 overflow-y-auto custom-scrollbar p-6 flex flex-col gap-8">
+            
+            <!-- Applicant Profile Summary -->
+            <div class="flex items-start gap-4">
+                <img src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-2.jpg" alt="Marcus Johnson" class="w-16 h-16 rounded-full border-2 border-border/50 object-cover shadow-md">
+                <div class="flex flex-col gap-1">
+                    <h3 class="text-xl font-bold text-textMain tracking-tight">Marcus Johnson</h3>
+                    <div class="flex items-center gap-2 text-sm text-textMuted">
+                        <i class="fa-regular fa-envelope"></i> marcus.j@example.com
+                    </div>
+                    <div class="flex items-center gap-2 text-sm text-textMuted">
+                        <i class="fa-solid fa-location-dot"></i> London, UK (Diaspora)
+                    </div>
+                </div>
+            </div>
+
+            <!-- Status & Meta -->
+            <div class="grid grid-cols-2 gap-4">
+                <div class="bg-inputBg border border-border/50 rounded-lg p-3 flex flex-col gap-1">
+                    <span class="text-xs text-textMuted uppercase tracking-wider">Status</span>
+                    <span class="inline-flex self-start items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary border border-primary/20">
+                        Pending Review
+                    </span>
+                </div>
+                <div class="bg-inputBg border border-border/50 rounded-lg p-3 flex flex-col gap-1">
+                    <span class="text-xs text-textMuted uppercase tracking-wider">Submitted</span>
+                    <span class="text-sm font-medium text-textMain">Oct 12, 2026</span>
+                </div>
+                <div class="bg-inputBg border border-border/50 rounded-lg p-3 flex flex-col gap-1">
+                    <span class="text-xs text-textMuted uppercase tracking-wider">EOI ID</span>
+                    <span class="text-sm font-medium text-textMain font-mono">EOI-25678</span>
+                </div>
+                <div class="bg-inputBg border border-border/50 rounded-lg p-3 flex flex-col gap-1">
+                    <span class="text-xs text-textMuted uppercase tracking-wider">Experience</span>
+                    <span class="text-sm font-medium text-textMain">12+ Years</span>
+                </div>
+            </div>
+
+            <!-- Cover Letter / Statement -->
+            <div class="flex flex-col gap-3">
+                <h4 class="text-sm font-semibold text-textMain uppercase tracking-wider border-b border-border/50 pb-2">Statement of Interest</h4>
+                <div class="text-sm text-textMuted leading-relaxed space-y-3">
+                    <p>I am writing to express my strong interest in the Lead System Architect role for the Digital Health Infrastructure Upgrade. With over a decade of experience designing scalable health data systems in the UK National Health Service, I believe I can bring valuable expertise to this initiative.</p>
+                    <p>My background includes leading the architecture for HL7/FHIR compliant data exchanges and managing cross-functional teams of developers and clinical informaticists.</p>
+                </div>
+            </div>
+
+            <!-- Attachments -->
+            <div class="flex flex-col gap-3">
+                <h4 class="text-sm font-semibold text-textMain uppercase tracking-wider border-b border-border/50 pb-2">Attachments</h4>
+                <div class="flex flex-col gap-2">
+                    <a href="#" class="flex items-center gap-3 p-3 rounded-lg border border-border/50 bg-inputBg hover:bg-surfaceHover transition-colors group">
+                        <div class="w-8 h-8 rounded bg-primary/10 text-primary flex items-center justify-center">
+                            <i class="fa-solid fa-file-pdf"></i>
+                        </div>
+                        <div class="flex flex-col flex-1">
+                            <span class="text-sm font-medium text-textMain group-hover:text-primary transition-colors">Resume_MJohnson_2026.pdf</span>
+                            <span class="text-xs text-textMuted">2.4 MB</span>
+                        </div>
+                        <i class="fa-solid fa-download text-textMuted group-hover:text-textMain"></i>
+                    </a>
+                    <a href="#" class="flex items-center gap-3 p-3 rounded-lg border border-border/50 bg-inputBg hover:bg-surfaceHover transition-colors group">
+                        <div class="w-8 h-8 rounded bg-primary/10 text-primary flex items-center justify-center">
+                            <i class="fa-solid fa-link"></i>
+                        </div>
+                        <div class="flex flex-col flex-1">
+                            <span class="text-sm font-medium text-textMain group-hover:text-primary transition-colors">LinkedIn Profile</span>
+                            <span class="text-xs text-textMuted">External Link</span>
+                        </div>
+                        <i class="fa-solid fa-arrow-up-right-from-square text-textMuted group-hover:text-textMain text-xs"></i>
+                    </a>
+                </div>
+            </div>
+
+        </div>
+
+        <!-- Drawer Footer / Actions -->
+        <div class="p-6 border-t border-border/50 bg-surface/80 backdrop-blur-md">
+            <div class="flex flex-col gap-3">
+                <label class="text-xs text-textMuted uppercase tracking-wider font-semibold">Update Status</label>
+                <div class="grid grid-cols-2 gap-3">
+                    <button class="bg-success/10 hover:bg-success/20 text-success border border-success/20 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors">
+                        Shortlist
+                    </button>
+                    <button class="bg-danger/10 hover:bg-danger/20 text-danger border border-danger/20 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors">
+                        Reject
+                    </button>
+                </div>
+                <button class="w-full bg-surfaceHover border border-border/50 text-textMain hover:bg-border/50 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors mt-2" onclick="document.getElementById('detail-drawer').classList.add('drawer-closed'); document.getElementById('drawer-backdrop').classList.add('hidden');">
+                    Close Drawer
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Footer Shell -->
+    <footer id="footer" class="w-full text-center text-xs text-textMuted/50 py-6 mt-auto relative z-10 border-t border-border/50 bg-background">
+        &copy; 2026 Herit Civic Platform. All rights reserved.
+    </footer>
+
+</body>
+</html>

--- a/frontend/portal/src/components/nav/AuthenticatedNav.tsx
+++ b/frontend/portal/src/components/nav/AuthenticatedNav.tsx
@@ -7,8 +7,8 @@ import { useCurrentUser } from '../../hooks/useCurrentUser';
 
 const HeritLogo = () => (
   <Link to="/" className="flex items-center gap-2 group">
-    <div className="w-8 h-8 bg-brand-light rounded-lg flex items-center justify-center border border-blue-200 group-hover:bg-blue-100 transition-colors">
-      <span className="text-brand font-bold text-sm">H</span>
+    <div className="w-8 h-8 bg-brand rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
+      H
     </div>
     <span className="text-lg font-bold tracking-tight text-gray-900 group-hover:text-brand transition-colors">
       Herit

--- a/frontend/portal/src/components/nav/PublicNav.tsx
+++ b/frontend/portal/src/components/nav/PublicNav.tsx
@@ -24,8 +24,8 @@ const GoogleIcon = () => (
 
 const HeritLogo = () => (
   <Link to="/" className="flex items-center gap-2 group">
-    <div className="w-8 h-8 bg-brand-light rounded-lg flex items-center justify-center border border-blue-200 group-hover:bg-blue-100 transition-colors">
-      <span className="text-brand font-bold text-sm">H</span>
+    <div className="w-8 h-8 bg-brand rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
+      H
     </div>
     <span className="text-lg font-bold tracking-tight text-gray-900 group-hover:text-brand transition-colors">
       Herit

--- a/frontend/portal/src/pages/auth/AuthErrorPage.tsx
+++ b/frontend/portal/src/pages/auth/AuthErrorPage.tsx
@@ -24,11 +24,8 @@ export default function AuthErrorPage({ onRetry }: AuthErrorPageProps) {
 
         {/* Brand (outside card) */}
         <div className="mb-8 flex flex-col items-center">
-          <div className="w-12 h-12 bg-brand-light rounded-xl flex items-center justify-center mb-3 shadow-sm border border-brand/10">
-            <svg className="w-6 h-6 text-brand" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                d="M3 21v-4m0 0h4m-4 0l4-4m14 4v-4m0 4h-4m4 0l-4-4M9 20h6a2 2 0 002-2v-8a2 2 0 00-2-2H9a2 2 0 00-2 2v8a2 2 0 002 2zm3-4v.01M12 8V7m0-3v.01M4 4h16" />
-            </svg>
+          <div className="w-12 h-12 bg-brand rounded-xl flex items-center justify-center text-white font-bold text-3xl shadow-sm mb-3">
+            H
           </div>
           <span className="text-xl font-bold tracking-tight text-gray-900">Herit</span>
         </div>

--- a/frontend/portal/src/pages/auth/AuthLoadingPage.tsx
+++ b/frontend/portal/src/pages/auth/AuthLoadingPage.tsx
@@ -16,11 +16,8 @@ export default function AuthLoadingPage() {
 
           {/* Brand */}
           <header className="mb-10 relative z-10">
-            <div className="w-16 h-16 mx-auto bg-brand-light rounded-2xl flex items-center justify-center mb-6 shadow-sm border border-brand/10">
-              <svg className="w-8 h-8 text-brand" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                  d="M3 21v-4m0 0h4m-4 0l4-4m14 4v-4m0 4h-4m4 0l-4-4M9 20h6a2 2 0 002-2v-8a2 2 0 00-2-2H9a2 2 0 00-2 2v8a2 2 0 002 2zm3-4v.01M12 8V7m0-3v.01M4 4h16" />
-              </svg>
+            <div className="w-16 h-16 mx-auto bg-brand rounded-2xl flex items-center justify-center text-white font-bold text-5xl shadow-sm mb-6">
+              H
             </div>
             <h1 className="text-2xl font-bold tracking-tight text-gray-900">Herit</h1>
             <p className="text-sm text-gray-500 mt-1 font-medium">Civic Engagement Platform</p>

--- a/frontend/portal/src/pages/auth/CompleteProfilePage.tsx
+++ b/frontend/portal/src/pages/auth/CompleteProfilePage.tsx
@@ -43,11 +43,8 @@ export default function CompleteProfilePage() {
       <header className="w-full bg-white border-b border-gray-200 sticky top-0 z-50">
         <div className="max-w-7xl mx-auto px-6 h-16 flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <div className="w-8 h-8 bg-brand-light rounded-lg flex items-center justify-center border border-brand/10">
-              <svg className="w-4 h-4 text-brand" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                  d="M3 21v-4m0 0h4m-4 0l4-4m14 4v-4m0 4h-4m4 0l-4-4M9 20h6a2 2 0 002-2v-8a2 2 0 00-2-2H9a2 2 0 00-2 2v8a2 2 0 002 2zm3-4v.01M12 8V7m0-3v.01M4 4h16" />
-              </svg>
+            <div className="w-8 h-8 bg-brand rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
+              H
             </div>
             <span className="text-lg font-bold tracking-tight text-gray-900">Herit</span>
           </div>


### PR DESCRIPTION
## Description

Replaces the incorrect civic/building SVG icon with the correct Herit brand icon (stylised H with solid brand-blue background and white text) across all affected design and implementation files.

The correct icon — as specified in `01-proposal-editor-standalone.html` — is a bold white "H" on a solid brand-colour rounded square. The incorrect icon was a line-art civic/building SVG that leaked from earlier design iterations.

**Design pages fixed:**
- `docs/frontend/portal/designs/flow2/` — all 5 HTML files (loading, auth-error, profile completion, dashboard new/returning user)
- `docs/frontend/portal/designs/flow3c/` — all 6 HTML files (added to version control for the first time)

**Implementation files fixed:**
- `AuthLoadingPage.tsx` — large centered brand icon
- `AuthErrorPage.tsx` — brand icon above the error card
- `CompleteProfilePage.tsx` — brand icon in the sticky header
- `AuthenticatedNav.tsx` — `HeritLogo` component (used by DashboardPage and all authenticated views)
- `PublicNav.tsx` — `HeritLogo` component (used by all public-facing pages)

Note: `flow3b` design files already have the correct icon in-progress; those were intentionally excluded from this commit.

## Linked Issue

Closes #210

## Type of Change

- [x] Bug fix

## Testing Notes

- TypeScript check passes clean (`tsc --noEmit`)
- Visually verified icon pattern matches the reference in `01-proposal-editor-standalone.html`

## Checklist

- [x] Code builds cleanly
- [x] Tests pass
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`fix/incorrect-herit-brand-icon`)