### PR TITLE
Update flow3b design pages to top-nav layout with correct brand icon

### DIFF
--- a/docs/frontend/portal/designs/flow3b/01-my-proposals-list.html
+++ b/docs/frontend/portal/designs/flow3b/01-my-proposals-list.html
@@ -31,6 +31,15 @@
                         background: '#F9FAFB',
                         border: '#E5E7EB',
                         brand: '#3B82F6',
+                        'primary-blue': '#1D4ED8',
+                        'primary-light': '#EFF6FF',
+                        'surface-main': '#FFFFFF',
+                        'surface-subtle': '#F9FAFB',
+                        'surface-border': '#E5E7EB',
+                        'text-main': '#111827',
+                        'text-muted': '#6B7280',
+                        'status-error': '#DC2626',
+                        'status-errorLight': '#FEF2F2',
                         status: {
                             blue: { bg: '#DBEAFE', text: '#1D4ED8' },
                             amber: { bg: '#FEF3C7', text: '#B45309' },
@@ -42,6 +51,7 @@
                     boxShadow: {
                         'soft': '0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03)',
                         'card': '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
+                        'nav': '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
                     }
                 }
             }
@@ -55,44 +65,55 @@
         ::-webkit-scrollbar-thumb:hover { background: #D1D5DB; }
     </style>
 </head>
-<body class="font-sans text-primary h-screen flex overflow-hidden bg-background">
+<body class="font-sans text-primary h-screen flex flex-col overflow-hidden bg-background">
 
-    <!-- Sidebar -->
-    <aside id="sidebar" class="w-[80px] bg-surface border-r border-border flex flex-col items-center py-6 h-full flex-shrink-0 z-20">
-        <div class="w-10 h-10 bg-primary text-white rounded-xl flex items-center justify-center font-bold text-xl mb-8">
+    <!-- Top Navigation -->
+    <header id="header"
+      class="bg-surface-main border-b border-surface-border shadow-nav sticky top-0 z-50 h-16 flex items-center justify-between px-6">
+      <!-- Left Nav -->
+      <div class="flex items-center gap-8"><a href="#"
+          class="flex items-center gap-2 group">
+          <div class="w-8 h-8 bg-brand-500 rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
             H
+          </div><span
+            class="text-lg font-bold tracking-tight text-text-main group-hover:text-primary-blue transition-colors">Herit</span>
+        </a>
+        <nav class="hidden md:flex items-center gap-6"><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">Browse
+            RFPs</a><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">Public
+            Proposals</a><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">CFEOI
+            Directory</a></nav>
+      </div><!-- Right Nav -->
+      <div class="flex items-center gap-4"><button
+          class="hidden sm:flex bg-primary-blue hover:bg-primary-blue/90 text-white text-sm font-medium py-2 px-4 rounded-lg transition-colors shadow-soft items-center gap-2"><i
+            class="fa-solid fa-plus text-xs"></i>
+          Create Proposal
+        </button>
+        <div class="relative group cursor-pointer">
+          <div class="flex items-center gap-2"><img
+              src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-2.jpg"
+              alt="User Avatar"
+              class="w-9 h-9 rounded-full object-cover border-2 border-surface-main shadow-sm"><i
+              class="fa-solid fa-chevron-down text-xs text-text-muted group-hover:text-text-main transition-colors"></i>
+          </div>
+          <div
+            class="absolute right-0 mt-2 w-48 bg-surface-main rounded-xl shadow-card border border-surface-border py-1 hidden group-hover:block z-50">
+            <a href="#"
+              class="block px-4 py-2 text-sm text-text-main bg-surface-subtle font-medium">My Dashboard</a>
+            <a href="#"
+              class="block px-4 py-2 text-sm text-text-main bg-surface-subtle font-medium">My Proposals</a>
+            <div class="h-px bg-surface-border my-1"></div><a href="#"
+              class="block px-4 py-2 text-sm text-status-error hover:bg-status-errorLight transition-colors">Sign
+              Out</a>
+          </div>
         </div>
-        
-        <nav class="flex flex-col gap-4 w-full px-3 flex-1">
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-house text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center bg-primary text-white shadow-md group relative">
-                <i class="fa-solid fa-file-lines text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-users text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-chart-simple text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-folder-open text-lg"></i>
-            </a>
-        </nav>
-
-        <div class="flex flex-col gap-4 w-full px-3 mt-auto">
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors">
-                <i class="fa-solid fa-gear text-lg"></i>
-            </a>
-            <button class="w-10 h-10 rounded-full overflow-hidden border-2 border-border mt-2">
-                <img src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-4.jpg" alt="User Profile" class="w-full h-full object-cover">
-            </button>
-        </div>
-    </aside>
+      </div>
+    </header>
 
     <!-- Main Content -->
-    <main id="main-content" class="flex-1 flex h-full overflow-hidden">
+    <main id="main-content" class="flex-1 flex overflow-hidden">
         
         <!-- Left Column: Proposals List (2/3 width) -->
         <section id="proposals-list-section" class="flex-1 flex flex-col h-full border-r border-border bg-surface relative z-10">

--- a/docs/frontend/portal/designs/flow3b/02-proposal-detail-resourcing-owner.html
+++ b/docs/frontend/portal/designs/flow3b/02-proposal-detail-resourcing-owner.html
@@ -31,6 +31,15 @@
                         background: '#F9FAFB',
                         border: '#E5E7EB',
                         brand: '#3B82F6',
+                        'primary-blue': '#1D4ED8',
+                        'primary-light': '#EFF6FF',
+                        'surface-main': '#FFFFFF',
+                        'surface-subtle': '#F9FAFB',
+                        'surface-border': '#E5E7EB',
+                        'text-main': '#111827',
+                        'text-muted': '#6B7280',
+                        'status-error': '#DC2626',
+                        'status-errorLight': '#FEF2F2',
                         status: {
                             blue: { bg: '#DBEAFE', text: '#1D4ED8' },
                             amber: { bg: '#FEF3C7', text: '#B45309' },
@@ -42,6 +51,7 @@
                     boxShadow: {
                         'soft': '0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03)',
                         'card': '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
+                        'nav': '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
                     }
                 }
             }
