### PR TITLE
Disable Oryx remote build for the API App Service deploy

### DIFF
--- a/infra/app/api-appservice-avm.bicep
+++ b/infra/app/api-appservice-avm.bicep
@@ -42,7 +42,14 @@ module api 'br/public:avm/res/web/site:0.6.0' = {
     })
     appSettingsKeyValuePairs: union(
       appSettings,
-      { ENABLE_ORYX_BUILD: true, ApplicationInsightsAgent_EXTENSION_VERSION: contains(kind, 'linux') ? '~3' : '~2' }
+      {
+        // azd already runs `dotnet publish` and zip-deploys the output, so a second
+        // remote build in Kudu/Oryx is redundant — and on the B1 plan it's slow enough
+        // to blow past azd's deploy timeout.
+        ENABLE_ORYX_BUILD: false
+        SCM_DO_BUILD_DURING_DEPLOYMENT: false
+        ApplicationInsightsAgent_EXTENSION_VERSION: contains(kind, 'linux') ? '~3' : '~2'
+      }
     )
     logsConfiguration: {
       applicationLogs: { fileSystem: { level: 'Verbose' } }


### PR DESCRIPTION
## Description

Troubleshooting the CD job failure after the last merge (`azd deploy` failing with `deployment of service 'api' timed out after 1200 seconds`).

Looking at the Actions logs for that run and an earlier CD failure on 07-03, the pattern is: the zip package uploads in ~5 seconds, then it sits in **"Running build process"** for the full 20-minute timeout window (or, in the 07-03 failure, times out at `RuntimeStarting` instead) before azd gives up.

Root cause: `infra/app/api-appservice-avm.bicep` hardcoded `ENABLE_ORYX_BUILD: true`, which makes Kudu re-run a full `dotnet restore` + `dotnet publish` remotely on every deploy. That's redundant — `azd deploy` already publishes the app and zip-deploys the output — and it's slow enough on the `B1` (Basic, 1 vCPU / 1.75GB) App Service Plan that it blows past azd's 20-minute deploy timeout, especially targeting the very new `net10.0` where Oryx's build images may not have a warm cache.

This isn't caused by the frontend-only PRs that were merged just before it (#251–#253) — they don't touch `src/Herit.Api` or `infra/`. It looks like a pre-existing, intermittent deploy issue that this surfaces cleanly.

## Fix

Set `ENABLE_ORYX_BUILD: false` and `SCM_DO_BUILD_DURING_DEPLOYMENT: false` so the App Service deploys the already-built zip as-is instead of rebuilding it remotely.

## Linked Issue

N/A — found via CD troubleshooting, no tracking issue filed.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- Validated the edited Bicep file compiles cleanly with `az bicep build --file infra/app/api-appservice-avm.bicep` (no errors; only pre-existing, unrelated warnings in `main.bicep`).
- `dotnet build`/`dotnet test` and the frontend build/test steps are unaffected by this change (infra-only).
- The real test is the next CD run on `main` after merge — watch that the `api` deploy step no longer hangs on "Running build process".

## Checklist

- [x] Code builds cleanly (`dotnet build` n/a — infra-only change; Bicep compiles via `az bicep build`)
- [x] Tests pass (`dotnet test` n/a — infra-only change)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)