### PR TITLE
Align CFEOI spec and flow3c mockups with the actual backend model

### DIFF
--- a/docs/frontend/portal/designs/flow3c/01-cfeoi-publish-form.html
+++ b/docs/frontend/portal/designs/flow3c/01-cfeoi-publish-form.html
@@ -165,10 +165,10 @@
 
             <form id="cfeoi-form" class="flex flex-col gap-8 bg-surface rounded-xl border border-border/50 shadow-lg p-6 sm:p-8 backdrop-blur-sm">
                 
-                <section id="role-identity" class="flex flex-col gap-5 border-b border-border/50 pb-8">
+                <section id="cfeoi-identity" class="flex flex-col gap-5 border-b border-border/50 pb-8">
                     <div>
-                        <h2 id="role-identity-heading" class="text-lg font-semibold text-textMain">Role Identity</h2>
-                        <p id="role-identity-desc" class="text-sm text-textMuted mt-1">Basic information about the role you are publishing.</p>
+                        <h2 class="text-lg font-semibold text-textMain">CFEOI Details</h2>
+                        <p class="text-sm text-textMuted mt-1">Basic information about the resource you are requesting.</p>
                     </div>
 
                     <div class="flex flex-col gap-4">
@@ -196,18 +196,13 @@
                                 </label>
                             </div>
                         </div>
-
-                        <div class="flex flex-col gap-1.5">
-                            <label id="role-title-label" class="text-sm font-medium text-textMain">Role Title</label>
-                            <input id="role-title-input" type="text" placeholder="e.g. Lead System Architect" class="w-full bg-inputBg border border-border/50 rounded-lg py-2.5 px-4 text-sm text-textMain placeholder-textMuted/50 focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all">
-                        </div>
                     </div>
                 </section>
 
-                <section id="role-requirements" class="flex flex-col gap-5 border-b border-border/50 pb-8">
+                <section id="cfeoi-description" class="flex flex-col gap-5">
                     <div>
-                        <h2 id="role-requirements-heading" class="text-lg font-semibold text-textMain">Role Requirements</h2>
-                        <p id="role-requirements-desc" class="text-sm text-textMuted mt-1">Detailed description and required skills for this role.</p>
+                        <h2 class="text-lg font-semibold text-textMain">Description &amp; Tags</h2>
+                        <p class="text-sm text-textMuted mt-1">Detailed description and optional tags for this CFEOI.</p>
                     </div>
 
                     <div class="flex flex-col gap-4">
@@ -226,7 +221,7 @@
                         </div>
 
                         <div class="flex flex-col gap-1.5">
-                            <label id="skills-label" class="text-sm font-medium text-textMain">Skills (comma separated)</label>
+                            <label id="tags-label" class="text-sm font-medium text-textMain">Tags (comma separated, optional)</label>
                             <div class="bg-inputBg border border-border/50 rounded-lg p-2 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition-all flex flex-wrap gap-2">
                                 <div class="flex items-center gap-1.5 bg-surfaceHover px-2.5 py-1 rounded-md border border-border">
                                     <span class="text-xs text-textMain">System Architecture</span>
@@ -236,50 +231,8 @@
                                     <span class="text-xs text-textMain">HL7 Integration</span>
                                     <button type="button" class="text-textMuted hover:text-danger transition-colors"><i class="fa-solid fa-xmark text-[10px]"></i></button>
                                 </div>
-                                <input id="skills-input" type="text" placeholder="Type a skill and press comma..." class="flex-1 bg-transparent border-none text-sm text-textMain placeholder-textMuted/50 focus:outline-none min-w-[150px] py-1 px-2">
+                                <input id="tags-input" type="text" placeholder="Type a skill and press comma..." class="flex-1 bg-transparent border-none text-sm text-textMain placeholder-textMuted/50 focus:outline-none min-w-[150px] py-1 px-2">
                             </div>
-                        </div>
-
-                        <div class="flex flex-col gap-1.5 w-full sm:w-1/3">
-                            <label class="text-sm font-medium text-textMain">Slots</label>
-                            <input type="number" min="1" value="1" class="w-full bg-inputBg border border-border/50 rounded-lg py-2.5 px-4 text-sm text-textMain focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all">
-                        </div>
-                    </div>
-                </section>
-
-                <section id="optional-details" class="flex flex-col gap-5">
-                    <div>
-                        <h2 class="text-lg font-semibold text-textMain">Optional Details</h2>
-                        <p class="text-sm text-textMuted mt-1">Additional parameters for the expression of interest.</p>
-                    </div>
-
-                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                        <div class="flex flex-col gap-1.5">
-                            <label class="text-sm font-medium text-textMain">Duration (weeks)</label>
-                            <input type="number" placeholder="e.g. 24" class="w-full bg-inputBg border border-border/50 rounded-lg py-2.5 px-4 text-sm text-textMain placeholder-textMuted/50 focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all">
-                        </div>
-
-                        <div class="flex flex-col gap-1.5">
-                            <label class="text-sm font-medium text-textMain">Location</label>
-                            <input type="text" placeholder="e.g. Remote / Capital City" class="w-full bg-inputBg border border-border/50 rounded-lg py-2.5 px-4 text-sm text-textMain placeholder-textMuted/50 focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all">
-                        </div>
-
-                        <div class="flex flex-col gap-1.5">
-                            <label class="text-sm font-medium text-textMain">Compensation</label>
-                            <input type="text" placeholder="e.g. $50,000 - $70,000" class="w-full bg-inputBg border border-border/50 rounded-lg py-2.5 px-4 text-sm text-textMain placeholder-textMuted/50 focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all">
-                        </div>
-
-                        <div class="flex flex-col gap-1.5">
-                            <label class="text-sm font-medium text-textMain">Application Deadline</label>
-                            <div class="relative">
-                                <input type="date" class="w-full bg-inputBg border border-border/50 rounded-lg py-2.5 pl-4 pr-10 text-sm text-textMain focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all [color-scheme:light]">
-                                <i class="fa-regular fa-calendar absolute right-4 top-1/2 -translate-y-1/2 text-textMuted text-sm pointer-events-none"></i>
-                            </div>
-                        </div>
-
-                        <div class="flex flex-col gap-1.5 sm:col-span-2">
-                            <label class="text-sm font-medium text-textMain">External Links</label>
-                            <textarea rows="3" placeholder="https://example.com/reference..." class="w-full bg-inputBg border border-border/50 rounded-lg py-2.5 px-4 text-sm text-textMain placeholder-textMuted/50 focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all resize-y"></textarea>
                         </div>
                     </div>
                 </section>
