### PR TITLE
Remove dark-theme leftovers from flow3c screens

### DIFF
--- a/docs/frontend/portal/designs/flow3c/01-cfeoi-publish-form.html
+++ b/docs/frontend/portal/designs/flow3c/01-cfeoi-publish-form.html
@@ -272,7 +272,7 @@
                         <div class="flex flex-col gap-1.5">
                             <label class="text-sm font-medium text-textMain">Application Deadline</label>
                             <div class="relative">
-                                <input type="date" class="w-full bg-inputBg border border-border/50 rounded-lg py-2.5 pl-4 pr-10 text-sm text-textMain focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all [color-scheme:dark]">
+                                <input type="date" class="w-full bg-inputBg border border-border/50 rounded-lg py-2.5 pl-4 pr-10 text-sm text-textMain focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all [color-scheme:light]">
                                 <i class="fa-regular fa-calendar absolute right-4 top-1/2 -translate-y-1/2 text-textMuted text-sm pointer-events-none"></i>
                             </div>
                         </div>
@@ -285,7 +285,7 @@
                 </section>
 
                 <div class="flex flex-col items-center gap-4 pt-4 mt-2 border-t border-border/50">
-                    <button type="button" class="w-full bg-primary hover:bg-primaryHover text-white font-medium py-3 px-6 rounded-lg transition-all shadow-[0_0_15px_rgba(59,130,246,0.3)] hover:shadow-[0_0_20px_rgba(59,130,246,0.5)] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-surface focus:ring-primary">
+                    <button type="button" class="w-full bg-primary hover:bg-primaryHover text-white font-medium py-3 px-6 rounded-lg transition-all shadow-soft focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-surface focus:ring-primary">
                         Publish CFEOI
                     </button>
                     <a href="#" class="text-sm text-textMuted hover:text-textMain transition-colors">Cancel and return to proposal</a>

--- a/docs/frontend/portal/designs/flow3c/02-cfeoi-publish-confirmation.html
+++ b/docs/frontend/portal/designs/flow3c/02-cfeoi-publish-confirmation.html
@@ -197,7 +197,7 @@
                 <div class="bg-surface rounded-xl border border-border/50 p-6 sm:p-8 flex flex-col gap-6">
                     <h2 class="text-xl font-bold text-textMain">Role Description</h2>
                     
-                    <div class="prose prose-invert max-w-none text-textMuted leading-relaxed">
+                    <div class="prose max-w-none text-textMuted leading-relaxed">
                         <p class="mb-4">We are seeking an experienced Lead System Architect to design and oversee the implementation of our new national digital health infrastructure. This role involves working closely with the Ministry of Health and international tech partners to ensure a robust, scalable, and secure system.</p>
                         
                         <p class="mb-4"><strong>Key Responsibilities:</strong></p>

--- a/docs/frontend/portal/designs/flow3c/03-cfeoi-detail-open-owner.html
+++ b/docs/frontend/portal/designs/flow3c/03-cfeoi-detail-open-owner.html
@@ -186,7 +186,7 @@
                 <div class="bg-surface rounded-xl border border-border/50 p-6 sm:p-8 flex flex-col gap-6">
                     <h2 class="text-xl font-bold text-textMain">Role Description</h2>
                     
-                    <div class="prose prose-invert max-w-none text-textMuted leading-relaxed">
+                    <div class="prose max-w-none text-textMuted leading-relaxed">
                         <p class="mb-4">We are seeking an experienced Lead System Architect to design and oversee the implementation of our new national digital health infrastructure. This role involves working closely with the Ministry of Health and international tech partners to ensure a robust, scalable, and secure system.</p>
                         
                         <p class="mb-4"><strong>Key Responsibilities:</strong></p>

--- a/docs/frontend/portal/designs/flow3c/04-cfeoi-edit-form.html
+++ b/docs/frontend/portal/designs/flow3c/04-cfeoi-edit-form.html
@@ -297,7 +297,7 @@ The ideal candidate will have a strong background in public sector IT transforma
                     <div class="flex flex-col gap-2">
                         <label for="deadline" class="text-sm font-medium text-textMain">Application Deadline</label>
                         <div class="relative w-full sm:w-1/2">
-                            <input type="date" id="deadline" value="2026-10-15" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent [color-scheme:dark]">
+                            <input type="date" id="deadline" value="2026-10-15" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent [color-scheme:light]">
                         </div>
                     </div>
 
@@ -312,7 +312,7 @@ https://example.gov/digital-strategy-2025</textarea>
 
             <!-- Actions -->
             <div id="form-actions" class="flex flex-col gap-4 mt-4 mb-12">
