### PR TITLE
Remove invented human-friendly reference IDs from flow3c screens

### DIFF
--- a/docs/frontend/portal/designs/flow3c/02-cfeoi-publish-success.html
+++ b/docs/frontend/portal/designs/flow3c/02-cfeoi-publish-success.html
@@ -145,12 +145,11 @@
             </div>
 
             <div id="summary-banner" class="w-full bg-infoBanner rounded-xl p-6 text-left border border-infoBannerText/20 shadow-lg mt-4">
-                <div class="flex items-center justify-between mb-4">
+                <div class="flex items-center mb-4">
                     <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-success/20 border border-success/30 text-success text-xs font-semibold">
                         <span class="w-1.5 h-1.5 rounded-full bg-success"></span>
                         Open
                     </span>
-                    <span class="text-infoBannerText font-medium text-sm">ID: CFE-2026-089</span>
                 </div>
                 
                 <h2 class="text-xl font-bold text-infoBannerText mb-2">Lead System Architect Search</h2>

--- a/docs/frontend/portal/designs/flow3c/03-cfeoi-detail-open-owner.html
+++ b/docs/frontend/portal/designs/flow3c/03-cfeoi-detail-open-owner.html
@@ -165,7 +165,6 @@
                             <span class="w-2 h-2 rounded-full bg-success"></span>
                             Open
                         </span>
-                        <span class="text-textMuted text-sm">ID: CFE-2026-089</span>
                     </div>
                     
                     <h1 class="text-3xl sm:text-4xl font-bold text-textMain tracking-tight">Lead System Architect Search</h1>
@@ -321,7 +320,7 @@
                         </div>
                         <div>
                             <h4 class="text-base font-bold text-textMain mb-1">Digital Health Infrastructure Upgrade</h4>
-                            <p class="text-sm text-textMuted mb-4">Ministry of Health • Ref: PRJ-2026-04</p>
+                            <p class="text-sm text-textMuted mb-4">Ministry of Health</p>
                         </div>
                         
                         <a href="#" class="inline-flex items-center gap-2 text-primary hover:text-primaryHover transition-colors text-sm font-medium w-fit">

--- a/docs/frontend/portal/designs/flow3c/06-eoi-inbox-owner.html
+++ b/docs/frontend/portal/designs/flow3c/06-eoi-inbox-owner.html
@@ -242,9 +242,6 @@
                             <th class="py-4 px-6 text-xs font-semibold text-textMuted uppercase tracking-wider cursor-pointer hover:text-textMain group">
                                 Status <i class="fa-solid fa-sort ml-1 text-border group-hover:text-textMuted"></i>
                             </th>
-                            <th class="py-4 px-6 text-xs font-semibold text-textMuted uppercase tracking-wider">
-                                ID #
-                            </th>
                             <th class="py-4 px-6 text-xs font-semibold text-textMuted uppercase tracking-wider cursor-pointer hover:text-textMain group">
                                 Submitted Date <i class="fa-solid fa-sort ml-1 text-border group-hover:text-textMuted"></i>
                             </th>
@@ -269,9 +266,6 @@
                                 <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-medium bg-primary/10 text-primary border border-primary/20">
                                     Pending
                                 </span>
-                            </td>
-                            <td class="py-4 px-6">
-                                <span class="text-sm text-textMuted font-mono">EOI-25678</span>
                             </td>
                             <td class="py-4 px-6">
                                 <div class="flex flex-col">
@@ -303,9 +297,6 @@
                                 </span>
                             </td>
                             <td class="py-4 px-6">
-                                <span class="text-sm text-textMuted font-mono">EOI-56585</span>
-                            </td>
-                            <td class="py-4 px-6">
                                 <div class="flex flex-col">
                                     <span class="text-sm text-textMain">Oct 11, 2026</span>
                                     <span class="text-xs text-textMuted">02:30 PM</span>
@@ -335,9 +326,6 @@
                                 </span>
                             </td>
                             <td class="py-4 px-6">
-                                <span class="text-sm text-textMuted font-mono">EOI-23588</span>
-                            </td>
-                            <td class="py-4 px-6">
                                 <div class="flex flex-col">
                                     <span class="text-sm text-textMain">Oct 10, 2026</span>
                                     <span class="text-xs text-textMuted">09:15 AM</span>
@@ -365,9 +353,6 @@
                                 <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-medium bg-danger/10 text-danger border border-danger/20">
                                     Rejected
                                 </span>
-                            </td>
-                            <td class="py-4 px-6">
-                                <span class="text-sm text-textMuted font-mono">EOI-45533</span>
                             </td>
                             <td class="py-4 px-6">
                                 <div class="flex flex-col">
@@ -435,7 +420,7 @@
             </div>
 
             <!-- Status & Meta -->
-            <div class="grid grid-cols-3 gap-4">
+            <div class="grid grid-cols-2 gap-4">
                 <div class="bg-inputBg border border-border/50 rounded-lg p-3 flex flex-col gap-1">
                     <span class="text-xs text-textMuted uppercase tracking-wider">Status</span>
                     <span class="inline-flex self-start items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary border border-primary/20">
@@ -445,10 +430,6 @@
                 <div class="bg-inputBg border border-border/50 rounded-lg p-3 flex flex-col gap-1">
                     <span class="text-xs text-textMuted uppercase tracking-wider">Submitted</span>
                     <span class="text-sm font-medium text-textMain">Oct 12, 2026</span>
-                </div>
-                <div class="bg-inputBg border border-border/50 rounded-lg p-3 flex flex-col gap-1">
-                    <span class="text-xs text-textMuted uppercase tracking-wider">EOI ID</span>
-                    <span class="text-sm font-medium text-textMain font-mono">EOI-25678</span>
                 </div>
             </div>
 


### PR DESCRIPTION
## Description

Screens 02, 03, and 06 displayed invented reference numbers (`CFE-2026-089`, `EOI-25678`, `PRJ-2026-04`), but the backend uses GUIDs and has no human-friendly reference-number scheme — confirmed by checking the implemented app (e.g. `frontend/portal/src/components/ProposalCard.tsx` only ever uses `proposal.id` internally for routing, never displaying it).

This PR removes the ID displays rather than substituting raw GUIDs, consistent with how the already-implemented flows (1-3b) never surface IDs to users:
- Success screen (02): removed the "ID: CFE-2026-089" badge next to the Open status pill.
- Detail page (03): removed the same ID badge, and removed "• Ref: PRJ-2026-04" from the parent-proposal card subtitle.
- EOI inbox (06): removed the "ID #" table column and the "EOI ID" drawer meta tile (rebalanced grids accordingly).

## Linked Issue

Closes #225

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Chore / refactor

## Testing Notes

These are static HTML design mockups under `docs/frontend/portal/designs/flow3c/`, not implemented application code — no build/backend changes are involved. Verified visually that all three screens render cleanly with the reference IDs removed and no orphaned layout gaps.

## Checklist

- [x] Code builds cleanly (`dotnet build`) — N/A, docs-only change
- [x] Tests pass (`dotnet test`) — N/A, docs-only change
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)