@@ -304,21 +257,7 @@
         function updateResourceTypeFraming() {
             const isHuman = document.getElementById('resource-type-human').checked;
 
-            document.getElementById('role-identity-heading').textContent = isHuman ? 'Role Identity' : 'Resource Identity';
-            document.getElementById('role-identity-desc').textContent = isHuman
-                ? 'Basic information about the role you are publishing.'
-                : 'Basic information about the resource you are requesting.';
-
-            document.getElementById('role-title-label').textContent = isHuman ? 'Role Title' : 'Resource Name';
-            document.getElementById('role-title-input').placeholder = isHuman ? 'e.g. Lead System Architect' : 'e.g. Field Vehicles (4x4)';
-
-            document.getElementById('role-requirements-heading').textContent = isHuman ? 'Role Requirements' : 'Resource Requirements';
-            document.getElementById('role-requirements-desc').textContent = isHuman
-                ? 'Detailed description and required skills for this role.'
-                : 'Detailed description and specifications for this resource.';
-
-            document.getElementById('skills-label').textContent = isHuman ? 'Skills (comma separated)' : 'Specifications (comma separated)';
-            document.getElementById('skills-input').placeholder = isHuman ? 'Type a skill and press comma...' : 'Type a specification and press comma...';
+            document.getElementById('tags-input').placeholder = isHuman ? 'Type a skill and press comma...' : 'Type a specification and press comma...';
         }
     </script>
 

--- a/docs/frontend/portal/designs/flow3c/02-cfeoi-publish-confirmation.html
+++ b/docs/frontend/portal/designs/flow3c/02-cfeoi-publish-confirmation.html
@@ -183,10 +183,6 @@
 
                     <div class="flex flex-wrap items-center gap-2 mt-2">
                         <span class="inline-flex items-center px-3 py-1 rounded-md bg-surface border border-border/50 text-textMain text-sm font-medium">
-                            <i class="fa-solid fa-briefcase text-textMuted mr-2"></i>
-                            Role: Lead System Architect
-                        </span>
-                        <span class="inline-flex items-center px-3 py-1 rounded-md bg-surface border border-border/50 text-textMain text-sm font-medium">
                             <i class="fa-regular fa-user text-textMuted mr-2"></i>
                             Individual Consultant
                         </span>
@@ -195,11 +191,11 @@
 
                 <!-- Description Section -->
                 <div class="bg-surface rounded-xl border border-border/50 p-6 sm:p-8 flex flex-col gap-6">
-                    <h2 class="text-xl font-bold text-textMain">Role Description</h2>
-                    
+                    <h2 class="text-xl font-bold text-textMain">Description</h2>
+
                     <div class="prose max-w-none text-textMuted leading-relaxed">
                         <p class="mb-4">We are seeking an experienced Lead System Architect to design and oversee the implementation of our new national digital health infrastructure. This role involves working closely with the Ministry of Health and international tech partners to ensure a robust, scalable, and secure system.</p>
-                        
+
                         <p class="mb-4"><strong>Key Responsibilities:</strong></p>
                         <ul class="list-disc pl-5 mb-4 space-y-2">
                             <li>Design end-to-end architecture for the national health data exchange.</li>
@@ -207,69 +203,19 @@
                             <li>Lead a team of senior developers and data engineers.</li>
                             <li>Evaluate and select appropriate cloud infrastructure providers.</li>
                         </ul>
-                        
+
                         <p>The ideal candidate will have a strong background in public sector IT transformations and a deep understanding of healthcare informatics.</p>
                     </div>
 
-                    <!-- Skills -->
+                    <!-- Tags -->
                     <div class="mt-4 pt-6 border-t border-border/50">
-                        <h3 class="text-sm font-semibold text-textMain uppercase tracking-wider mb-3">Required Skills</h3>
+                        <h3 class="text-sm font-semibold text-textMain uppercase tracking-wider mb-3">Tags</h3>
                         <div class="flex flex-wrap gap-2">
                             <span class="px-3 py-1.5 bg-inputBg border border-border/50 rounded-full text-sm text-textMuted hover:text-textMain hover:border-border transition-colors cursor-default">System Architecture</span>
                             <span class="px-3 py-1.5 bg-inputBg border border-border/50 rounded-full text-sm text-textMuted hover:text-textMain hover:border-border transition-colors cursor-default">Cloud Infrastructure</span>
                             <span class="px-3 py-1.5 bg-inputBg border border-border/50 rounded-full text-sm text-textMuted hover:text-textMain hover:border-border transition-colors cursor-default">HL7/FHIR</span>
                             <span class="px-3 py-1.5 bg-inputBg border border-border/50 rounded-full text-sm text-textMuted hover:text-textMain hover:border-border transition-colors cursor-default">Team Leadership</span>
                             <span class="px-3 py-1.5 bg-inputBg border border-border/50 rounded-full text-sm text-textMuted hover:text-textMain hover:border-border transition-colors cursor-default">Healthcare Informatics</span>
