### PR TITLE
Implement the owner CFEOI detail view (Open and Closed states)

### DIFF
--- a/frontend/portal/src/pages/public/CfeoiDetailPage.tsx
+++ b/frontend/portal/src/pages/public/CfeoiDetailPage.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useIsAuthenticated, useMsal } from '@azure/msal-react';
 import { getCfeoiById } from '../../api/cfeois';
 import { getProposalById } from '../../api/proposals';
+import { listEoisByCfeoi } from '../../api/eois';
 import { apiScopes } from '../../auth/authScopes';
 import { useCurrentUser } from '../../hooks/useCurrentUser';
 import LoadingSpinner from '../../components/LoadingSpinner';
@@ -98,6 +99,14 @@ export default function CfeoiDetailPage() {
     enabled: !!cfeoi?.proposalId,
   });
 
+  const isOwner = !!currentUser && !!proposal && currentUser.id === proposal.authorId;
+
+  const { data: eois } = useQuery({
+    queryKey: ['eois', 'cfeoi', cfeoiId],
+    queryFn: () => listEoisByCfeoi(cfeoiId!),
+    enabled: isOwner && !!cfeoiId,
+  });
+
   if (isLoading) return <LoadingSpinner className="py-32" />;
 
   if (isError || !cfeoi) {
@@ -110,11 +119,23 @@ export default function CfeoiDetailPage() {
     );
   }
 
-  const isOwner = !!currentUser && !!proposal && currentUser.id === proposal.authorId;
-
   return (
     <div className="w-full pb-16 bg-gray-50">
       {showSignInModal && <SignInModal onClose={() => setShowSignInModal(false)} />}
+
+      {/* Closed-state banner (owner only) */}
+      {isOwner && cfeoi.status === 'Closed' && (
+        <div className="bg-blue-50 border-b border-blue-200 px-6 py-3">
+          <div className="max-w-[1200px] mx-auto flex items-start sm:items-center gap-3">
+            <svg className="w-4 h-4 text-blue-700 mt-0.5 sm:mt-0 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <p className="text-sm text-blue-900">
+              <span className="font-semibold">This CFEOI is now closed.</span> It is no longer accepting new expressions of interest. You can still review submitted applications below.
+            </p>
+          </div>
+        </div>
+      )}
 
       {/* Success banner */}
       {showSuccessBanner && (
@@ -205,11 +226,56 @@ export default function CfeoiDetailPage() {
             {isOwner && cfeoi.status === 'Open' && (
               <SidebarCard>
                 <h3 className="text-sm font-bold text-gray-900 mb-4 uppercase tracking-wider">Manage CFEOI</h3>
+                <div className="flex flex-col gap-3">
+                  <Link
+                    to={`/cfeois/${cfeoiId}/edit`}
+                    className="w-full flex items-center justify-center px-4 py-2.5 border border-gray-300 text-sm font-medium rounded-lg text-gray-700 bg-white hover:bg-gray-50 shadow-sm transition-colors"
+                  >
+                    Edit Details
+                  </Link>
+                  <button
+                    onClick={() => {
+                      // TODO: implement Close CFEOI confirmation modal — see Flow 3c, "Close CFEOI"
+                    }}
+                    className="w-full flex items-center justify-center px-4 py-2.5 border border-red-200 text-sm font-medium rounded-lg text-red-600 bg-white hover:bg-red-50 shadow-sm transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-400"
+                  >
+                    Close CFEOI
+                  </button>
+                </div>
+                <p className="text-xs text-gray-500 mt-4 text-center">Closing is irreversible and stops new applications.</p>
+              </SidebarCard>
+            )}
+
+            {isOwner && cfeoi.status === 'Closed' && (
+              <SidebarCard>
+                <h3 className="text-sm font-bold text-gray-900 mb-4 uppercase tracking-wider">Manage CFEOI</h3>
+                <div className="flex items-start gap-3 bg-gray-50 border border-gray-200 rounded-lg p-4">
+                  <svg className="w-4 h-4 text-gray-400 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                  </svg>
+                  <p className="text-sm text-gray-600">This CFEOI is closed. Editing and closing are no longer available — closure is a terminal state.</p>
+                </div>
+              </SidebarCard>
+            )}
+
+            {isOwner && (
+              <SidebarCard>
+                <h3 className="text-lg font-bold text-gray-900 mb-1">Expressions of Interest</h3>
+                <p className="text-sm text-gray-500 mb-6">Current applications received for this role.</p>
+                <div className="flex items-end justify-between mb-6">
+                  <div className="flex flex-col">
+                    <span className="text-4xl font-bold text-gray-900 leading-none">{eois?.length ?? 0}</span>
+                    <span className="text-sm text-gray-500 mt-1">Total Received</span>
+                  </div>
+                </div>
                 <Link
-                  to={`/cfeois/${cfeoiId}/edit`}
-                  className="w-full flex items-center justify-center px-4 py-2.5 border border-gray-300 text-sm font-medium rounded-lg text-gray-700 bg-white hover:bg-gray-50 shadow-sm transition-colors"
+                  to={`/cfeois/${cfeoiId}/eois`}
+                  className="w-full flex items-center justify-center gap-2 bg-brand hover:bg-brand-dark text-white font-medium py-2.5 px-4 rounded-lg transition-colors"
                 >
-                  Edit Details
+                  View All EOIs
+                  <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                  </svg>
                 </Link>
               </SidebarCard>
             )}


### PR DESCRIPTION
## Description

Implements the owner's view of the CFEOI detail page per mockups `flow3c/03-cfeoi-detail-open-owner.html` (Open) and `flow3c/06-cfeoi-detail-closed-owner.html` (Closed), and spec section 3c.

Extends the existing public `CfeoiDetailPage` (`/cfeois/:cfeoiId`) with owner-conditional sections, rather than a separate owner route — matching the pattern flow 3b used for owner vs public proposal detail (`ProposalDetailPage`).

- **Open, owner view**: "Manage CFEOI" card with Edit (already wired to `/cfeois/:cfeoiId/edit` from #247) and Close actions, plus an EOI summary card showing the total EOI count (via `listEoisByCfeoi`) with a link to the EOI inbox (`/cfeois/:cfeoiId/eois`).
- **Closed, owner view**: an info banner ("This CFEOI is now closed...") above the breadcrumb, the Manage CFEOI card replaced with a locked-state message (no Edit/Close), and the EOI summary/inbox link still reachable so already-submitted EOIs remain reviewable.
- Non-owners never see any of the management sections (gated on `isOwner`, computed the same way as the edit form: current user id vs. the parent proposal's `authorId`).
- The parent-proposal link (existing "Related Context" section) is unchanged and available regardless of ownership.

The **Close** button is wired as a stub (`// TODO`) for now, following the exact same deferral pattern already in this file for the unimplemented "Express Interest" button. The actual confirmation modal + `updateCfeoiStatus` call is separate, tracked in #249 ("Implement the Close CFEOI confirmation modal").

## Linked Issue

Closes #248

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- `npm run build` (tsc + vite build) passes.
- `npm run test:run` passes (existing suite, 5 tests).
- Note: `npm run lint` currently fails on this branch and on `main` because `eslint` is not installed as a dependency — pre-existing, unrelated to this change.

## Checklist

- [x] Code builds cleanly (`dotnet build` n/a — frontend-only change; `npm run build` passes)
- [x] Tests pass (`npm run test:run`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)