-                <button type="submit" class="w-full bg-primary hover:bg-primaryHover text-white font-medium py-3 px-4 rounded-lg transition-all shadow-[0_0_15px_rgba(59,130,246,0.2)] hover:shadow-[0_0_20px_rgba(59,130,246,0.4)] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-background focus:ring-primary text-center">
+                <button type="submit" class="w-full bg-primary hover:bg-primaryHover text-white font-medium py-3 px-4 rounded-lg transition-all shadow-soft focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-background focus:ring-primary text-center">
                     Save Changes
                 </button>
                 <div class="text-center">

--- a/docs/frontend/portal/designs/flow3c/05-close-cfeoi-modal.html
+++ b/docs/frontend/portal/designs/flow3c/05-close-cfeoi-modal.html
@@ -239,7 +239,7 @@
             
             <!-- Modal Header / Icon -->
             <div class="px-6 pt-8 pb-4 flex flex-col items-center text-center">
-                <div class="w-16 h-16 rounded-full bg-danger/10 border border-danger/20 flex items-center justify-center mb-5 shadow-[0_0_20px_rgba(239,68,68,0.15)]">
+                <div class="w-16 h-16 rounded-full bg-danger/10 border border-danger/20 flex items-center justify-center mb-5 shadow-sm">
                     <i class="fa-solid fa-triangle-exclamation text-3xl text-danger"></i>
                 </div>
                 <h2 id="modal-title" class="text-xl font-bold text-textMain mb-2 tracking-tight">Close CFEOI?</h2>
@@ -265,7 +265,7 @@
                 <button type="button" class="w-full sm:w-1/2 bg-surfaceHover border border-border/50 text-textMain hover:bg-border/50 font-medium py-2.5 px-4 rounded-lg transition-colors text-sm text-center focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-surface focus:ring-border">
                     Cancel
                 </button>
-                <button type="button" class="w-full sm:w-1/2 bg-danger hover:bg-danger/90 text-white font-medium py-2.5 px-4 rounded-lg transition-all shadow-[0_0_15px_rgba(239,68,68,0.2)] hover:shadow-[0_0_20px_rgba(239,68,68,0.4)] text-sm text-center focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-surface focus:ring-danger">
+                <button type="button" class="w-full sm:w-1/2 bg-danger hover:bg-danger/90 text-white font-medium py-2.5 px-4 rounded-lg transition-all shadow-sm text-sm text-center focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-surface focus:ring-danger">
                     Close CFEOI
                 </button>
             </div>

--- a/docs/frontend/portal/designs/flow3c/06-cfeoi-detail-closed-owner.html
+++ b/docs/frontend/portal/designs/flow3c/06-cfeoi-detail-closed-owner.html
@@ -194,7 +194,7 @@
                 <div class="bg-surface rounded-xl border border-border/50 p-6 sm:p-8 flex flex-col gap-6">
                     <h2 class="text-xl font-bold text-textMain">Role Description</h2>
                     
-                    <div class="prose prose-invert max-w-none text-textMuted leading-relaxed">
+                    <div class="prose max-w-none text-textMuted leading-relaxed">
                         <p class="mb-4">We are seeking an experienced Lead System Architect to design and oversee the implementation of our new national digital health infrastructure. This role involves working closely with the Ministry of Health and international tech partners to ensure a robust, scalable, and secure system.</p>
                         
                         <p class="mb-4"><strong>Key Responsibilities:</strong></p>


### PR DESCRIPTION
## Description

Flow3c screens carried leftover artifacts from a dark theme:
- Neon glow box-shadows on buttons and icon circles (e.g. `shadow-[0_0_15px_rgba(59,130,246,0.3)]`).
- `[color-scheme:dark]` on date inputs, which renders a dark native date picker on an otherwise light page.
- `prose-invert` on role description text in 02/03/06, producing near-invisible text on a white background.

This PR replaces the glow shadows with the standard elevation shadows already used in flow1-3b (`shadow-soft` for primary CTA buttons, `shadow-sm` for the close-modal icon circle and destructive button), switches the date inputs to `[color-scheme:light]`, and drops `prose-invert` in favor of plain `prose`.

## Linked Issue

Closes #230

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

These are static HTML design mockups under `docs/frontend/portal/designs/flow3c/`, not implemented application code — no build/backend changes are involved. Verified visually that buttons no longer glow, date pickers render with light native styling, and role description text is fully legible against the white card background.

## Checklist

- [x] Code builds cleanly (`dotnet build`) — N/A, docs-only change
- [x] Tests pass (`dotnet test`) — N/A, docs-only change
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)