### PR TITLE
Rename Reference Documents to External Links on CFEOI detail page

### DIFF
--- a/docs/frontend/portal/designs/flow3c/03-cfeoi-detail-open-owner.html
+++ b/docs/frontend/portal/designs/flow3c/03-cfeoi-detail-open-owner.html
@@ -214,14 +214,14 @@
                     
                     <!-- External Links -->
                     <div class="mt-2 pt-6 border-t border-border/50">
-                        <h3 class="text-sm font-semibold text-textMain uppercase tracking-wider mb-3">Reference Documents</h3>
+                        <h3 class="text-sm font-semibold text-textMain uppercase tracking-wider mb-3">External Links</h3>
                         <div class="flex flex-col gap-2">
                             <a href="#" class="inline-flex items-center gap-2 text-primary hover:text-primaryHover transition-colors text-sm w-fit">
-                                <i class="fa-solid fa-link text-xs"></i>
-                                Preliminary Architecture Draft (PDF)
+                                <i class="fa-solid fa-arrow-up-right-from-square text-xs"></i>
+                                Preliminary Architecture Draft
                             </a>
                             <a href="#" class="inline-flex items-center gap-2 text-primary hover:text-primaryHover transition-colors text-sm w-fit">
-                                <i class="fa-solid fa-link text-xs"></i>
+                                <i class="fa-solid fa-arrow-up-right-from-square text-xs"></i>
                                 Ministry of Health Digital Strategy 2025-2030
                             </a>
                         </div>


### PR DESCRIPTION
## Description

The CFEOI detail page (03) labeled its external-links section "Reference Documents" and styled one entry with a "(PDF)" suffix, implying file attachments. Attachments are out of scope for the CFEOI model; the backend field is external links. This PR relabels the section "External Links" and presents entries as plain links (swapping the file-link icon for an external-link icon and dropping the "(PDF)" suffix).

## Linked Issue

Closes #224

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Chore / refactor

## Testing Notes

This is a static HTML design mockup under `docs/frontend/portal/designs/flow3c/`, not implemented application code — no build/backend changes are involved. Verified visually that the section reads clearly as external links rather than document attachments.

## Checklist

- [x] Code builds cleanly (`dotnet build`) — N/A, docs-only change
- [x] Tests pass (`dotnet test`) — N/A, docs-only change
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)