### PR TITLE
Fix CFEOI Resource Type options to Human / Non-Human

### DIFF
--- a/docs/frontend/portal/designs/flow3c/01-cfeoi-publish-form.html
+++ b/docs/frontend/portal/designs/flow3c/01-cfeoi-publish-form.html
@@ -166,8 +166,8 @@
                 
                 <section id="role-identity" class="flex flex-col gap-5 border-b border-border/50 pb-8">
                     <div>
-                        <h2 class="text-lg font-semibold text-textMain">Role Identity</h2>
-                        <p class="text-sm text-textMuted mt-1">Basic information about the role you are publishing.</p>
+                        <h2 id="role-identity-heading" class="text-lg font-semibold text-textMain">Role Identity</h2>
+                        <p id="role-identity-desc" class="text-sm text-textMuted mt-1">Basic information about the role you are publishing.</p>
                     </div>
 
                     <div class="flex flex-col gap-4">
@@ -176,37 +176,37 @@
                             <input type="text" placeholder="e.g. Lead System Architect Search" class="w-full bg-inputBg border border-border/50 rounded-lg py-3 px-4 text-lg font-semibold text-textMain placeholder-textMuted/50 focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all">
                         </div>
 
-                        <div class="flex flex-col gap-1.5">
-                            <label class="text-sm font-medium text-textMain">Role Title</label>
-                            <input type="text" placeholder="e.g. Lead System Architect" class="w-full bg-inputBg border border-border/50 rounded-lg py-2.5 px-4 text-sm text-textMain placeholder-textMuted/50 focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all">
-                        </div>
-
                         <div class="flex flex-col gap-2">
                             <label class="text-sm font-medium text-textMain">Resource Type</label>
                             <div class="flex flex-wrap gap-4">
                                 <label class="flex items-center gap-2 cursor-pointer group">
-                                    <input type="radio" name="resource_type" class="hidden peer" checked>
+                                    <input type="radio" name="resource_type" id="resource-type-human" class="hidden peer" checked onchange="updateResourceTypeFraming()">
                                     <div class="w-4 h-4 rounded-full border border-border/50 peer-checked:border-primary peer-checked:bg-primary flex items-center justify-center transition-colors">
                                         <div class="w-2 h-2 rounded-full bg-white opacity-0 peer-checked:opacity-100 transition-opacity"></div>
                                     </div>
-                                    <span class="text-sm text-textMuted group-hover:text-textMain peer-checked:text-textMain transition-colors">Individual Expert</span>
+                                    <span class="text-sm text-textMuted group-hover:text-textMain peer-checked:text-textMain transition-colors">Human <span class="text-textMuted/70">(skills & expertise)</span></span>
                                 </label>
                                 <label class="flex items-center gap-2 cursor-pointer group">
-                                    <input type="radio" name="resource_type" class="hidden peer">
+                                    <input type="radio" name="resource_type" id="resource-type-non-human" class="hidden peer" onchange="updateResourceTypeFraming()">
                                     <div class="w-4 h-4 rounded-full border border-border/50 peer-checked:border-primary peer-checked:bg-primary flex items-center justify-center transition-colors">
                                         <div class="w-2 h-2 rounded-full bg-white opacity-0 peer-checked:opacity-100 transition-opacity"></div>
                                     </div>
-                                    <span class="text-sm text-textMuted group-hover:text-textMain peer-checked:text-textMain transition-colors">Advisory Firm</span>
+                                    <span class="text-sm text-textMuted group-hover:text-textMain peer-checked:text-textMain transition-colors">Non-Human <span class="text-textMuted/70">(infrastructure, real estate, equipment, financial support)</span></span>
                                 </label>
                             </div>