-                        </div>
-                    </div>
-                    
-                    <!-- External Links -->
-                    <div class="mt-2 pt-6 border-t border-border/50">
-                        <h3 class="text-sm font-semibold text-textMain uppercase tracking-wider mb-3">External Links</h3>
-                        <div class="flex flex-col gap-2">
-                            <a href="#" class="inline-flex items-center gap-2 text-primary hover:text-primaryHover transition-colors text-sm w-fit">
-                                <i class="fa-solid fa-arrow-up-right-from-square text-xs"></i>
-                                Preliminary Architecture Draft
-                            </a>
-                            <a href="#" class="inline-flex items-center gap-2 text-primary hover:text-primaryHover transition-colors text-sm w-fit">
-                                <i class="fa-solid fa-arrow-up-right-from-square text-xs"></i>
-                                Ministry of Health Digital Strategy 2025-2030
-                            </a>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Details Grid -->
-                <div class="bg-surface rounded-xl border border-border/50 p-6 sm:p-8">
-                    <h2 class="text-xl font-bold text-textMain mb-6">Role Details</h2>
-                    
-                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-y-8 gap-x-6">
-                        <div class="flex flex-col gap-1">
-                            <span class="text-xs font-semibold text-textMuted uppercase tracking-wider">Available Slots</span>
-                            <span class="text-textMain font-medium text-lg">1 Position</span>
-                        </div>
-                        
-                        <div class="flex flex-col gap-1">
-                            <span class="text-xs font-semibold text-textMuted uppercase tracking-wider">Duration</span>
-                            <span class="text-textMain font-medium text-lg">24 Weeks</span>
-                        </div>
-                        
-                        <div class="flex flex-col gap-1">
-                            <span class="text-xs font-semibold text-textMuted uppercase tracking-wider">Location</span>
-                            <span class="text-textMain font-medium text-lg">Hybrid (Capital City / Remote)</span>
-                        </div>
-                        
-                        <div class="flex flex-col gap-1">
-                            <span class="text-xs font-semibold text-textMuted uppercase tracking-wider">Compensation</span>
-                            <span class="text-textMain font-medium text-lg">$120,000 - $150,000 USD</span>
-                        </div>
-                        
-                        <div class="flex flex-col gap-1 sm:col-span-2 pt-4 border-t border-border/50">
-                            <span class="text-xs font-semibold text-textMuted uppercase tracking-wider">Application Deadline</span>
-                            <div class="flex items-center gap-2 mt-1">
-                                <i class="fa-regular fa-calendar text-primary"></i>
-                                <span class="text-textMain font-medium text-lg">October 15, 2026</span>
-                            </div>
                         </div>
                     </div>
                 </div>

--- a/docs/frontend/portal/designs/flow3c/03-cfeoi-detail-open-owner.html
+++ b/docs/frontend/portal/designs/flow3c/03-cfeoi-detail-open-owner.html
@@ -172,10 +172,6 @@
 
                     <div class="flex flex-wrap items-center gap-2 mt-2">
                         <span class="inline-flex items-center px-3 py-1 rounded-md bg-surface border border-border/50 text-textMain text-sm font-medium">
-                            <i class="fa-solid fa-briefcase text-textMuted mr-2"></i>
-                            Role: Lead System Architect
-                        </span>
-                        <span class="inline-flex items-center px-3 py-1 rounded-md bg-surface border border-border/50 text-textMain text-sm font-medium">
                             <i class="fa-regular fa-user text-textMuted mr-2"></i>
                             Individual Consultant
                         </span>
@@ -184,11 +180,11 @@
 
                 <!-- Description Section -->
                 <div class="bg-surface rounded-xl border border-border/50 p-6 sm:p-8 flex flex-col gap-6">
-                    <h2 class="text-xl font-bold text-textMain">Role Description</h2>
-                    
+                    <h2 class="text-xl font-bold text-textMain">Description</h2>
+
                     <div class="prose max-w-none text-textMuted leading-relaxed">
                         <p class="mb-4">We are seeking an experienced Lead System Architect to design and oversee the implementation of our new national digital health infrastructure. This role involves working closely with the Ministry of Health and international tech partners to ensure a robust, scalable, and secure system.</p>
-                        
+
                         <p class="mb-4"><strong>Key Responsibilities:</strong></p>
                         <ul class="list-disc pl-5 mb-4 space-y-2">
                             <li>Design end-to-end architecture for the national health data exchange.</li>
@@ -196,69 +192,19 @@
                             <li>Lead a team of senior developers and data engineers.</li>
                             <li>Evaluate and select appropriate cloud infrastructure providers.</li>
                         </ul>
-                        
+
                         <p>The ideal candidate will have a strong background in public sector IT transformations and a deep understanding of healthcare informatics.</p>
                     </div>
 
-                    <!-- Skills -->
+                    <!-- Tags -->
                     <div class="mt-4 pt-6 border-t border-border/50">