@@ -55,44 +65,55 @@
         ::-webkit-scrollbar-thumb:hover { background: #D1D5DB; }
     </style>
 </head>
-<body class="font-sans text-primary h-screen flex overflow-hidden bg-background m-0 p-0">
+<body class="font-sans text-primary h-screen flex flex-col overflow-hidden bg-background m-0 p-0">
 
-    <!-- Sidebar -->
-    <aside id="sidebar" class="w-[80px] bg-surface border-r border-border flex flex-col items-center py-6 h-full flex-shrink-0 z-20">
-        <div class="w-10 h-10 bg-primary text-white rounded-xl flex items-center justify-center font-bold text-xl mb-8">
+    <!-- Top Navigation -->
+    <header id="header"
+      class="bg-surface-main border-b border-surface-border shadow-nav sticky top-0 z-50 h-16 flex items-center justify-between px-6">
+      <!-- Left Nav -->
+      <div class="flex items-center gap-8"><a href="#"
+          class="flex items-center gap-2 group">
+          <div class="w-8 h-8 bg-brand-500 rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
             H
+          </div><span
+            class="text-lg font-bold tracking-tight text-text-main group-hover:text-primary-blue transition-colors">Herit</span>
+        </a>
+        <nav class="hidden md:flex items-center gap-6"><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">Browse
+            RFPs</a><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">Public
+            Proposals</a><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">CFEOI
+            Directory</a></nav>
+      </div><!-- Right Nav -->
+      <div class="flex items-center gap-4"><button
+          class="hidden sm:flex bg-primary-blue hover:bg-primary-blue/90 text-white text-sm font-medium py-2 px-4 rounded-lg transition-colors shadow-soft items-center gap-2"><i
+            class="fa-solid fa-plus text-xs"></i>
+          Create Proposal
+        </button>
+        <div class="relative group cursor-pointer">
+          <div class="flex items-center gap-2"><img
+              src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-2.jpg"
+              alt="User Avatar"
+              class="w-9 h-9 rounded-full object-cover border-2 border-surface-main shadow-sm"><i
+              class="fa-solid fa-chevron-down text-xs text-text-muted group-hover:text-text-main transition-colors"></i>
+          </div>
+          <div
+            class="absolute right-0 mt-2 w-48 bg-surface-main rounded-xl shadow-card border border-surface-border py-1 hidden group-hover:block z-50">
+            <a href="#"
+              class="block px-4 py-2 text-sm text-text-main bg-surface-subtle font-medium">My Dashboard</a>
+            <a href="#"
+              class="block px-4 py-2 text-sm text-text-main bg-surface-subtle font-medium">My Proposals</a>
+            <div class="h-px bg-surface-border my-1"></div><a href="#"
+              class="block px-4 py-2 text-sm text-status-error hover:bg-status-errorLight transition-colors">Sign
+              Out</a>
+          </div>
         </div>
-        
-        <nav class="flex flex-col gap-4 w-full px-3 flex-1">
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-house text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center bg-primary text-white shadow-md group relative">
-                <i class="fa-solid fa-file-lines text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-users text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-chart-simple text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-folder-open text-lg"></i>
-            </a>
-        </nav>
-
-        <div class="flex flex-col gap-4 w-full px-3 mt-auto">
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors">
-                <i class="fa-solid fa-gear text-lg"></i>
-            </a>
-            <button class="w-10 h-10 rounded-full overflow-hidden border-2 border-border mt-2">
-                <img src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-4.jpg" alt="User Profile" class="w-full h-full object-cover">
-            </button>
-        </div>
-    </aside>
+      </div>
+    </header>
 
     <!-- Main Content -->
-    <main id="main-content" class="flex-1 flex h-full overflow-hidden">
+    <main id="main-content" class="flex-1 flex overflow-hidden">
         
         <!-- Left Column: Proposal Detail (2/3 width) -->
         <section id="proposal-detail-section" class="flex-1 flex flex-col h-full border-r border-border bg-surface relative z-10 overflow-y-auto">

--- a/docs/frontend/portal/designs/flow3b/03-proposal-detail-submitted-owner.html
+++ b/docs/frontend/portal/designs/flow3b/03-proposal-detail-submitted-owner.html
@@ -31,6 +31,15 @@
                         background: '#F9FAFB',
                         border: '#E5E7EB',
                         brand: '#3B82F6',
+                        'primary-blue': '#1D4ED8',
+                        'primary-light': '#EFF6FF',
+                        'surface-main': '#FFFFFF',
+                        'surface-subtle': '#F9FAFB',
+                        'surface-border': '#E5E7EB',
+                        'text-main': '#111827',
+                        'text-muted': '#6B7280',
+                        'status-error': '#DC2626',
+                        'status-errorLight': '#FEF2F2',
                         status: {
                             blue: { bg: '#DBEAFE', text: '#1D4ED8' },
                             amber: { bg: '#FEF3C7', text: '#B45309' },
@@ -42,6 +51,7 @@
                     boxShadow: {
                         'soft': '0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03)',
                         'card': '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
+                        'nav': '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
                     }
                 }
             }
