### PR TITLE
Implement the Close CFEOI confirmation modal

### DIFF
--- a/frontend/portal/src/pages/public/CfeoiDetailPage.tsx
+++ b/frontend/portal/src/pages/public/CfeoiDetailPage.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useIsAuthenticated, useMsal } from '@azure/msal-react';
-import { getCfeoiById } from '../../api/cfeois';
+import { getCfeoiById, updateCfeoiStatus } from '../../api/cfeois';
 import { getProposalById } from '../../api/proposals';
 import { listEoisByCfeoi } from '../../api/eois';
 import { apiScopes } from '../../auth/authScopes';
@@ -79,7 +79,10 @@ export default function CfeoiDetailPage() {
   const [searchParams] = useSearchParams();
   const isAuthenticated = useIsAuthenticated();
   const { user: currentUser } = useCurrentUser();
+  const queryClient = useQueryClient();
   const [showSignInModal, setShowSignInModal] = useState(false);
+  const [showCloseModal, setShowCloseModal] = useState(false);
+  const [closeConfirmed, setCloseConfirmed] = useState(false);
   const [showSuccessBanner, setShowSuccessBanner] = useState(
     searchParams.get('published') === 'true' || searchParams.get('updated') === 'true'
   );
@@ -105,6 +108,15 @@ export default function CfeoiDetailPage() {
     queryKey: ['eois', 'cfeoi', cfeoiId],
     queryFn: () => listEoisByCfeoi(cfeoiId!),
     enabled: isOwner && !!cfeoiId,
+  });
+
+  const closeMutation = useMutation({
+    mutationFn: () => updateCfeoiStatus(cfeoiId!, 'Closed'),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['cfeois', cfeoiId] });
+      setShowCloseModal(false);
+      setCloseConfirmed(false);
+    },
   });
 
   if (isLoading) return <LoadingSpinner className="py-32" />;
@@ -234,9 +246,7 @@ export default function CfeoiDetailPage() {
                     Edit Details
                   </Link>
                   <button
-                    onClick={() => {
-                      // TODO: implement Close CFEOI confirmation modal — see Flow 3c, "Close CFEOI"
-                    }}
+                    onClick={() => setShowCloseModal(true)}
                     className="w-full flex items-center justify-center px-4 py-2.5 border border-red-200 text-sm font-medium rounded-lg text-red-600 bg-white hover:bg-red-50 shadow-sm transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-400"
                   >
                     Close CFEOI
@@ -340,6 +350,59 @@ export default function CfeoiDetailPage() {
           </div>
         </div>
       </div>
+
+      {/* Close CFEOI confirmation modal */}
+      {showCloseModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40">
+          <div className="bg-white rounded-2xl shadow-xl max-w-lg w-full overflow-hidden">
+            <div className="px-6 pt-6 pb-4 flex flex-col items-center text-center">
+              <div className="w-14 h-14 rounded-full bg-red-50 flex items-center justify-center mb-4 border border-red-100">
+                <svg className="w-7 h-7 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                </svg>
+              </div>
+              <h2 className="text-xl font-bold text-gray-900 mb-2">Close CFEOI?</h2>
+              <p className="text-sm text-gray-500 leading-relaxed">
+                This action is irreversible. Once closed, {cfeoi.title} will no longer accept new expressions of interest, and it cannot be reopened.
+              </p>
+            </div>
+            <div className="px-6 py-4 bg-gray-50 border-y border-gray-200">
+              <label className="flex items-start gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={closeConfirmed}
+                  onChange={(e) => setCloseConfirmed(e.target.checked)}
+                  className="mt-0.5 w-4 h-4 accent-brand border-gray-300 rounded"
+                />
+                <span className="text-sm text-gray-700">
+                  I understand that closing this CFEOI is a permanent action and cannot be undone.
+                </span>
+              </label>
+            </div>
+            {closeMutation.isError && (
+              <p className="text-sm text-red-600 px-6 pt-4">Something went wrong. Please try again.</p>
+            )}
+            <div className="px-6 py-4 flex gap-3 justify-end">
+              <button
+                onClick={() => {
+                  setShowCloseModal(false);
+                  setCloseConfirmed(false);
+                }}
+                className="px-4 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => closeMutation.mutate()}
+                disabled={!closeConfirmed || closeMutation.isPending}
+                className="px-4 py-2 text-sm font-medium text-white bg-red-600 border border-transparent rounded-lg hover:bg-red-700 transition-colors disabled:opacity-60"
+              >
+                {closeMutation.isPending ? 'Closing...' : 'Close CFEOI'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Description

Implements the close-CFEOI flow per mockup `flow3c/05-close-cfeoi-modal.html` and spec section 3c.

- Wires the "Close CFEOI" button on the owner's CFEOI detail page (added as an inert stub in #248) to a destructive confirmation modal.
- Reuses the shared confirmation-modal pattern already established by `ProposalDetailPage`'s withdraw-proposal modal (same layout, icon treatment, and required acknowledgement checkbox) rather than building a new one, per the issue's instruction.
- The modal explicitly states that closing is irreversible and that `Closed` is a terminal state; the "Close CFEOI" button stays disabled until the checkbox is checked.
- On confirm, calls `updateCfeoiStatus(id, 'Closed')`, dismisses the modal, and invalidates the CFEOI query. The page's existing Closed-state banner and locked-state "Manage CFEOI" card (both added in #248) then render automatically from the refetched `Closed` status — this serves as the in-app confirmation without needing a separate success toast, consistent with how the withdraw-proposal flow behaves.

## Linked Issue

Closes #249

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- `npm run build` (tsc + vite build) passes.
- `npm run test:run` passes (existing suite, 5 tests).
- Note: `npm run lint` currently fails on this branch and on `main` because `eslint` is not installed as a dependency — pre-existing, unrelated to this change.

## Checklist

- [x] Code builds cleanly (`dotnet build` n/a — frontend-only change; `npm run build` passes)
- [x] Tests pass (`npm run test:run`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)