-                        <h3 class="text-sm font-semibold text-textMain uppercase tracking-wider mb-3">Required Skills</h3>
+                        <h3 class="text-sm font-semibold text-textMain uppercase tracking-wider mb-3">Tags</h3>
                         <div class="flex flex-wrap gap-2">
                             <span class="px-3 py-1.5 bg-inputBg border border-border/50 rounded-full text-sm text-textMuted hover:text-textMain hover:border-border transition-colors cursor-default">System Architecture</span>
                             <span class="px-3 py-1.5 bg-inputBg border border-border/50 rounded-full text-sm text-textMuted hover:text-textMain hover:border-border transition-colors cursor-default">Cloud Infrastructure</span>
                             <span class="px-3 py-1.5 bg-inputBg border border-border/50 rounded-full text-sm text-textMuted hover:text-textMain hover:border-border transition-colors cursor-default">HL7/FHIR</span>
                             <span class="px-3 py-1.5 bg-inputBg border border-border/50 rounded-full text-sm text-textMuted hover:text-textMain hover:border-border transition-colors cursor-default">Team Leadership</span>
                             <span class="px-3 py-1.5 bg-inputBg border border-border/50 rounded-full text-sm text-textMuted hover:text-textMain hover:border-border transition-colors cursor-default">Healthcare Informatics</span>
-                        </div>
-                    </div>
-                    
-                    <!-- External Links -->
-                    <div class="mt-2 pt-6 border-t border-border/50">
-                        <h3 class="text-sm font-semibold text-textMain uppercase tracking-wider mb-3">External Links</h3>
-                        <div class="flex flex-col gap-2">
-                            <a href="#" class="inline-flex items-center gap-2 text-primary hover:text-primaryHover transition-colors text-sm w-fit">
-                                <i class="fa-solid fa-arrow-up-right-from-square text-xs"></i>
-                                Preliminary Architecture Draft
-                            </a>
-                            <a href="#" class="inline-flex items-center gap-2 text-primary hover:text-primaryHover transition-colors text-sm w-fit">
-                                <i class="fa-solid fa-arrow-up-right-from-square text-xs"></i>
-                                Ministry of Health Digital Strategy 2025-2030
-                            </a>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Details Grid -->
-                <div class="bg-surface rounded-xl border border-border/50 p-6 sm:p-8">
-                    <h2 class="text-xl font-bold text-textMain mb-6">Role Details</h2>
-                    
-                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-y-8 gap-x-6">
-                        <div class="flex flex-col gap-1">
-                            <span class="text-xs font-semibold text-textMuted uppercase tracking-wider">Available Slots</span>
-                            <span class="text-textMain font-medium text-lg">1 Position</span>
-                        </div>
-                        
-                        <div class="flex flex-col gap-1">
-                            <span class="text-xs font-semibold text-textMuted uppercase tracking-wider">Duration</span>
-                            <span class="text-textMain font-medium text-lg">24 Weeks</span>
-                        </div>
-                        
-                        <div class="flex flex-col gap-1">
-                            <span class="text-xs font-semibold text-textMuted uppercase tracking-wider">Location</span>
-                            <span class="text-textMain font-medium text-lg">Hybrid (Capital City / Remote)</span>
-                        </div>
-                        
-                        <div class="flex flex-col gap-1">
-                            <span class="text-xs font-semibold text-textMuted uppercase tracking-wider">Compensation</span>
-                            <span class="text-textMain font-medium text-lg">$120,000 - $150,000 USD</span>
-                        </div>
-                        
-                        <div class="flex flex-col gap-1 sm:col-span-2 pt-4 border-t border-border/50">
-                            <span class="text-xs font-semibold text-textMuted uppercase tracking-wider">Application Deadline</span>
-                            <div class="flex items-center gap-2 mt-1">
-                                <i class="fa-regular fa-calendar text-primary"></i>
-                                <span class="text-textMain font-medium text-lg">October 15, 2026</span>
-                            </div>
                         </div>
                     </div>
                 </div>

--- a/docs/frontend/portal/designs/flow3c/04-cfeoi-edit-form.html
+++ b/docs/frontend/portal/designs/flow3c/04-cfeoi-edit-form.html
@@ -168,10 +168,10 @@
 
         <form id="edit-cfeoi-form" class="flex flex-col gap-8 mt-6">
             
-            <!-- Section 1: Role Identity -->
-            <div id="section-role-identity" class="bg-surface rounded-xl border border-border/50 overflow-hidden shadow-lg">
+            <!-- Section 1: CFEOI Details -->
+            <div id="section-cfeoi-identity" class="bg-surface rounded-xl border border-border/50 overflow-hidden shadow-lg">
                 <div class="px-6 py-4 border-b border-border/50 bg-surface flex items-center justify-between">
-                    <h2 id="role-identity-heading" class="text-base font-semibold text-textMain">Role Identity</h2>
+                    <h2 class="text-base font-semibold text-textMain">CFEOI Details</h2>
                     <button type="button" class="text-textMuted hover:text-textMain transition-colors"><i class="fa-solid fa-chevron-down text-sm"></i></button>
                 </div>
                 <div class="p-6 flex flex-col gap-6">
@@ -186,7 +186,7 @@
                         <div class="flex flex-col sm:flex-row gap-4">
                             <label class="flex items-center gap-3 cursor-pointer group">
                                 <div class="relative flex items-center justify-center w-5 h-5">