@@ -69,44 +79,55 @@
         }
     </style>
 </head>
-<body class="font-sans text-primary h-screen flex overflow-hidden bg-background m-0 p-0">
+<body class="font-sans text-primary h-screen flex flex-col overflow-hidden bg-background m-0 p-0">
 
-    <!-- Sidebar -->
-    <aside id="sidebar" class="w-[80px] bg-surface border-r border-border flex flex-col items-center py-6 h-full flex-shrink-0 z-20">
-        <div class="w-10 h-10 bg-primary text-white rounded-xl flex items-center justify-center font-bold text-xl mb-8">
+    <!-- Top Navigation -->
+    <header id="header"
+      class="bg-surface-main border-b border-surface-border shadow-nav sticky top-0 z-50 h-16 flex items-center justify-between px-6">
+      <!-- Left Nav -->
+      <div class="flex items-center gap-8"><a href="#"
+          class="flex items-center gap-2 group">
+          <div class="w-8 h-8 bg-brand-500 rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
             H
+          </div><span
+            class="text-lg font-bold tracking-tight text-text-main group-hover:text-primary-blue transition-colors">Herit</span>
+        </a>
+        <nav class="hidden md:flex items-center gap-6"><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">Browse
+            RFPs</a><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">Public
+            Proposals</a><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">CFEOI
+            Directory</a></nav>
+      </div><!-- Right Nav -->
+      <div class="flex items-center gap-4"><button
+          class="hidden sm:flex bg-primary-blue hover:bg-primary-blue/90 text-white text-sm font-medium py-2 px-4 rounded-lg transition-colors shadow-soft items-center gap-2"><i
+            class="fa-solid fa-plus text-xs"></i>
+          Create Proposal
+        </button>
+        <div class="relative group cursor-pointer">
+          <div class="flex items-center gap-2"><img
+              src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-2.jpg"
+              alt="User Avatar"
+              class="w-9 h-9 rounded-full object-cover border-2 border-surface-main shadow-sm"><i
+              class="fa-solid fa-chevron-down text-xs text-text-muted group-hover:text-text-main transition-colors"></i>
+          </div>
+          <div
+            class="absolute right-0 mt-2 w-48 bg-surface-main rounded-xl shadow-card border border-surface-border py-1 hidden group-hover:block z-50">
+            <a href="#"
+              class="block px-4 py-2 text-sm text-text-main bg-surface-subtle font-medium">My Dashboard</a>
+            <a href="#"
+              class="block px-4 py-2 text-sm text-text-main bg-surface-subtle font-medium">My Proposals</a>
+            <div class="h-px bg-surface-border my-1"></div><a href="#"
+              class="block px-4 py-2 text-sm text-status-error hover:bg-status-errorLight transition-colors">Sign
+              Out</a>
+          </div>
         </div>
