### PR TITLE
Normalize flow3c theme tokens to the app's brand palette

### DIFF
--- a/docs/frontend/portal/designs/flow3c/01-cfeoi-publish-form.html
+++ b/docs/frontend/portal/designs/flow3c/01-cfeoi-publish-form.html
@@ -26,8 +26,9 @@
                         background: '#F9FAFB',
                         surface: '#FFFFFF',
                         surfaceHover: '#F9FAFB',
-                        primary: '#3B82F6',
-                        primaryHover: '#2563EB',
+                        primary: '#1D4ED8',
+                        primaryHover: '#1E40AF',
+                        brand: '#1D4ED8',
                         textMain: '#111827',
                         textMuted: '#6B7280',
                         border: '#E5E7EB',
@@ -92,7 +93,7 @@
       <!-- Left Nav -->
       <div class="flex items-center gap-8"><a href="#"
           class="flex items-center gap-2 group">
-          <div class="w-8 h-8 bg-brand-500 rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
+          <div class="w-8 h-8 bg-brand rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
             H
           </div><span
             class="text-lg font-bold tracking-tight text-text-main group-hover:text-primary-blue transition-colors">Herit</span>

--- a/docs/frontend/portal/designs/flow3c/02-cfeoi-publish-confirmation.html
+++ b/docs/frontend/portal/designs/flow3c/02-cfeoi-publish-confirmation.html
@@ -26,8 +26,9 @@
                         background: '#F9FAFB',
                         surface: '#FFFFFF',
                         surfaceHover: '#F9FAFB',
-                        primary: '#3B82F6',
-                        primaryHover: '#2563EB',
+                        primary: '#1D4ED8',
+                        primaryHover: '#1E40AF',
+                        brand: '#1D4ED8',
                         textMain: '#111827',
                         textMuted: '#6B7280',
                         border: '#E5E7EB',
@@ -92,7 +93,7 @@
       <!-- Left Nav -->
       <div class="flex items-center gap-8"><a href="#"
           class="flex items-center gap-2 group">
-          <div class="w-8 h-8 bg-brand-500 rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
+          <div class="w-8 h-8 bg-brand rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
             H
           </div><span
             class="text-lg font-bold tracking-tight text-text-main group-hover:text-primary-blue transition-colors">Herit</span>

--- a/docs/frontend/portal/designs/flow3c/03-cfeoi-detail-open-owner.html
+++ b/docs/frontend/portal/designs/flow3c/03-cfeoi-detail-open-owner.html
@@ -26,8 +26,9 @@
                         background: '#F9FAFB',
                         surface: '#FFFFFF',
                         surfaceHover: '#F9FAFB',
-                        primary: '#3B82F6',
-                        primaryHover: '#2563EB',
+                        primary: '#1D4ED8',
+                        primaryHover: '#1E40AF',
+                        brand: '#1D4ED8',
                         textMain: '#111827',
                         textMuted: '#6B7280',
                         border: '#E5E7EB',
@@ -92,7 +93,7 @@
       <!-- Left Nav -->
       <div class="flex items-center gap-8"><a href="#"
           class="flex items-center gap-2 group">
-          <div class="w-8 h-8 bg-brand-500 rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
+          <div class="w-8 h-8 bg-brand rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
             H
           </div><span
             class="text-lg font-bold tracking-tight text-text-main group-hover:text-primary-blue transition-colors">Herit</span>

--- a/docs/frontend/portal/designs/flow3c/04-cfeoi-edit-form.html
+++ b/docs/frontend/portal/designs/flow3c/04-cfeoi-edit-form.html
@@ -26,8 +26,9 @@
                         background: '#F9FAFB',
                         surface: '#FFFFFF',
                         surfaceHover: '#F9FAFB',
-                        primary: '#3B82F6',
-                        primaryHover: '#2563EB',
+                        primary: '#1D4ED8',
+                        primaryHover: '#1E40AF',
+                        brand: '#1D4ED8',
                         textMain: '#111827',
                         textMuted: '#6B7280',
                         border: '#E5E7EB',
@@ -92,7 +93,7 @@
       <!-- Left Nav -->
       <div class="flex items-center gap-8"><a href="#"
           class="flex items-center gap-2 group">
