### PR TITLE
Remove out-of-scope features from the EOI inbox

### DIFF
--- a/docs/frontend/portal/designs/flow3c/06-eoi-inbox-owner.html
+++ b/docs/frontend/portal/designs/flow3c/06-eoi-inbox-owner.html
@@ -215,9 +215,9 @@
             <div class="p-4 sm:p-5 border-b border-border/50 flex flex-col sm:flex-row gap-4 justify-between items-center bg-surface/50">
                 <div class="relative w-full sm:w-96">
                     <i class="fa-solid fa-magnifying-glass absolute left-3.5 top-1/2 transform -translate-y-1/2 text-textMuted text-sm"></i>
-                    <input type="text" placeholder="Search applicant name, email, or ID..." class="w-full bg-inputBg border border-border/50 rounded-lg pl-10 pr-4 py-2 text-sm text-textMain placeholder-textMuted focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-colors">
+                    <input type="text" placeholder="Search applicant name..." class="w-full bg-inputBg border border-border/50 rounded-lg pl-10 pr-4 py-2 text-sm text-textMain placeholder-textMuted focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-colors">
                 </div>
-                
+
                 <div class="flex items-center gap-3 w-full sm:w-auto">
                     <div class="relative flex-1 sm:flex-none">
                         <select class="w-full sm:w-auto appearance-none bg-inputBg border border-border/50 rounded-lg pl-4 pr-10 py-2 text-sm text-textMain focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-colors cursor-pointer">
@@ -228,11 +228,6 @@
                         </select>
                         <i class="fa-solid fa-chevron-down absolute right-3.5 top-1/2 transform -translate-y-1/2 text-textMuted text-[10px] pointer-events-none"></i>
                     </div>
-                    
-                    <button class="bg-surfaceHover border border-border/50 text-textMain hover:bg-border/50 px-4 py-2 rounded-lg text-sm font-medium transition-colors flex items-center gap-2 whitespace-nowrap">
-                        <i class="fa-solid fa-download text-xs"></i>
-                        Export CSV
-                    </button>
                 </div>
             </div>
 
@@ -241,11 +236,6 @@
                 <table class="w-full text-left border-collapse">
                     <thead>
                         <tr class="border-b border-border/50 bg-inputBg/30">
-                            <th class="py-4 px-6 text-xs font-semibold text-textMuted uppercase tracking-wider w-12">
-                                <div class="flex items-center justify-center">
-                                    <input type="checkbox" class="rounded border-border/50 bg-inputBg text-primary focus:ring-primary focus:ring-offset-surface">
-                                </div>
-                            </th>
                             <th class="py-4 px-6 text-xs font-semibold text-textMuted uppercase tracking-wider cursor-pointer hover:text-textMain group">
                                 Applicant <i class="fa-solid fa-sort ml-1 text-border group-hover:text-textMuted"></i>
                             </th>
@@ -266,11 +256,6 @@
                     <tbody class="divide-y divide-border/50">
                         <!-- Row 1 -->
                         <tr class="hover:bg-surfaceHover/50 transition-colors group">
-                            <td class="py-4 px-6">
-                                <div class="flex items-center justify-center">
-                                    <input type="checkbox" class="rounded border-border/50 bg-inputBg text-primary focus:ring-primary focus:ring-offset-surface">
-                                </div>
-                            </td>
                             <td class="py-4 px-6">
                                 <div class="flex items-center gap-3">
                                     <img src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-2.jpg" alt="Applicant" class="w-8 h-8 rounded-full border border-border/50 object-cover">
@@ -304,11 +289,6 @@
                         <!-- Row 2 -->
                         <tr class="hover:bg-surfaceHover/50 transition-colors group">
                             <td class="py-4 px-6">
-                                <div class="flex items-center justify-center">
-                                    <input type="checkbox" class="rounded border-border/50 bg-inputBg text-primary focus:ring-primary focus:ring-offset-surface">
-                                </div>
-                            </td>
-                            <td class="py-4 px-6">
                                 <div class="flex items-center gap-3">
                                     <img src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-6.jpg" alt="Applicant" class="w-8 h-8 rounded-full border border-border/50 object-cover">
                                     <div class="flex flex-col">
@@ -341,11 +321,6 @@
                         <!-- Row 3 -->
                         <tr class="hover:bg-surfaceHover/50 transition-colors group">
                             <td class="py-4 px-6">
-                                <div class="flex items-center justify-center">
-                                    <input type="checkbox" class="rounded border-border/50 bg-inputBg text-primary focus:ring-primary focus:ring-offset-surface">
-                                </div>
-                            </td>
-                            <td class="py-4 px-6">
                                 <div class="flex items-center gap-3">
                                     <img src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-3.jpg" alt="Applicant" class="w-8 h-8 rounded-full border border-border/50 object-cover">
                                     <div class="flex flex-col">
@@ -377,11 +352,6 @@
 
                          <!-- Row 4 -->
                          <tr class="hover:bg-surfaceHover/50 transition-colors group">