-        
-        <nav class="flex flex-col gap-4 w-full px-3 flex-1">
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-house text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center bg-primary text-white shadow-md group relative">
-                <i class="fa-solid fa-file-lines text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-users text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-chart-simple text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-folder-open text-lg"></i>
-            </a>
-        </nav>
-
-        <div class="flex flex-col gap-4 w-full px-3 mt-auto">
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors">
-                <i class="fa-solid fa-gear text-lg"></i>
-            </a>
-            <button class="w-10 h-10 rounded-full overflow-hidden border-2 border-border mt-2">
-                <img src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-4.jpg" alt="User Profile" class="w-full h-full object-cover">
-            </button>
-        </div>
-    </aside>
+      </div>
+    </header>
 
     <!-- Main Content -->
-    <main id="main-content" class="flex-1 flex h-full overflow-hidden">
+    <main id="main-content" class="flex-1 flex overflow-hidden">
         
         <!-- Left Column: Proposal Detail (2/3 width) -->
         <section id="proposal-detail-section" class="flex-1 flex flex-col h-full border-r border-border bg-surface relative z-10 overflow-y-auto">

--- a/docs/frontend/portal/designs/flow3b/04-proposal-detail-under-review-owner.html
+++ b/docs/frontend/portal/designs/flow3b/04-proposal-detail-under-review-owner.html
@@ -31,6 +31,15 @@
                         background: '#F9FAFB',
                         border: '#E5E7EB',
                         brand: '#3B82F6',
+                        'primary-blue': '#1D4ED8',
+                        'primary-light': '#EFF6FF',
+                        'surface-main': '#FFFFFF',
+                        'surface-subtle': '#F9FAFB',
+                        'surface-border': '#E5E7EB',
+                        'text-main': '#111827',
+                        'text-muted': '#6B7280',
+                        'status-error': '#DC2626',
+                        'status-errorLight': '#FEF2F2',
                         status: {
                             blue: { bg: '#DBEAFE', text: '#1D4ED8' },
                             amber: { bg: '#FEF3C7', text: '#B45309' },
@@ -42,6 +51,7 @@
                     boxShadow: {
                         'soft': '0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03)',
                         'card': '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
+                        'nav': '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
                     }
                 }
             }
@@ -69,44 +79,55 @@
         }
     </style>
 </head>
-<body class="font-sans text-primary h-screen flex overflow-hidden bg-background m-0 p-0">
+<body class="font-sans text-primary h-screen flex flex-col overflow-hidden bg-background m-0 p-0">
 
-    <!-- Sidebar -->
-    <aside id="sidebar" class="w-[80px] bg-surface border-r border-border flex flex-col items-center py-6 h-full flex-shrink-0 z-20">
-        <div class="w-10 h-10 bg-primary text-white rounded-xl flex items-center justify-center font-bold text-xl mb-8">
+    <!-- Top Navigation -->
+    <header id="header"
+      class="bg-surface-main border-b border-surface-border shadow-nav sticky top-0 z-50 h-16 flex items-center justify-between px-6">
+      <!-- Left Nav -->
+      <div class="flex items-center gap-8"><a href="#"
+          class="flex items-center gap-2 group">
+          <div class="w-8 h-8 bg-brand-500 rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
             H
+          </div><span
+            class="text-lg font-bold tracking-tight text-text-main group-hover:text-primary-blue transition-colors">Herit</span>
+        </a>
+        <nav class="hidden md:flex items-center gap-6"><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">Browse
+            RFPs</a><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">Public
+            Proposals</a><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">CFEOI
+            Directory</a></nav>
+      </div><!-- Right Nav -->
+      <div class="flex items-center gap-4"><button
+          class="hidden sm:flex bg-primary-blue hover:bg-primary-blue/90 text-white text-sm font-medium py-2 px-4 rounded-lg transition-colors shadow-soft items-center gap-2"><i
+            class="fa-solid fa-plus text-xs"></i>
+          Create Proposal
+        </button>
+        <div class="relative group cursor-pointer">
+          <div class="flex items-center gap-2"><img
+              src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-2.jpg"
+              alt="User Avatar"
+              class="w-9 h-9 rounded-full object-cover border-2 border-surface-main shadow-sm"><i
+              class="fa-solid fa-chevron-down text-xs text-text-muted group-hover:text-text-main transition-colors"></i>
+          </div>
+          <div
+            class="absolute right-0 mt-2 w-48 bg-surface-main rounded-xl shadow-card border border-surface-border py-1 hidden group-hover:block z-50">
+            <a href="#"
+              class="block px-4 py-2 text-sm text-text-main bg-surface-subtle font-medium">My Dashboard</a>
+            <a href="#"
+              class="block px-4 py-2 text-sm text-text-main bg-surface-subtle font-medium">My Proposals</a>
+            <div class="h-px bg-surface-border my-1"></div><a href="#"
+              class="block px-4 py-2 text-sm text-status-error hover:bg-status-errorLight transition-colors">Sign
+              Out</a>
+          </div>
         </div>