-                                    <input type="radio" name="resource-type" id="resource-type-human" value="human" class="peer sr-only" checked onchange="updateResourceTypeFraming()">
+                                    <input type="radio" name="resource-type" id="resource-type-human" value="human" class="peer sr-only" checked>
                                     <div class="w-5 h-5 rounded-full border border-border/50 bg-inputBg peer-checked:border-primary peer-checked:bg-primary transition-colors"></div>
                                     <div class="absolute w-2 h-2 rounded-full bg-white opacity-0 peer-checked:opacity-100 transition-opacity"></div>
                                 </div>
@@ -194,7 +194,7 @@
                             </label>
                             <label class="flex items-center gap-3 cursor-pointer group">
                                 <div class="relative flex items-center justify-center w-5 h-5">
-                                    <input type="radio" name="resource-type" id="resource-type-non-human" value="non-human" class="peer sr-only" onchange="updateResourceTypeFraming()">
+                                    <input type="radio" name="resource-type" id="resource-type-non-human" value="non-human" class="peer sr-only">
                                     <div class="w-5 h-5 rounded-full border border-border/50 bg-inputBg peer-checked:border-primary peer-checked:bg-primary transition-colors"></div>
                                     <div class="absolute w-2 h-2 rounded-full bg-white opacity-0 peer-checked:opacity-100 transition-opacity"></div>
                                 </div>
@@ -203,22 +203,17 @@
                         </div>
                     </div>
 
-                    <div class="flex flex-col gap-2">
-                        <label for="role-title" class="text-sm font-medium text-textMain"><span id="role-title-label">Role Title</span> <span class="text-danger">*</span></label>
-                        <input type="text" id="role-title" value="Lead System Architect" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">
-                    </div>
-
                 </div>
             </div>
 
-            <!-- Section 2: Role Requirements -->
-            <div id="section-role-requirements" class="bg-surface rounded-xl border border-border/50 overflow-hidden shadow-lg">
+            <!-- Section 2: Description & Tags -->
+            <div id="section-cfeoi-description" class="bg-surface rounded-xl border border-border/50 overflow-hidden shadow-lg">
                 <div class="px-6 py-4 border-b border-border/50 bg-surface flex items-center justify-between">
-                    <h2 id="role-requirements-heading" class="text-base font-semibold text-textMain">Role Requirements</h2>
+                    <h2 class="text-base font-semibold text-textMain">Description &amp; Tags</h2>
                     <button type="button" class="text-textMuted hover:text-textMain transition-colors"><i class="fa-solid fa-chevron-down text-sm"></i></button>
                 </div>
                 <div class="p-6 flex flex-col gap-6">
-                    
+
                     <div class="flex flex-col gap-2">
                         <label for="description" class="text-sm font-medium text-textMain">Description <span class="text-danger">*</span></label>
                         <div class="border border-border/50 rounded-lg overflow-hidden bg-inputBg">
@@ -246,8 +241,8 @@ The ideal candidate will have a strong background in public sector IT transforma
                     </div>
 
                     <div class="flex flex-col gap-2">
-                        <label for="skills" class="text-sm font-medium text-textMain"><span id="skills-label">Skills (comma separated)</span> <span class="text-danger">*</span></label>
-                        <input type="text" id="skills" value="System Architecture, Cloud Infrastructure, HL7/FHIR, Team Leadership, Healthcare Informatics" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">
+                        <label for="tags" class="text-sm font-medium text-textMain">Tags (comma separated, optional)</label>
+                        <input type="text" id="tags" value="System Architecture, Cloud Infrastructure, HL7/FHIR, Team Leadership, Healthcare Informatics" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">
                         <div class="flex flex-wrap gap-2 mt-2">
                             <span class="inline-flex items-center gap-1.5 px-3 py-1 bg-surface border border-border/50 rounded-full text-xs text-textMuted">
                                 System Architecture <button type="button" class="hover:text-danger transition-colors"><i class="fa-solid fa-xmark"></i></button>
@@ -259,52 +254,6 @@ The ideal candidate will have a strong background in public sector IT transforma
                                 HL7/FHIR <button type="button" class="hover:text-danger transition-colors"><i class="fa-solid fa-xmark"></i></button>
                             </span>
                         </div>
-                    </div>
-
-                    <div class="flex flex-col sm:flex-row gap-6">
-                        <div class="flex flex-col gap-2 flex-1">
-                            <label for="slots" class="text-sm font-medium text-textMain">Available Slots <span class="text-danger">*</span></label>
-                            <input type="number" id="slots" value="1" min="1" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">
-                        </div>
-                        <div class="flex flex-col gap-2 flex-1">
-                            <label for="duration" class="text-sm font-medium text-textMain">Duration (Weeks)</label>
-                            <input type="number" id="duration" value="24" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">
-                        </div>
-                    </div>
-
-                </div>
-            </div>
-
-            <!-- Section 3: Optional Details -->
-            <div id="section-optional-details" class="bg-surface rounded-xl border border-border/50 overflow-hidden shadow-lg">
-                <div class="px-6 py-4 border-b border-border/50 bg-surface flex items-center justify-between">
-                    <h2 class="text-base font-semibold text-textMain">Optional Details</h2>
-                    <button type="button" class="text-textMuted hover:text-textMain transition-colors"><i class="fa-solid fa-chevron-down text-sm"></i></button>
-                </div>
-                <div class="p-6 flex flex-col gap-6">
-                    
-                    <div class="flex flex-col sm:flex-row gap-6">
-                        <div class="flex flex-col gap-2 flex-1">
-                            <label for="location" class="text-sm font-medium text-textMain">Location</label>
-                            <input type="text" id="location" value="Hybrid (Capital City / Remote)" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">
-                        </div>
-                        <div class="flex flex-col gap-2 flex-1">
-                            <label for="compensation" class="text-sm font-medium text-textMain">Compensation</label>
-                            <input type="text" id="compensation" value="$120,000 - $150,000 USD" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">
-                        </div>
-                    </div>
-
-                    <div class="flex flex-col gap-2">
-                        <label for="deadline" class="text-sm font-medium text-textMain">Application Deadline</label>
-                        <div class="relative w-full sm:w-1/2">
-                            <input type="date" id="deadline" value="2026-10-15" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent [color-scheme:light]">
-                        </div>
-                    </div>
-
-                    <div class="flex flex-col gap-2">
-                        <label for="external-links" class="text-sm font-medium text-textMain">External Links (One per line)</label>
-                        <textarea id="external-links" rows="3" class="w-full bg-inputBg border border-border/50 rounded-lg px-4 py-2.5 text-textMain text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent resize-y custom-scrollbar">https://example.gov/preliminary-architecture.pdf
-https://example.gov/digital-strategy-2025</textarea>
                     </div>
 
                 </div>
