### PR TITLE
Align Close CFEOI modal with the flow3b confirmation modal pattern

### DIFF
--- a/docs/frontend/portal/designs/flow3c/05-close-cfeoi-modal.html
+++ b/docs/frontend/portal/designs/flow3c/05-close-cfeoi-modal.html
@@ -232,14 +232,14 @@
     <!-- Modal Overlay (Active Layer) -->
     <div id="modal-overlay" class="fixed inset-0 z-[100] flex items-center justify-center p-4 sm:p-6" role="dialog" aria-modal="true" aria-labelledby="modal-title">
         <!-- Backdrop -->
-        <div class="absolute inset-0 bg-background/80 backdrop-blur-sm transition-opacity"></div>
+        <div class="absolute inset-0 bg-textMain/40 backdrop-blur-sm transition-opacity"></div>
 
         <!-- Modal Panel -->
-        <div class="relative bg-surface rounded-[14px] border border-border/50 shadow-2xl w-full max-w-md transform transition-all flex flex-col overflow-hidden">
-            
+        <div class="relative bg-surface rounded-2xl border border-border/50 shadow-[0_20px_25px_-5px_rgba(0,0,0,0.1),0_8px_10px_-6px_rgba(0,0,0,0.1)] w-full max-w-lg transform transition-all flex flex-col overflow-hidden">
+
             <!-- Modal Header / Icon -->
             <div class="px-6 pt-8 pb-4 flex flex-col items-center text-center">
-                <div class="w-16 h-16 rounded-full bg-danger/10 border border-danger/20 flex items-center justify-center mb-5 shadow-sm">
+                <div class="w-14 h-14 rounded-full bg-danger/10 border border-danger/20 flex items-center justify-center mb-5 shadow-sm">
                     <i class="fa-solid fa-triangle-exclamation text-3xl text-danger"></i>
                 </div>
                 <h2 id="modal-title" class="text-xl font-bold text-textMain mb-2 tracking-tight">Close CFEOI?</h2>


### PR DESCRIPTION
## Description

The Close CFEOI modal (05) diverged from flow3b's withdraw confirmation modal (07) — the portal's only other destructive-confirmation modal: `rounded-[14px]` vs `rounded-2xl`, `max-w-md` vs `max-w-lg`, a plain `shadow-2xl` vs flow3b's layered elevation shadow, a slightly larger icon circle, and a light backdrop tint (`bg-background/80`) vs flow3b's dark dimmed backdrop (`bg-primary/40`, where flow3b's `primary` is `#111827`).

This PR aligns 05 with 07's values:
- Backdrop: `bg-textMain/40` (flow3c's `textMain` is the same `#111827` flow3b calls `primary`) instead of a light background tint.
- Modal panel: `rounded-2xl`, `max-w-lg`, and the same layered shadow (`shadow-[0_20px_25px_-5px_rgba(0,0,0,0.1),0_8px_10px_-6px_rgba(0,0,0,0.1)]`).
- Icon circle: `w-14 h-14` to match flow3b's size.

The CFEOI-specific body content (context info box vs flow3b's confirmation checkbox) is left as-is since that's domain-appropriate content, not shared chrome.

## Linked Issue

Closes #231

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

This is a static HTML design mockup under `docs/frontend/portal/designs/flow3c/`, not implemented application code — no build/backend changes are involved. Verified visually that the modal now renders with the same corner radius, width, shadow, and dimmed backdrop as flow3b's withdraw confirmation modal.

## Checklist

- [x] Code builds cleanly (`dotnet build`) — N/A, docs-only change
- [x] Tests pass (`dotnet test`) — N/A, docs-only change
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)