-        
-        <nav class="flex flex-col gap-4 w-full px-3 flex-1">
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-house text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center bg-primary text-white shadow-md group relative">
-                <i class="fa-solid fa-file-lines text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-users text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-chart-simple text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-folder-open text-lg"></i>
-            </a>
-        </nav>
-
-        <div class="flex flex-col gap-4 w-full px-3 mt-auto">
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors">
-                <i class="fa-solid fa-gear text-lg"></i>
-            </a>
-            <button class="w-10 h-10 rounded-full overflow-hidden border-2 border-border mt-2">
-                <img src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-4.jpg" alt="User Profile" class="w-full h-full object-cover">
-            </button>
-        </div>
-    </aside>
+      </div>
+    </header>
 
     <!-- Main Content -->
-    <main id="main-content" class="flex-1 flex h-full overflow-hidden">
+    <main id="main-content" class="flex-1 flex overflow-hidden">
         
         <!-- Left Column: Proposal Detail (2/3 width) -->
         <section id="proposal-detail-section" class="flex-1 flex flex-col h-full border-r border-border bg-surface relative z-10 overflow-y-auto">

--- a/docs/frontend/portal/designs/flow3b/05-proposal-detail-approved-owner.html
+++ b/docs/frontend/portal/designs/flow3b/05-proposal-detail-approved-owner.html
@@ -31,6 +31,15 @@
                         background: '#F9FAFB',
                         border: '#E5E7EB',
                         brand: '#3B82F6',
+                        'primary-blue': '#1D4ED8',
+                        'primary-light': '#EFF6FF',
+                        'surface-main': '#FFFFFF',
+                        'surface-subtle': '#F9FAFB',
+                        'surface-border': '#E5E7EB',
+                        'text-main': '#111827',
+                        'text-muted': '#6B7280',
+                        'status-error': '#DC2626',
+                        'status-errorLight': '#FEF2F2',
                         status: {
                             blue: { bg: '#DBEAFE', text: '#1D4ED8' },
                             amber: { bg: '#FEF3C7', text: '#B45309' },
@@ -42,6 +51,7 @@
                     boxShadow: {
                         'soft': '0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03)',
                         'card': '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
+                        'nav': '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
                     }
                 }
             }
@@ -69,44 +79,55 @@
         }
     </style>
 </head>
-<body class="font-sans text-primary h-screen flex overflow-hidden bg-background m-0 p-0">
+<body class="font-sans text-primary h-screen flex flex-col overflow-hidden bg-background m-0 p-0">
 
-    <!-- Sidebar -->
-    <aside id="sidebar" class="w-[80px] bg-surface border-r border-border flex flex-col items-center py-6 h-full flex-shrink-0 z-20">
-        <div class="w-10 h-10 bg-primary text-white rounded-xl flex items-center justify-center font-bold text-xl mb-8">
+    <!-- Top Navigation -->
+    <header id="header"
+      class="bg-surface-main border-b border-surface-border shadow-nav sticky top-0 z-50 h-16 flex items-center justify-between px-6">
+      <!-- Left Nav -->
+      <div class="flex items-center gap-8"><a href="#"
+          class="flex items-center gap-2 group">
+          <div class="w-8 h-8 bg-brand-500 rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
             H