-                            <td class="py-4 px-6">
-                                <div class="flex items-center justify-center">
-                                    <input type="checkbox" class="rounded border-border/50 bg-inputBg text-primary focus:ring-primary focus:ring-offset-surface">
-                                </div>
-                            </td>
                             <td class="py-4 px-6">
                                 <div class="flex items-center gap-3">
                                     <img src="https://storage.googleapis.com/uxpilot-auth.appspot.com/avatars/avatar-7.jpg" alt="Applicant" class="w-8 h-8 rounded-full border border-border/50 object-cover">
@@ -465,7 +435,7 @@
             </div>
 
             <!-- Status & Meta -->
-            <div class="grid grid-cols-2 gap-4">
+            <div class="grid grid-cols-3 gap-4">
                 <div class="bg-inputBg border border-border/50 rounded-lg p-3 flex flex-col gap-1">
                     <span class="text-xs text-textMuted uppercase tracking-wider">Status</span>
                     <span class="inline-flex self-start items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary border border-primary/20">
@@ -480,45 +450,14 @@
                     <span class="text-xs text-textMuted uppercase tracking-wider">EOI ID</span>
                     <span class="text-sm font-medium text-textMain font-mono">EOI-25678</span>
                 </div>
-                <div class="bg-inputBg border border-border/50 rounded-lg p-3 flex flex-col gap-1">
-                    <span class="text-xs text-textMuted uppercase tracking-wider">Experience</span>
-                    <span class="text-sm font-medium text-textMain">12+ Years</span>
-                </div>
             </div>
 
             <!-- Cover Letter / Statement -->
             <div class="flex flex-col gap-3">
-                <h4 class="text-sm font-semibold text-textMain uppercase tracking-wider border-b border-border/50 pb-2">Statement of Interest</h4>
+                <h4 class="text-sm font-semibold text-textMain uppercase tracking-wider border-b border-border/50 pb-2">Message / Cover Note</h4>
                 <div class="text-sm text-textMuted leading-relaxed space-y-3">
                     <p>I am writing to express my strong interest in the Lead System Architect role for the Digital Health Infrastructure Upgrade. With over a decade of experience designing scalable health data systems in the UK National Health Service, I believe I can bring valuable expertise to this initiative.</p>
                     <p>My background includes leading the architecture for HL7/FHIR compliant data exchanges and managing cross-functional teams of developers and clinical informaticists.</p>
-                </div>
-            </div>
-
-            <!-- Attachments -->
-            <div class="flex flex-col gap-3">
-                <h4 class="text-sm font-semibold text-textMain uppercase tracking-wider border-b border-border/50 pb-2">Attachments</h4>
-                <div class="flex flex-col gap-2">
-                    <a href="#" class="flex items-center gap-3 p-3 rounded-lg border border-border/50 bg-inputBg hover:bg-surfaceHover transition-colors group">
-                        <div class="w-8 h-8 rounded bg-primary/10 text-primary flex items-center justify-center">
-                            <i class="fa-solid fa-file-pdf"></i>
-                        </div>
-                        <div class="flex flex-col flex-1">
-                            <span class="text-sm font-medium text-textMain group-hover:text-primary transition-colors">Resume_MJohnson_2026.pdf</span>
-                            <span class="text-xs text-textMuted">2.4 MB</span>
-                        </div>
-                        <i class="fa-solid fa-download text-textMuted group-hover:text-textMain"></i>
-                    </a>
-                    <a href="#" class="flex items-center gap-3 p-3 rounded-lg border border-border/50 bg-inputBg hover:bg-surfaceHover transition-colors group">
-                        <div class="w-8 h-8 rounded bg-primary/10 text-primary flex items-center justify-center">
-                            <i class="fa-solid fa-link"></i>
-                        </div>
-                        <div class="flex flex-col flex-1">
-                            <span class="text-sm font-medium text-textMain group-hover:text-primary transition-colors">LinkedIn Profile</span>
-                            <span class="text-xs text-textMuted">External Link</span>
-                        </div>
-                        <i class="fa-solid fa-arrow-up-right-from-square text-textMuted group-hover:text-textMain text-xs"></i>
-                    </a>
                 </div>
             </div>
 


### PR DESCRIPTION
## Description

The EOI inbox (06) design mockup included several features that are explicitly out of scope or unsupported by the backend EOI model: CV/attachment downloads (the "Attachments" section with a resume PDF and LinkedIn link), Export CSV, bulk-select checkboxes (no bulk API exists), an "Experience" field (not on the EOI model), and search by applicant email/ID. Per spec, an EOI only exposes submitter name and message/cover note, with Approve/Reject actions.

This PR strips out the Export CSV button, the header/row bulk-select checkboxes, the Experience meta tile, and the entire Attachments section, narrows the search field to name-only, and renames "Statement of Interest" to "Message / Cover Note" to match the actual EOI field.

## Linked Issue

Closes #222

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

This is a static HTML design mockup under `docs/frontend/portal/designs/flow3c/`, not implemented application code — no build/backend changes are involved. Verified visually that the table, toolbar, and drawer render cleanly with the out-of-scope elements removed and the meta grid rebalanced to 3 columns.

## Checklist

- [x] Code builds cleanly (`dotnet build`) — N/A, docs-only change
- [x] Tests pass (`dotnet test`) — N/A, docs-only change
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)