### PR TITLE
Add missing required Title field to CFEOI forms and displays

### DIFF
--- a/docs/frontend/portal/designs/flow3c/01-cfeoi-publish-form.html
+++ b/docs/frontend/portal/designs/flow3c/01-cfeoi-publish-form.html
@@ -172,8 +172,13 @@
 
                     <div class="flex flex-col gap-4">
                         <div class="flex flex-col gap-1.5">
+                            <label class="text-sm font-medium text-textMain">Title</label>
+                            <input type="text" placeholder="e.g. Lead System Architect Search" class="w-full bg-inputBg border border-border/50 rounded-lg py-3 px-4 text-lg font-semibold text-textMain placeholder-textMuted/50 focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all">
+                        </div>
+
+                        <div class="flex flex-col gap-1.5">
                             <label class="text-sm font-medium text-textMain">Role Title</label>
-                            <input type="text" placeholder="e.g. Lead System Architect" class="w-full bg-inputBg border border-border/50 rounded-lg py-3 px-4 text-lg font-semibold text-textMain placeholder-textMuted/50 focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all">
+                            <input type="text" placeholder="e.g. Lead System Architect" class="w-full bg-inputBg border border-border/50 rounded-lg py-2.5 px-4 text-sm text-textMain placeholder-textMuted/50 focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all">
                         </div>
 
                         <div class="flex flex-col gap-2">

--- a/docs/frontend/portal/designs/flow3c/02-cfeoi-publish-success.html
+++ b/docs/frontend/portal/designs/flow3c/02-cfeoi-publish-success.html
@@ -153,9 +153,13 @@
                     <span class="text-infoBannerText font-medium text-sm">ID: CFE-2026-089</span>
                 </div>
                 
-                <h2 class="text-xl font-bold text-infoBannerText mb-2">Lead System Architect</h2>
-                
-                <div class="mt-4 pt-4 border-t border-infoBannerText/10">
+                <h2 class="text-xl font-bold text-infoBannerText mb-2">Lead System Architect Search</h2>
+
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-4 pt-4 border-t border-infoBannerText/10">
+                    <div>
+                        <p class="text-infoBannerText/70 text-xs uppercase tracking-wider font-semibold mb-1">Role Title</p>
+                        <p class="text-infoBannerText font-medium text-sm">Lead System Architect</p>
+                    </div>
                     <div>
                         <p class="text-infoBannerText/70 text-xs uppercase tracking-wider font-semibold mb-1">Application Deadline</p>
                         <p class="text-infoBannerText font-medium text-sm">October 15, 2026</p>

--- a/docs/frontend/portal/designs/flow3c/03-cfeoi-detail-open-owner.html
+++ b/docs/frontend/portal/designs/flow3c/03-cfeoi-detail-open-owner.html
@@ -148,7 +148,7 @@
                 <li>
                     <div class="flex items-center">
                         <i class="fa-solid fa-chevron-right text-[10px] mx-2"></i>
-                        <span class="text-textMain font-medium">Lead System Architect</span>
+                        <span class="text-textMain font-medium">Lead System Architect Search</span>
                     </div>
                 </li>
             </ol>
@@ -168,9 +168,13 @@
                         <span class="text-textMuted text-sm">ID: CFE-2026-089</span>
                     </div>
                     
-                    <h1 class="text-3xl sm:text-4xl font-bold text-textMain tracking-tight">Lead System Architect</h1>
-                    
+                    <h1 class="text-3xl sm:text-4xl font-bold text-textMain tracking-tight">Lead System Architect Search</h1>
+
                     <div class="flex flex-wrap items-center gap-2 mt-2">
+                        <span class="inline-flex items-center px-3 py-1 rounded-md bg-surface border border-border/50 text-textMain text-sm font-medium">
+                            <i class="fa-solid fa-briefcase text-textMuted mr-2"></i>
+                            Role: Lead System Architect
+                        </span>
                         <span class="inline-flex items-center px-3 py-1 rounded-md bg-surface border border-border/50 text-textMain text-sm font-medium">
                             <i class="fa-regular fa-user text-textMuted mr-2"></i>
                             Individual Consultant

--- a/docs/frontend/portal/designs/flow3c/04-cfeoi-edit-form.html
+++ b/docs/frontend/portal/designs/flow3c/04-cfeoi-edit-form.html
@@ -148,7 +148,7 @@
                 <li>
                     <div class="flex items-center">
                         <i class="fa-solid fa-chevron-right text-[10px] mx-2"></i>
-                        <a href="#" class="hover:text-textMain transition-colors">Lead System Architect</a>
+                        <a href="#" class="hover:text-textMain transition-colors">Lead System Architect Search</a>
                     </div>
                 </li>
                 <li>
@@ -175,6 +175,11 @@
                 </div>
                 <div class="p-6 flex flex-col gap-6">
                     
+                    <div class="flex flex-col gap-2">
+                        <label for="title" class="text-sm font-medium text-textMain">Title <span class="text-danger">*</span></label>
+                        <input type="text" id="title" value="Lead System Architect Search" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">
+                    </div>
+
                     <div class="flex flex-col gap-2">
                         <label for="role-title" class="text-sm font-medium text-textMain">Role Title <span class="text-danger">*</span></label>
                         <input type="text" id="role-title" value="Lead System Architect" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">


### PR DESCRIPTION
## Description

The CFEOI entity requires both a **Title** and a **Role Title** as separate required fields (see `docs/frontend/portal/user-flows-high-level.md` §3c and the PRD §5.3), but the flow3c design mockups only had Role Title. This PR adds the missing Title field to the publish form (01) and edit form (04), and updates the success screen (02) and detail page (03) to display it.

Title is now the primary heading/identifier for the CFEOI (page headings, breadcrumbs), with Role Title shown as a supporting detail (a labeled field below Title in the forms, a badge on the detail page, and a row in the summary grid on the success screen).

## Linked Issue

Closes #219

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Chore / refactor

## Testing Notes

These are static HTML design mockups under `docs/frontend/portal/designs/flow3c/`, not implemented application code — no build/backend changes are involved. Verified visually that the new Title field and its relationship to Role Title reads clearly across all four screens.

## Checklist

- [x] Code builds cleanly (`dotnet build`) — N/A, docs-only change
- [x] Tests pass (`dotnet test`) — N/A, docs-only change
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)