+          </div><span
+            class="text-lg font-bold tracking-tight text-text-main group-hover:text-primary-blue transition-colors">Herit</span>
+        </a>
+        <nav class="hidden md:flex items-center gap-6"><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">Browse
+            RFPs</a><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">Public
+            Proposals</a><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">CFEOI
+            Directory</a></nav>
+      </div><!-- Right Nav -->
+      <div class="flex items-center gap-4"><button
+          class="hidden sm:flex bg-primary-blue hover:bg-primary-blue/90 text-white text-sm font-medium py-2 px-4 rounded-lg transition-colors shadow-soft items-center gap-2"><i
+            class="fa-solid fa-plus text-xs"></i>
+          Create Proposal
+        </button>
+        <div class="relative group cursor-pointer">
+          <div class="flex items-center gap-2"><img
+              src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-2.jpg"
+              alt="User Avatar"
+              class="w-9 h-9 rounded-full object-cover border-2 border-surface-main shadow-sm"><i
+              class="fa-solid fa-chevron-down text-xs text-text-muted group-hover:text-text-main transition-colors"></i>
+          </div>
+          <div
+            class="absolute right-0 mt-2 w-48 bg-surface-main rounded-xl shadow-card border border-surface-border py-1 hidden group-hover:block z-50">
+            <a href="#"
+              class="block px-4 py-2 text-sm text-text-main bg-surface-subtle font-medium">My Dashboard</a>
+            <a href="#"
+              class="block px-4 py-2 text-sm text-text-main bg-surface-subtle font-medium">My Proposals</a>
+            <div class="h-px bg-surface-border my-1"></div><a href="#"
+              class="block px-4 py-2 text-sm text-status-error hover:bg-status-errorLight transition-colors">Sign
+              Out</a>
+          </div>
         </div>
-        
-        <nav class="flex flex-col gap-4 w-full px-3 flex-1">
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-house text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center bg-primary text-white shadow-md group relative">
-                <i class="fa-solid fa-file-lines text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-users text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-chart-simple text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-folder-open text-lg"></i>
-            </a>
-        </nav>
-
-        <div class="flex flex-col gap-4 w-full px-3 mt-auto">
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors">
-                <i class="fa-solid fa-gear text-lg"></i>
-            </a>
-            <button class="w-10 h-10 rounded-full overflow-hidden border-2 border-border mt-2">
-                <img src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-4.jpg" alt="User Profile" class="w-full h-full object-cover">
-            </button>
-        </div>
-    </aside>
+      </div>
+    </header>
 
     <!-- Main Content -->
-    <main id="main-content" class="flex-1 flex h-full overflow-hidden">
+    <main id="main-content" class="flex-1 flex overflow-hidden">
         
         <!-- Left Column: Proposal Detail (2/3 width) -->
         <section id="proposal-detail-section" class="flex-1 flex flex-col h-full border-r border-border bg-surface relative z-10 overflow-y-auto">

--- a/docs/frontend/portal/designs/flow3b/06-proposal-detail-withdrawn-owner.html
+++ b/docs/frontend/portal/designs/flow3b/06-proposal-detail-withdrawn-owner.html
@@ -31,6 +31,15 @@
                         background: '#F9FAFB',
                         border: '#E5E7EB',
                         brand: '#3B82F6',
+                        'primary-blue': '#1D4ED8',
+                        'primary-light': '#EFF6FF',
+                        'surface-main': '#FFFFFF',
+                        'surface-subtle': '#F9FAFB',
+                        'surface-border': '#E5E7EB',
+                        'text-main': '#111827',
+                        'text-muted': '#6B7280',
+                        'status-error': '#DC2626',
+                        'status-errorLight': '#FEF2F2',
                         status: {
                             blue: { bg: '#DBEAFE', text: '#1D4ED8' },
                             amber: { bg: '#FEF3C7', text: '#B45309' },
@@ -42,6 +51,7 @@
                     boxShadow: {
                         'soft': '0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03)',
                         'card': '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
+                        'nav': '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
                     }
                 }
             }
@@ -69,44 +79,55 @@
         }
     </style>
 </head>
-<body class="font-sans text-primary h-screen flex overflow-hidden bg-background m-0 p-0">
+<body class="font-sans text-primary h-screen flex flex-col overflow-hidden bg-background m-0 p-0">
 
-    <!-- Sidebar -->
-    <aside id="sidebar" class="w-[80px] bg-surface border-r border-border flex flex-col items-center py-6 h-full flex-shrink-0 z-20">
-        <div class="w-10 h-10 bg-primary text-white rounded-xl flex items-center justify-center font-bold text-xl mb-8">
+    <!-- Top Navigation -->
+    <header id="header"
+      class="bg-surface-main border-b border-surface-border shadow-nav sticky top-0 z-50 h-16 flex items-center justify-between px-6">
+      <!-- Left Nav -->
+      <div class="flex items-center gap-8"><a href="#"
+          class="flex items-center gap-2 group">
+          <div class="w-8 h-8 bg-brand-500 rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
             H