+                        </div>
+
+                        <div class="flex flex-col gap-1.5">
+                            <label id="role-title-label" class="text-sm font-medium text-textMain">Role Title</label>
+                            <input id="role-title-input" type="text" placeholder="e.g. Lead System Architect" class="w-full bg-inputBg border border-border/50 rounded-lg py-2.5 px-4 text-sm text-textMain placeholder-textMuted/50 focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all">
                         </div>
                     </div>
                 </section>
 
                 <section id="role-requirements" class="flex flex-col gap-5 border-b border-border/50 pb-8">
                     <div>
-                        <h2 class="text-lg font-semibold text-textMain">Role Requirements</h2>
-                        <p class="text-sm text-textMuted mt-1">Detailed description and required skills for this role.</p>
+                        <h2 id="role-requirements-heading" class="text-lg font-semibold text-textMain">Role Requirements</h2>
+                        <p id="role-requirements-desc" class="text-sm text-textMuted mt-1">Detailed description and required skills for this role.</p>
                     </div>
 
                     <div class="flex flex-col gap-4">
@@ -225,7 +225,7 @@
                         </div>
 
                         <div class="flex flex-col gap-1.5">
-                            <label class="text-sm font-medium text-textMain">Skills (comma separated)</label>
+                            <label id="skills-label" class="text-sm font-medium text-textMain">Skills (comma separated)</label>
                             <div class="bg-inputBg border border-border/50 rounded-lg p-2 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition-all flex flex-wrap gap-2">
                                 <div class="flex items-center gap-1.5 bg-surfaceHover px-2.5 py-1 rounded-md border border-border">
                                     <span class="text-xs text-textMain">System Architecture</span>
@@ -235,7 +235,7 @@
                                     <span class="text-xs text-textMain">HL7 Integration</span>
                                     <button type="button" class="text-textMuted hover:text-danger transition-colors"><i class="fa-solid fa-xmark text-[10px]"></i></button>
                                 </div>
-                                <input type="text" placeholder="Type a skill and press comma..." class="flex-1 bg-transparent border-none text-sm text-textMain placeholder-textMuted/50 focus:outline-none min-w-[150px] py-1 px-2">
+                                <input id="skills-input" type="text" placeholder="Type a skill and press comma..." class="flex-1 bg-transparent border-none text-sm text-textMain placeholder-textMuted/50 focus:outline-none min-w-[150px] py-1 px-2">
                             </div>
                         </div>
 
@@ -298,6 +298,28 @@
     <footer id="footer" class="w-full text-center text-xs text-textMuted/50 py-6 mt-auto relative z-10">
         &copy; 2026 Herit Civic Platform. All rights reserved.
     </footer>
+
+    <script>
+        function updateResourceTypeFraming() {
+            const isHuman = document.getElementById('resource-type-human').checked;
+
+            document.getElementById('role-identity-heading').textContent = isHuman ? 'Role Identity' : 'Resource Identity';
+            document.getElementById('role-identity-desc').textContent = isHuman
+                ? 'Basic information about the role you are publishing.'
+                : 'Basic information about the resource you are requesting.';
+
+            document.getElementById('role-title-label').textContent = isHuman ? 'Role Title' : 'Resource Name';
+            document.getElementById('role-title-input').placeholder = isHuman ? 'e.g. Lead System Architect' : 'e.g. Field Vehicles (4x4)';
+
+            document.getElementById('role-requirements-heading').textContent = isHuman ? 'Role Requirements' : 'Resource Requirements';
+            document.getElementById('role-requirements-desc').textContent = isHuman
+                ? 'Detailed description and required skills for this role.'
+                : 'Detailed description and specifications for this resource.';
+
+            document.getElementById('skills-label').textContent = isHuman ? 'Skills (comma separated)' : 'Specifications (comma separated)';
+            document.getElementById('skills-input').placeholder = isHuman ? 'Type a skill and press comma...' : 'Type a specification and press comma...';
+        }
+    </script>
 
 </body>
 </html>