@@ -328,17 +277,6 @@ https://example.gov/digital-strategy-2025</textarea>
         &copy; 2026 Herit Civic Platform. All rights reserved.
     </footer>
 
-    <script>
-        function updateResourceTypeFraming() {
-            const isHuman = document.getElementById('resource-type-human').checked;
-
-            document.getElementById('role-identity-heading').textContent = isHuman ? 'Role Identity' : 'Resource Identity';
-            document.getElementById('role-requirements-heading').textContent = isHuman ? 'Role Requirements' : 'Resource Requirements';
-
-            document.getElementById('role-title-label').textContent = isHuman ? 'Role Title' : 'Resource Name';
-            document.getElementById('skills-label').textContent = isHuman ? 'Skills (comma separated)' : 'Specifications (comma separated)';
-        }
-    </script>
 
 </body>
 </html>

--- a/docs/frontend/portal/designs/flow3c/05-close-cfeoi-modal.html
+++ b/docs/frontend/portal/designs/flow3c/05-close-cfeoi-modal.html
@@ -162,7 +162,6 @@
                 <!-- Header Area -->
                 <div class="flex flex-col gap-4">
                     <div class="flex items-center gap-3">
-                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-surface border border-border/50 text-textMuted">Technology & IT</span>
                         <span class="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium bg-success/10 text-success border border-success/20">
                             <span class="w-1.5 h-1.5 rounded-full bg-success"></span>
                             Open
@@ -191,7 +190,7 @@
                     <div class="h-px w-full bg-border/50"></div>
 
                     <div>
-                        <h3 class="text-base font-semibold text-textMain mb-3">Required Skills</h3>
+                        <h3 class="text-base font-semibold text-textMain mb-3">Tags</h3>
                         <div class="flex flex-wrap gap-2">
                             <span class="inline-flex items-center px-3 py-1 bg-inputBg border border-border/50 rounded-full text-xs text-textMain">System Architecture</span>
                             <span class="inline-flex items-center px-3 py-1 bg-inputBg border border-border/50 rounded-full text-xs text-textMain">Cloud Infrastructure</span>

--- a/docs/frontend/portal/designs/flow3c/06-cfeoi-detail-closed-owner.html
+++ b/docs/frontend/portal/designs/flow3c/06-cfeoi-detail-closed-owner.html
@@ -180,10 +180,6 @@
 
                     <div class="flex flex-wrap items-center gap-2 mt-2">
                         <span class="inline-flex items-center px-3 py-1 rounded-md bg-surface border border-border/50 text-textMain text-sm font-medium">
-                            <i class="fa-solid fa-briefcase text-textMuted mr-2"></i>
-                            Role: Lead System Architect
-                        </span>
-                        <span class="inline-flex items-center px-3 py-1 rounded-md bg-surface border border-border/50 text-textMain text-sm font-medium">
                             <i class="fa-regular fa-user text-textMuted mr-2"></i>
                             Individual Consultant
                         </span>
@@ -192,11 +188,11 @@
 
                 <!-- Description Section -->
                 <div class="bg-surface rounded-xl border border-border/50 p-6 sm:p-8 flex flex-col gap-6">
-                    <h2 class="text-xl font-bold text-textMain">Role Description</h2>
-                    
+                    <h2 class="text-xl font-bold text-textMain">Description</h2>
+
                     <div class="prose max-w-none text-textMuted leading-relaxed">
                         <p class="mb-4">We are seeking an experienced Lead System Architect to design and oversee the implementation of our new national digital health infrastructure. This role involves working closely with the Ministry of Health and international tech partners to ensure a robust, scalable, and secure system.</p>
-                        
+
                         <p class="mb-4"><strong>Key Responsibilities:</strong></p>
                         <ul class="list-disc pl-5 mb-4 space-y-2">
                             <li>Design end-to-end architecture for the national health data exchange.</li>
@@ -204,69 +200,19 @@
                             <li>Lead a team of senior developers and data engineers.</li>
                             <li>Evaluate and select appropriate cloud infrastructure providers.</li>
                         </ul>
-                        
+
                         <p>The ideal candidate will have a strong background in public sector IT transformations and a deep understanding of healthcare informatics.</p>
                     </div>
 
