### PR TITLE
Remove invented Category field from flow3c CFEOI screens

### DIFF
--- a/docs/frontend/portal/designs/flow3c/01-cfeoi-publish-form.html
+++ b/docs/frontend/portal/designs/flow3c/01-cfeoi-publish-form.html
@@ -172,19 +172,6 @@
 
                     <div class="flex flex-col gap-4">
                         <div class="flex flex-col gap-1.5">
-                            <label class="text-sm font-medium text-textMain">Category</label>
-                            <div class="relative">
-                                <select class="w-full bg-inputBg border border-border/50 rounded-lg py-2.5 px-4 text-sm text-textMain appearance-none focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all">
-                                    <option value="" disabled selected>Select a category...</option>
-                                    <option value="technology">Technology & IT</option>
-                                    <option value="healthcare">Healthcare Services</option>
-                                    <option value="management">Project Management</option>
-                                </select>
-                                <i class="fa-solid fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-textMuted text-xs pointer-events-none"></i>
-                            </div>
-                        </div>
-
-                        <div class="flex flex-col gap-1.5">
                             <label class="text-sm font-medium text-textMain">Role Title</label>
                             <input type="text" placeholder="e.g. Lead System Architect" class="w-full bg-inputBg border border-border/50 rounded-lg py-3 px-4 text-lg font-semibold text-textMain placeholder-textMuted/50 focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all">
                         </div>

--- a/docs/frontend/portal/designs/flow3c/02-cfeoi-publish-success.html
+++ b/docs/frontend/portal/designs/flow3c/02-cfeoi-publish-success.html
@@ -155,11 +155,7 @@
                 
                 <h2 class="text-xl font-bold text-infoBannerText mb-2">Lead System Architect</h2>
                 
-                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-4 pt-4 border-t border-infoBannerText/10">
-                    <div>
-                        <p class="text-infoBannerText/70 text-xs uppercase tracking-wider font-semibold mb-1">Category</p>
-                        <p class="text-infoBannerText font-medium text-sm">Technology & IT</p>
-                    </div>
+                <div class="mt-4 pt-4 border-t border-infoBannerText/10">
                     <div>
                         <p class="text-infoBannerText/70 text-xs uppercase tracking-wider font-semibold mb-1">Application Deadline</p>
                         <p class="text-infoBannerText font-medium text-sm">October 15, 2026</p>

--- a/docs/frontend/portal/designs/flow3c/03-cfeoi-detail-open-owner.html
+++ b/docs/frontend/portal/designs/flow3c/03-cfeoi-detail-open-owner.html
@@ -172,10 +172,6 @@
                     
                     <div class="flex flex-wrap items-center gap-2 mt-2">
                         <span class="inline-flex items-center px-3 py-1 rounded-md bg-surface border border-border/50 text-textMain text-sm font-medium">
-                            <i class="fa-solid fa-layer-group text-textMuted mr-2"></i>
-                            Technology & IT
-                        </span>
-                        <span class="inline-flex items-center px-3 py-1 rounded-md bg-surface border border-border/50 text-textMain text-sm font-medium">
                             <i class="fa-regular fa-user text-textMuted mr-2"></i>
                             Individual Consultant
                         </span>

--- a/docs/frontend/portal/designs/flow3c/04-cfeoi-edit-form.html
+++ b/docs/frontend/portal/designs/flow3c/04-cfeoi-edit-form.html
@@ -176,18 +176,6 @@
                 <div class="p-6 flex flex-col gap-6">
                     
                     <div class="flex flex-col gap-2">
-                        <label for="category" class="text-sm font-medium text-textMain">Category <span class="text-danger">*</span></label>
-                        <div class="relative">
-                            <select id="category" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent appearance-none">
-                                <option value="technology" selected>Technology & IT</option>
-                                <option value="healthcare">Healthcare</option>
-                                <option value="infrastructure">Infrastructure</option>
-                            </select>
-                            <i class="fa-solid fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-textMuted text-xs pointer-events-none"></i>
-                        </div>
-                    </div>
-
-                    <div class="flex flex-col gap-2">
                         <label for="role-title" class="text-sm font-medium text-textMain">Role Title <span class="text-danger">*</span></label>
                         <input type="text" id="role-title" value="Lead System Architect" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">
                     </div>


### PR DESCRIPTION
## Description

The CFEOI publish form (01), edit form (04), success screen (02), and detail page (03) design mockups all included a "Category" dropdown/tag (e.g. "Technology & IT"). Category is not a field on the CFEOI entity and has no backend/API support (see the CFEOI field list in section 3c of `docs/frontend/portal/user-flows-high-level.md` and the CFEOI entity in the PRD §5.3). This PR removes it from all four static design screens.

## Linked Issue

Closes #218

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Chore / refactor

## Testing Notes

These are static HTML design mockups under `docs/frontend/portal/designs/flow3c/`, not implemented application code — no build/backend changes are involved. Verified visually that removing the Category field/select/badge leaves each layout intact (grid adjusted on the success screen since it had two columns).

## Checklist

- [x] Code builds cleanly (`dotnet build`) — N/A, docs-only change
- [x] Tests pass (`dotnet test`) — N/A, docs-only change
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)