+          </div><span
+            class="text-lg font-bold tracking-tight text-text-main group-hover:text-primary-blue transition-colors">Herit</span>
+        </a>
+        <nav class="hidden md:flex items-center gap-6"><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">Browse
+            RFPs</a><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">Public
+            Proposals</a><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">CFEOI
+            Directory</a></nav>
+      </div><!-- Right Nav -->
+      <div class="flex items-center gap-4"><button
+          class="hidden sm:flex bg-primary-blue hover:bg-primary-blue/90 text-white text-sm font-medium py-2 px-4 rounded-lg transition-colors shadow-soft items-center gap-2"><i
+            class="fa-solid fa-plus text-xs"></i>
+          Create Proposal
+        </button>
+        <div class="relative group cursor-pointer">
+          <div class="flex items-center gap-2"><img
+              src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-2.jpg"
+              alt="User Avatar"
+              class="w-9 h-9 rounded-full object-cover border-2 border-surface-main shadow-sm"><i
+              class="fa-solid fa-chevron-down text-xs text-text-muted group-hover:text-text-main transition-colors"></i>
+          </div>
+          <div
+            class="absolute right-0 mt-2 w-48 bg-surface-main rounded-xl shadow-card border border-surface-border py-1 hidden group-hover:block z-50">
+            <a href="#"
+              class="block px-4 py-2 text-sm text-text-main bg-surface-subtle font-medium">My Dashboard</a>
+            <a href="#"
+              class="block px-4 py-2 text-sm text-text-main bg-surface-subtle font-medium">My Proposals</a>
+            <div class="h-px bg-surface-border my-1"></div><a href="#"
+              class="block px-4 py-2 text-sm text-status-error hover:bg-status-errorLight transition-colors">Sign
+              Out</a>
+          </div>
         </div>
-        
-        <nav class="flex flex-col gap-4 w-full px-3 flex-1">
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-house text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center bg-primary text-white shadow-md group relative">
-                <i class="fa-solid fa-file-lines text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-users text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-chart-simple text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-folder-open text-lg"></i>
-            </a>
-        </nav>
-
-        <div class="flex flex-col gap-4 w-full px-3 mt-auto">
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors">
-                <i class="fa-solid fa-gear text-lg"></i>
-            </a>
-            <button class="w-10 h-10 rounded-full overflow-hidden border-2 border-border mt-2">
-                <img src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-4.jpg" alt="User Profile" class="w-full h-full object-cover">
-            </button>
-        </div>
-    </aside>
+      </div>
+    </header>
 
     <!-- Main Content -->
-    <main id="main-content" class="flex-1 flex h-full overflow-hidden">
+    <main id="main-content" class="flex-1 flex overflow-hidden">
         
         <!-- Left Column: Proposal Detail (2/3 width) -->
         <section id="proposal-detail-section" class="flex-1 flex flex-col h-full border-r border-border bg-surface relative z-10 overflow-y-auto">

--- a/docs/frontend/portal/designs/flow3b/07-withdraw-confirmation-modal.html
+++ b/docs/frontend/portal/designs/flow3b/07-withdraw-confirmation-modal.html
@@ -30,6 +30,15 @@
                         background: '#F9FAFB',
                         border: '#E5E7EB',
                         brand: '#3B82F6',
+                        'primary-blue': '#1D4ED8',
+                        'primary-light': '#EFF6FF',
+                        'surface-main': '#FFFFFF',
+                        'surface-subtle': '#F9FAFB',
+                        'surface-border': '#E5E7EB',
+                        'text-main': '#111827',
+                        'text-muted': '#6B7280',
+                        'status-error': '#DC2626',
+                        'status-errorLight': '#FEF2F2',
                         status: {
                             blue: { bg: '#DBEAFE', text: '#1D4ED8' },
                             amber: { bg: '#FEF3C7', text: '#B45309' },
@@ -41,6 +50,7 @@
                     boxShadow: {
                         'soft': '0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03)',
                         'card': '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
+                        'nav': '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
                     }
                 }
             }
@@ -67,44 +77,55 @@
         }
     </style>
 </head>
-<body class="font-sans text-primary h-screen flex overflow-hidden bg-background m-0 p-0 relative">
+<body class="font-sans text-primary h-screen flex flex-col overflow-hidden bg-background m-0 p-0 relative">
 
