### PR TITLE
Fix EOI status model in the EOI inbox

### DIFF
--- a/docs/frontend/portal/designs/flow3c/06-eoi-inbox-owner.html
+++ b/docs/frontend/portal/designs/flow3c/06-eoi-inbox-owner.html
@@ -193,12 +193,16 @@
                         <span class="text-[10px] uppercase tracking-wider text-textMuted font-medium">Total</span>
                     </div>
                     <div class="bg-surface border border-border/50 rounded-lg px-4 py-2 flex flex-col items-center min-w-[100px]">
-                        <span class="text-2xl font-bold text-success">8</span>
-                        <span class="text-[10px] uppercase tracking-wider text-textMuted font-medium">Reviewed</span>
-                    </div>
-                    <div class="bg-surface border border-border/50 rounded-lg px-4 py-2 flex flex-col items-center min-w-[100px]">
                         <span class="text-2xl font-bold text-primary">4</span>
                         <span class="text-[10px] uppercase tracking-wider text-textMuted font-medium">Pending</span>
+                    </div>
+                    <div class="bg-surface border border-border/50 rounded-lg px-4 py-2 flex flex-col items-center min-w-[100px]">
+                        <span class="text-2xl font-bold text-success">6</span>
+                        <span class="text-[10px] uppercase tracking-wider text-textMuted font-medium">Approved</span>
+                    </div>
+                    <div class="bg-surface border border-border/50 rounded-lg px-4 py-2 flex flex-col items-center min-w-[100px]">
+                        <span class="text-2xl font-bold text-danger">2</span>
+                        <span class="text-[10px] uppercase tracking-wider text-textMuted font-medium">Rejected</span>
                     </div>
                 </div>
             </div>
@@ -218,9 +222,8 @@
                     <div class="relative flex-1 sm:flex-none">
                         <select class="w-full sm:w-auto appearance-none bg-inputBg border border-border/50 rounded-lg pl-4 pr-10 py-2 text-sm text-textMain focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-colors cursor-pointer">
                             <option value="">Status: All</option>
-                            <option value="pending">Pending Review</option>
-                            <option value="reviewed">Reviewed</option>
-                            <option value="shortlisted">Shortlisted</option>
+                            <option value="pending">Pending</option>
+                            <option value="approved">Approved</option>
                             <option value="rejected">Rejected</option>
                         </select>
                         <i class="fa-solid fa-chevron-down absolute right-3.5 top-1/2 transform -translate-y-1/2 text-textMuted text-[10px] pointer-events-none"></i>
@@ -279,7 +282,7 @@
                             </td>
                             <td class="py-4 px-6">
                                 <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-medium bg-primary/10 text-primary border border-primary/20">
-                                    Pending Review
+                                    Pending
                                 </span>
                             </td>
                             <td class="py-4 px-6">
@@ -316,7 +319,7 @@
                             </td>
                             <td class="py-4 px-6">
                                 <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-medium bg-success/10 text-success border border-success/20">
-                                    Shortlisted
+                                    Approved
                                 </span>
                             </td>
                             <td class="py-4 px-6">
@@ -352,8 +355,8 @@
                                 </div>
                             </td>
                             <td class="py-4 px-6">
-                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-medium bg-surfaceHover text-textMuted border border-border">
-                                    Reviewed
+                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-medium bg-success/10 text-success border border-success/20">
+                                    Approved
                                 </span>
                             </td>
                             <td class="py-4 px-6">
@@ -466,7 +469,7 @@
                 <div class="bg-inputBg border border-border/50 rounded-lg p-3 flex flex-col gap-1">
                     <span class="text-xs text-textMuted uppercase tracking-wider">Status</span>
                     <span class="inline-flex self-start items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary border border-primary/20">
-                        Pending Review
+                        Pending
                     </span>
                 </div>
                 <div class="bg-inputBg border border-border/50 rounded-lg p-3 flex flex-col gap-1">
@@ -527,7 +530,7 @@
                 <label class="text-xs text-textMuted uppercase tracking-wider font-semibold">Update Status</label>
                 <div class="grid grid-cols-2 gap-3">
                     <button class="bg-success/10 hover:bg-success/20 text-success border border-success/20 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors">
-                        Shortlist
+                        Approve
                     </button>
                     <button class="bg-danger/10 hover:bg-danger/20 text-danger border border-danger/20 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors">
                         Reject


### PR DESCRIPTION
## Description

The EOI inbox (06) design mockup used statuses that don't exist in the backend: filter options included "Pending Review", "Reviewed", and "Shortlisted", and the detail drawer's actions were "Shortlist" and "Reject". The backend `EoiStatus` enum has exactly three values — `Pending`, `Approved`, `Rejected` — and the only owner actions are Approve and Reject (see `docs/frontend/portal/user-flows-high-level.md` §3d).

This PR updates the filter dropdown, the summary tiles (now Total / Pending / Approved / Rejected), the table status badges, the drawer's status badge, and the drawer's action buttons to match the real status model.

## Linked Issue

Closes #221

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

This is a static HTML design mockup under `docs/frontend/portal/designs/flow3c/`, not implemented application code — no build/backend changes are involved. Verified visually that all status references (filter, tiles, table, drawer) now consistently use Pending/Approved/Rejected and Approve/Reject actions.

## Checklist

- [x] Code builds cleanly (`dotnet build`) — N/A, docs-only change
- [x] Tests pass (`dotnet test`) — N/A, docs-only change
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)