-                    <!-- Skills -->
+                    <!-- Tags -->
                     <div class="mt-4 pt-6 border-t border-border/50">
-                        <h3 class="text-sm font-semibold text-textMain uppercase tracking-wider mb-3">Required Skills</h3>
+                        <h3 class="text-sm font-semibold text-textMain uppercase tracking-wider mb-3">Tags</h3>
                         <div class="flex flex-wrap gap-2">
                             <span class="px-3 py-1.5 bg-inputBg border border-border/50 rounded-full text-sm text-textMuted hover:text-textMain hover:border-border transition-colors cursor-default">System Architecture</span>
                             <span class="px-3 py-1.5 bg-inputBg border border-border/50 rounded-full text-sm text-textMuted hover:text-textMain hover:border-border transition-colors cursor-default">Cloud Infrastructure</span>
                             <span class="px-3 py-1.5 bg-inputBg border border-border/50 rounded-full text-sm text-textMuted hover:text-textMain hover:border-border transition-colors cursor-default">HL7/FHIR</span>
                             <span class="px-3 py-1.5 bg-inputBg border border-border/50 rounded-full text-sm text-textMuted hover:text-textMain hover:border-border transition-colors cursor-default">Team Leadership</span>
                             <span class="px-3 py-1.5 bg-inputBg border border-border/50 rounded-full text-sm text-textMuted hover:text-textMain hover:border-border transition-colors cursor-default">Healthcare Informatics</span>
-                        </div>
-                    </div>
-                    
-                    <!-- External Links -->
-                    <div class="mt-2 pt-6 border-t border-border/50">
-                        <h3 class="text-sm font-semibold text-textMain uppercase tracking-wider mb-3">External Links</h3>
-                        <div class="flex flex-col gap-2">
-                            <a href="#" class="inline-flex items-center gap-2 text-primary hover:text-primaryHover transition-colors text-sm w-fit">
-                                <i class="fa-solid fa-arrow-up-right-from-square text-xs"></i>
-                                Preliminary Architecture Draft
-                            </a>
-                            <a href="#" class="inline-flex items-center gap-2 text-primary hover:text-primaryHover transition-colors text-sm w-fit">
-                                <i class="fa-solid fa-arrow-up-right-from-square text-xs"></i>
-                                Ministry of Health Digital Strategy 2025-2030
-                            </a>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Details Grid -->
-                <div class="bg-surface rounded-xl border border-border/50 p-6 sm:p-8">
-                    <h2 class="text-xl font-bold text-textMain mb-6">Role Details</h2>
-                    
-                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-y-8 gap-x-6">
-                        <div class="flex flex-col gap-1">
-                            <span class="text-xs font-semibold text-textMuted uppercase tracking-wider">Available Slots</span>
-                            <span class="text-textMain font-medium text-lg">1 Position</span>
-                        </div>
-                        
-                        <div class="flex flex-col gap-1">
-                            <span class="text-xs font-semibold text-textMuted uppercase tracking-wider">Duration</span>
-                            <span class="text-textMain font-medium text-lg">24 Weeks</span>
-                        </div>
-                        
-                        <div class="flex flex-col gap-1">
-                            <span class="text-xs font-semibold text-textMuted uppercase tracking-wider">Location</span>
-                            <span class="text-textMain font-medium text-lg">Hybrid (Capital City / Remote)</span>
-                        </div>
-                        
-                        <div class="flex flex-col gap-1">
-                            <span class="text-xs font-semibold text-textMuted uppercase tracking-wider">Compensation</span>
-                            <span class="text-textMain font-medium text-lg">$120,000 - $150,000 USD</span>
-                        </div>
-                        
-                        <div class="flex flex-col gap-1 sm:col-span-2 pt-4 border-t border-border/50">
-                            <span class="text-xs font-semibold text-textMuted uppercase tracking-wider">Application Deadline</span>
-                            <div class="flex items-center gap-2 mt-1">
-                                <i class="fa-regular fa-calendar text-primary"></i>
-                                <span class="text-textMain font-medium text-lg">October 15, 2026</span>
-                            </div>
                         </div>
                     </div>
                 </div>

--- a/docs/frontend/portal/user-flows-high-level.md
+++ b/docs/frontend/portal/user-flows-high-level.md
@@ -23,7 +23,7 @@
 - Branch: From landing or RFP list → Public Proposals List
   - Note: The current `GET /api/v1/Proposals` endpoint returns all proposals with no server-side visibility or status filtering. Until query parameters are added to the backend, the frontend must filter client-side to show only proposals with `Visibility = Public`.
 - Node 3: Proposal Detail (public) — summary, status, visible CFEOIs
-- Node 4: CFEOI Detail (public) — resource type, role title, skills required, slots, duration, location, deadline, external links
+- Node 4: CFEOI Detail (public) — title, description, resource type, tags
 - Decision: Attempt to interact (Express Interest / Apply / Bookmark)?
   - If Yes → Prompt: Sign in with Google (link to Authentication flow)
   - If No → End (continue browsing)
@@ -78,8 +78,8 @@
 - Precondition: Proposal must be in **Resourcing** status (or later) to publish a CFEOI
 - Start: From Proposal Detail (owner) click "Publish CFEOI"
 - Node: CFEOI Form