--- a/docs/frontend/portal/designs/flow3c/04-cfeoi-edit-form.html
+++ b/docs/frontend/portal/designs/flow3c/04-cfeoi-edit-form.html
@@ -170,19 +170,14 @@
             <!-- Section 1: Role Identity -->
             <div id="section-role-identity" class="bg-surface rounded-xl border border-border/50 overflow-hidden shadow-lg">
                 <div class="px-6 py-4 border-b border-border/50 bg-surface flex items-center justify-between">
-                    <h2 class="text-base font-semibold text-textMain">Role Identity</h2>
+                    <h2 id="role-identity-heading" class="text-base font-semibold text-textMain">Role Identity</h2>
                     <button type="button" class="text-textMuted hover:text-textMain transition-colors"><i class="fa-solid fa-chevron-down text-sm"></i></button>
                 </div>
                 <div class="p-6 flex flex-col gap-6">
-                    
+
                     <div class="flex flex-col gap-2">
                         <label for="title" class="text-sm font-medium text-textMain">Title <span class="text-danger">*</span></label>
                         <input type="text" id="title" value="Lead System Architect Search" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">
-                    </div>
-
-                    <div class="flex flex-col gap-2">
-                        <label for="role-title" class="text-sm font-medium text-textMain">Role Title <span class="text-danger">*</span></label>
-                        <input type="text" id="role-title" value="Lead System Architect" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">
                     </div>
 
                     <div class="flex flex-col gap-3">
@@ -190,21 +185,26 @@
                         <div class="flex flex-col sm:flex-row gap-4">
                             <label class="flex items-center gap-3 cursor-pointer group">
                                 <div class="relative flex items-center justify-center w-5 h-5">
-                                    <input type="radio" name="resource-type" value="individual" class="peer sr-only" checked>
+                                    <input type="radio" name="resource-type" id="resource-type-human" value="human" class="peer sr-only" checked onchange="updateResourceTypeFraming()">
                                     <div class="w-5 h-5 rounded-full border border-border/50 bg-inputBg peer-checked:border-primary peer-checked:bg-primary transition-colors"></div>
                                     <div class="absolute w-2 h-2 rounded-full bg-white opacity-0 peer-checked:opacity-100 transition-opacity"></div>
                                 </div>
-                                <span class="text-sm text-textMuted group-hover:text-textMain transition-colors">Individual Consultant</span>
+                                <span class="text-sm text-textMuted group-hover:text-textMain transition-colors">Human <span class="text-textMuted/70">(skills & expertise)</span></span>
                             </label>
                             <label class="flex items-center gap-3 cursor-pointer group">
                                 <div class="relative flex items-center justify-center w-5 h-5">
-                                    <input type="radio" name="resource-type" value="firm" class="peer sr-only">
+                                    <input type="radio" name="resource-type" id="resource-type-non-human" value="non-human" class="peer sr-only" onchange="updateResourceTypeFraming()">
                                     <div class="w-5 h-5 rounded-full border border-border/50 bg-inputBg peer-checked:border-primary peer-checked:bg-primary transition-colors"></div>
                                     <div class="absolute w-2 h-2 rounded-full bg-white opacity-0 peer-checked:opacity-100 transition-opacity"></div>
                                 </div>
-                                <span class="text-sm text-textMuted group-hover:text-textMain transition-colors">Firm / Organization</span>
+                                <span class="text-sm text-textMuted group-hover:text-textMain transition-colors">Non-Human <span class="text-textMuted/70">(infrastructure, real estate, equipment, financial support)</span></span>
                             </label>
                         </div>
+                    </div>
+
+                    <div class="flex flex-col gap-2">
+                        <label for="role-title" class="text-sm font-medium text-textMain"><span id="role-title-label">Role Title</span> <span class="text-danger">*</span></label>
+                        <input type="text" id="role-title" value="Lead System Architect" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">
                     </div>
 
                 </div>