-    <!-- Sidebar -->
-    <aside id="sidebar" class="w-[80px] bg-surface border-r border-border flex flex-col items-center py-6 h-full flex-shrink-0 z-20">
-        <div class="w-10 h-10 bg-primary text-white rounded-xl flex items-center justify-center font-bold text-xl mb-8">
+    <!-- Top Navigation -->
+    <header id="header"
+      class="bg-surface-main border-b border-surface-border shadow-nav sticky top-0 z-50 h-16 flex items-center justify-between px-6">
+      <!-- Left Nav -->
+      <div class="flex items-center gap-8"><a href="#"
+          class="flex items-center gap-2 group">
+          <div class="w-8 h-8 bg-brand-500 rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
             H
+          </div><span
+            class="text-lg font-bold tracking-tight text-text-main group-hover:text-primary-blue transition-colors">Herit</span>
+        </a>
+        <nav class="hidden md:flex items-center gap-6"><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">Browse
+            RFPs</a><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">Public
+            Proposals</a><a href="#"
+            class="text-sm font-medium text-text-muted hover:text-text-main transition-colors">CFEOI
+            Directory</a></nav>
+      </div><!-- Right Nav -->
+      <div class="flex items-center gap-4"><button
+          class="hidden sm:flex bg-primary-blue hover:bg-primary-blue/90 text-white text-sm font-medium py-2 px-4 rounded-lg transition-colors shadow-soft items-center gap-2"><i
+            class="fa-solid fa-plus text-xs"></i>
+          Create Proposal
+        </button>
+        <div class="relative group cursor-pointer">
+          <div class="flex items-center gap-2"><img
+              src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-2.jpg"
+              alt="User Avatar"
+              class="w-9 h-9 rounded-full object-cover border-2 border-surface-main shadow-sm"><i
+              class="fa-solid fa-chevron-down text-xs text-text-muted group-hover:text-text-main transition-colors"></i>
+          </div>
+          <div
+            class="absolute right-0 mt-2 w-48 bg-surface-main rounded-xl shadow-card border border-surface-border py-1 hidden group-hover:block z-50">
+            <a href="#"
+              class="block px-4 py-2 text-sm text-text-main bg-surface-subtle font-medium">My Dashboard</a>
+            <a href="#"
+              class="block px-4 py-2 text-sm text-text-main bg-surface-subtle font-medium">My Proposals</a>
+            <div class="h-px bg-surface-border my-1"></div><a href="#"
+              class="block px-4 py-2 text-sm text-status-error hover:bg-status-errorLight transition-colors">Sign
+              Out</a>
+          </div>
         </div>
-        
-        <nav class="flex flex-col gap-4 w-full px-3 flex-1">
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-house text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center bg-primary text-white shadow-md group relative">
-                <i class="fa-solid fa-file-lines text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-users text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-chart-simple text-lg"></i>
-            </a>
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors group relative">
-                <i class="fa-solid fa-folder-open text-lg"></i>
-            </a>
-        </nav>
-
-        <div class="flex flex-col gap-4 w-full px-3 mt-auto">
-            <a href="#" class="w-12 h-12 rounded-xl flex items-center justify-center text-secondary hover:bg-gray-50 transition-colors">
-                <i class="fa-solid fa-gear text-lg"></i>
-            </a>
-            <button class="w-10 h-10 rounded-full overflow-hidden border-2 border-border mt-2">
-                <img src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-4.jpg" alt="User Profile" class="w-full h-full object-cover">
-            </button>
-        </div>
-    </aside>
+      </div>
+    </header>
 
     <!-- Main Content (Blurred Background for Modal) -->
-    <main id="main-content" class="flex-1 flex h-full overflow-hidden blur-[2px] pointer-events-none">
+    <main id="main-content" class="flex-1 flex overflow-hidden blur-[2px] pointer-events-none">
         
         <!-- Left Column: Proposal Detail (2/3 width) -->
         <section id="proposal-detail-section" class="flex-1 flex flex-col h-full border-r border-border bg-surface relative z-10 overflow-y-auto">


### PR DESCRIPTION
## Description

Commits the in-progress redesign of the flow3b proposal lifecycle design pages (7 HTML files), converting them from the original sidebar layout to a responsive top navigation layout consistent with the rest of the design system.

Also fixes the Herit brand icon introduced during the layout conversion — the new top nav mistakenly used the incorrect civic SVG, which has been replaced with the correct stylised H icon (`bg-brand-500`, white text, `shadow-sm`).

## Type of Change

- [x] Bug fix
- [x] Chore / refactor

## Testing Notes

Visually verified brand icon matches the correct pattern from `01-proposal-editor-standalone.html` across all 7 files.

## Checklist

- [x] Code builds cleanly
- [x] Tests pass
- [ ] Relevant documentation updated
- [x] Branch follows naming convention