-  - **Required fields**: title, description, resource type (`Human` / `Non-Human`), role title, skills required, number of slots
-  - **Optional fields**: duration (weeks), location, compensation, deadline, external links
+  - **Required fields**: title, description, resource type (`Human` / `Non-Human`)
+  - **Optional fields**: tags (free-text, comma-separated; used to convey required skills/expertise for a Human resource, or specifications for a Non-Human one)
   - Note: CFEOI has no independent visibility setting — it inherits the parent proposal's visibility automatically. Do not include a visibility control in this form.
   - Note: Attachments and CFEOI drafts are out-of-scope. Publishing immediately creates an `Open` CFEOI via `POST /api/v1/Cfeoi`.
 - Action: Publish CFEOI → immediate creation of an `Open` CFEOI; show in-app confirmation and placeholder: Future email notification to subscribers/department (no current backend dependency)
@@ -136,7 +136,7 @@
 - Visibility terminology for EOIs uses: `Private` / `Shared`. "Private" means visible to the submitter only; "Shared" means visible to the submitter and relevant staff/proposal owner.
 - No "Draft" status appears for proposals; proposal-editing actions occur within `Ideation` or `Resourcing` states.
 - CFEOI flows do not include draft saving; publishing creates an `Open` CFEOI immediately. CFEOI has no visibility field; it inherits visibility from its parent proposal. CFEOI `Closed` status is terminal.
-- CFEOI forms include all required fields (title, description, resource type, role title, skills, slots) and all optional fields (duration in weeks, location, compensation, deadline, external links). No "visibility" control appears on the CFEOI form.
+- CFEOI forms include all required fields (title, description, resource type) and the optional tags field. No "visibility" control appears on the CFEOI form.
 - EOI withdrawal is shown as a deletion action, not a status transition. Withdrawn EOIs do not appear in any list.
 - EOI status filter options in the owner's inbox are: `Pending`, `Approved`, `Rejected` — no other values.
 - Notification actions are shown only as clearly labelled placeholders (future infrastructure), not as required dependencies.


### PR DESCRIPTION
## Description

The design review cycle (#218–#231) validated the flow3c mockups against section 3c of `docs/frontend/portal/user-flows-high-level.md` — but that spec section was itself wrong about the backend it claims as source of truth. The actual `Cfeoi` entity (`src/Herit.Domain/Entities/Cfeoi.cs`, mirrored in `PublishCfeoiCommand`/`UpdateCfeoiCommand` and the frontend `Cfeoi` type) has exactly six fields: `Title`, `Description`, `ResourceType`, `ProposalId`, `Status`, `Tags`. The spec and mockups instead described a much richer model: role title, skills required, number of slots, duration, location, compensation, deadline, and external links — none of which exist on the backend.

This PR trims the spec and designs down to the real model. **The backend was not changed.**

### Spec (`docs/frontend/portal/user-flows-high-level.md`)
- Section 1, Node 4 (public CFEOI detail): field list corrected to title, description, resource type, tags.
- Section 3c: required fields now title/description/resource type only; optional fields now just tags, with a note mapping "skills" onto Tags.
- Acceptance criteria: same field-list correction.
- Checked sections 3d/3e and flow3d for stray references to the removed fields — found none, no changes needed there.

### Flow3c mockups
- **01 (publish form) / 04 (edit form)**: removed Role Title, Slots, Duration, Location, Compensation, Deadline, and External Links. Renamed "Skills" to "Tags" (optional). Merged the two now-thinner sections into one "CFEOI Details" + one "Description & Tags" section rather than leaving a section with a single field. Removed the now-dead JS that relabeled sections/fields based on resource type (04) or trimmed it to only what's still meaningful — the Tags placeholder (01).
- **03 (detail page) / 02 (publish confirmation) / 06 (closed-state detail)**: removed the "Role: ..." badge, renamed "Role Description" → "Description", renamed "Required Skills" → "Tags", removed the "External Links" section, and removed the entire "Role Details" card (Available Slots/Duration/Location/Compensation/Deadline) since every real remaining field (title, description, resource type, status, tags, proposal) is already displayed elsewhere on the page — nothing legitimate was left to show there.
- **05 (close modal)**: the blurred background preview still had the already-removed "Category" badge (a leftover #218 missed since it wasn't in that issue's scope) and a "Required Skills" heading; both fixed for consistency.

### Verification of implemented code
Checked `CfeoiDetailPage.tsx`, `CfeoiDirectoryPage.tsx`, and `CfeoiCard.tsx` (flow1, already implemented) — all were built against the real `Cfeoi` type and already show only title/description/resourceType/status/tags. No implementation changes needed.

## Candidate post-MVP backend enhancements (not implemented, listed per issue instructions)
If any of the removed concepts are judged valuable later, they'd need new backend fields/validation first:
- **Slots** — number of openings for a CFEOI.
- **Deadline** — application cutoff date.
- **Duration / Location / Compensation** — role logistics, likely only meaningful for `Human` resource types.
- A first-class **Role Title** distinct from the CFEOI `Title`, if the product wants to separate "the call" from "the specific role" it's requesting.

## Linked Issue

Closes #244

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Chore / refactor

## Testing Notes

Docs/design-mockup-only change — no backend or frontend application code touched. Verified each edited HTML file has balanced `<div>` tags, confirmed no references to the removed fields remain anywhere in `docs/frontend/portal/designs/flow3c/`, `flow3d/`, or the spec doc via grep, and confirmed the already-implemented CFEOI pages don't reference any of the removed fields either.

## Checklist

- [x] Code builds cleanly (`dotnet build`) — N/A, docs-only change
- [x] Tests pass (`dotnet test`) — N/A, docs-only change
- [x] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)