@@ -213,7 +213,7 @@
             <!-- Section 2: Role Requirements -->
             <div id="section-role-requirements" class="bg-surface rounded-xl border border-border/50 overflow-hidden shadow-lg">
                 <div class="px-6 py-4 border-b border-border/50 bg-surface flex items-center justify-between">
-                    <h2 class="text-base font-semibold text-textMain">Role Requirements</h2>
+                    <h2 id="role-requirements-heading" class="text-base font-semibold text-textMain">Role Requirements</h2>
                     <button type="button" class="text-textMuted hover:text-textMain transition-colors"><i class="fa-solid fa-chevron-down text-sm"></i></button>
                 </div>
                 <div class="p-6 flex flex-col gap-6">
@@ -245,7 +245,7 @@ The ideal candidate will have a strong background in public sector IT transforma
                     </div>
 
                     <div class="flex flex-col gap-2">
-                        <label for="skills" class="text-sm font-medium text-textMain">Skills (comma separated) <span class="text-danger">*</span></label>
+                        <label for="skills" class="text-sm font-medium text-textMain"><span id="skills-label">Skills (comma separated)</span> <span class="text-danger">*</span></label>
                         <input type="text" id="skills" value="System Architecture, Cloud Infrastructure, HL7/FHIR, Team Leadership, Healthcare Informatics" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">
                         <div class="flex flex-wrap gap-2 mt-2">
                             <span class="inline-flex items-center gap-1.5 px-3 py-1 bg-surface border border-border/50 rounded-full text-xs text-textMuted">
@@ -326,6 +326,18 @@ https://example.gov/digital-strategy-2025</textarea>
     <footer id="footer" class="w-full text-center text-xs text-textMuted/50 py-6 mt-auto relative z-10 border-t border-border/50 bg-background">
         &copy; 2026 Herit Civic Platform. All rights reserved.
     </footer>
+
+    <script>
+        function updateResourceTypeFraming() {
+            const isHuman = document.getElementById('resource-type-human').checked;
+
+            document.getElementById('role-identity-heading').textContent = isHuman ? 'Role Identity' : 'Resource Identity';
+            document.getElementById('role-requirements-heading').textContent = isHuman ? 'Role Requirements' : 'Resource Requirements';
+
+            document.getElementById('role-title-label').textContent = isHuman ? 'Role Title' : 'Resource Name';
+            document.getElementById('skills-label').textContent = isHuman ? 'Skills (comma separated)' : 'Specifications (comma separated)';
+        }
+    </script>
 
 </body>
 </html>


### PR DESCRIPTION
## Description

The Resource Type radio options in the publish form (01: "Individual Expert" / "Advisory Firm") and edit form (04: "Individual Consultant" / "Firm / Organization") were both variants of Human, matching neither the backend enum (`Human` / `Non-Human`, see PRD §5.3) nor allowing a Non-Human CFEOI (infrastructure, real estate, equipment, financial support) to be published.

This PR:
- Fixes both forms' radio options to `Human` / `Non-Human`, with descriptive helper text matching the PRD's parenthetical (skills & expertise / infrastructure, real estate, equipment, financial support).
- Adapts the Human-only framing to work for Non-Human resources: since "Role Identity"/"Role Requirements"/"Role Title"/"Skills" only make sense for a Human role, selecting Non-Human now relabels these to generic resource terms ("Resource Identity"/"Resource Requirements"/"Resource Name"/"Specifications") via a small `onchange` handler — consistent with the existing interactive-toggle pattern already used elsewhere in these design mockups (e.g. flow2's terms-checkbox toggle).

## Linked Issue

Closes #220

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

These are static HTML design mockups under `docs/frontend/portal/designs/flow3c/`, not implemented application code — no build/backend changes are involved. Opened both files in a browser and toggled between Human and Non-Human to confirm the labels/placeholders swap correctly and the required-field asterisks are preserved.

## Checklist

- [x] Code builds cleanly (`dotnet build`) — N/A, docs-only change
- [x] Tests pass (`dotnet test`) — N/A, docs-only change
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)