-          <div class="w-8 h-8 bg-brand-500 rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
+          <div class="w-8 h-8 bg-brand rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
             H
           </div><span
             class="text-lg font-bold tracking-tight text-text-main group-hover:text-primary-blue transition-colors">Herit</span>

--- a/docs/frontend/portal/designs/flow3c/05-close-cfeoi-modal.html
+++ b/docs/frontend/portal/designs/flow3c/05-close-cfeoi-modal.html
@@ -26,8 +26,9 @@
                         background: '#F9FAFB',
                         surface: '#FFFFFF',
                         surfaceHover: '#F9FAFB',
-                        primary: '#3B82F6',
-                        primaryHover: '#2563EB',
+                        primary: '#1D4ED8',
+                        primaryHover: '#1E40AF',
+                        brand: '#1D4ED8',
                         textMain: '#111827',
                         textMuted: '#6B7280',
                         border: '#E5E7EB',
@@ -92,7 +93,7 @@
       <!-- Left Nav -->
       <div class="flex items-center gap-8"><a href="#"
           class="flex items-center gap-2 group">
-          <div class="w-8 h-8 bg-brand-500 rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
+          <div class="w-8 h-8 bg-brand rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
             H
           </div><span
             class="text-lg font-bold tracking-tight text-text-main group-hover:text-primary-blue transition-colors">Herit</span>

--- a/docs/frontend/portal/designs/flow3c/06-cfeoi-detail-closed-owner.html
+++ b/docs/frontend/portal/designs/flow3c/06-cfeoi-detail-closed-owner.html
@@ -26,8 +26,9 @@
                         background: '#F9FAFB',
                         surface: '#FFFFFF',
                         surfaceHover: '#F9FAFB',
-                        primary: '#3B82F6',
-                        primaryHover: '#2563EB',
+                        primary: '#1D4ED8',
+                        primaryHover: '#1E40AF',
+                        brand: '#1D4ED8',
                         textMain: '#111827',
                         textMuted: '#6B7280',
                         border: '#E5E7EB',
@@ -92,7 +93,7 @@
       <!-- Left Nav -->
       <div class="flex items-center gap-8"><a href="#"
           class="flex items-center gap-2 group">
-          <div class="w-8 h-8 bg-brand-500 rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
+          <div class="w-8 h-8 bg-brand rounded-lg flex items-center justify-center text-white font-bold text-xl shadow-sm">
             H
           </div><span
             class="text-lg font-bold tracking-tight text-text-main group-hover:text-primary-blue transition-colors">Herit</span>


### PR DESCRIPTION
## Description

Flow3c defined `primary: #3B82F6` / `primaryHover: #2563EB`, a noticeably lighter blue than the implemented app's brand color (`brand: #1D4ED8`, from `frontend/portal/tailwind.config.ts`), flow1's `#1E40AF`, and the shared tokens used in flow3b. Buttons in flow3c rendered visibly lighter than the rest of the implemented app.

This PR, across all six flow3c screens (01, 02, 03, 04, 05, 06):
- Updates `primary` → `#1D4ED8` and `primaryHover` → `#1E40AF`, matching the real app's brand/brand-dark colors (verified against `frontend/portal/src/components/*.tsx`, which use `bg-brand hover:bg-brand-dark`).
- Adds the missing `brand` color to each config, and fixes the header logo class from `bg-brand-500` (undefined, renders transparent) to `bg-brand` (matches how the real app's nav components render their logo, e.g. `AuthenticatedNav.tsx`).

Note: `docs/frontend/portal/designs/flow3d/01-eoi-inbox-owner.html` (moved out of flow3c in #238) has the identical `bg-brand-500` bug, but is left untouched here since the issue scopes this fix to flow3c specifically — worth a quick follow-up if desired.

## Linked Issue

Closes #229

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Chore / refactor

## Testing Notes

These are static HTML design mockups under `docs/frontend/portal/designs/flow3c/`, not implemented application code — no build/backend changes are involved. Verified visually that buttons/accents now render the darker brand blue and the header logo box is no longer transparent.

## Checklist

- [x] Code builds cleanly (`dotnet build`) — N/A, docs-only change
- [x] Tests pass (`dotnet test`) — N/A, docs-only change
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)