### PR TITLE
Enforce server-side visibility and status filtering on list endpoints

### DIFF
--- a/docs/frontend/portal/designs/flow3d-3e-implementation-tasks.md
+++ b/docs/frontend/portal/designs/flow3d-3e-implementation-tasks.md
@@ -17,7 +17,7 @@ Shared context for all tasks:
 
 Implement the EOI inbox per mockup `flow3d/01-eoi-inbox-owner.html` and spec section 3d, replacing the stub `CfeoiEoiInboxPage.tsx` at `/cfeois/:cfeoiId/eois`.
 
-The inbox lists EOIs for the CFEOI via `listEoisByCfeoi`, filtered client-side by status (`Pending`/`Approved`/`Rejected` — the only three values; withdrawn EOIs are deleted and simply don't appear). Each entry shows submitter and message/cover note, with Approve and Reject actions calling `updateEoiStatus`; both are terminal, so approved/rejected entries show no further actions. Reachable from the owner CFEOI detail page's "View All EOIs" link (already implemented in flow3c). Guard the route to the proposal owner. Respect EOI visibility: only `Shared` EOIs are visible to the owner per the spec's visibility rules — confirm the backend's behaviour for this endpoint and match it. The inbox must remain accessible when the CFEOI is `Closed` (with the closed-state banner from the mockup).
+The inbox lists EOIs for the CFEOI via `listEoisByCfeoi`, filtered client-side by status (`Pending`/`Approved`/`Rejected` — the only three values; withdrawn EOIs are deleted and simply don't appear). Each entry shows submitter and message/cover note, with Approve and Reject actions calling `updateEoiStatus`; both are terminal, so approved/rejected entries show no further actions. Reachable from the owner CFEOI detail page's "View All EOIs" link (already implemented in flow3c). Guard the route to the proposal owner. Respect EOI visibility: only `Shared` EOIs are visible to the owner per the spec's visibility rules — the backend now enforces this on `listEoisByCfeoi`; the inbox additionally filters to `Shared` client-side as defense-in-depth. The inbox must remain accessible when the CFEOI is `Closed` (with the closed-state banner from the mockup).
 
 ## 2. Implement contributor states on the CFEOI detail page (flow 3e)
 
@@ -35,7 +35,7 @@ A dedicated page reached from the CFEOI detail CTA, showing the target CFEOI con
 
 Implement the My EOIs page per mockup `flow3e/03-my-eois.html` and spec section 3e, replacing the stub `MyEoisPage.tsx`.
 
-List the user's EOIs via `listMyEois`, each showing the parent CFEOI (linked) and proposal, a status badge (reuse `StatusBadge`), the Private/Shared visibility segmented toggle calling `setEoiVisibility`, and the withdraw action — labelled "Withdraw" on `Pending`/`Approved` rows and "Delete" on `Rejected` rows per the decided behaviour (both open the same confirmation modal from task 5). Include client-side status filter tabs with the interim-filtering note, and the empty state with a link to the CFEOI directory.
+List the user's EOIs via `listMyEois`, each showing the parent CFEOI (linked) and proposal, a status badge (reuse `StatusBadge`), the Private/Shared visibility segmented toggle calling `setEoiVisibility`, and the withdraw action — labelled "Withdraw" on `Pending`/`Approved` rows and "Delete" on `Rejected` rows per the decided behaviour (both open the same confirmation modal from task 5). Include client-side status filter tabs (a UI concern) and the empty state with a link to the CFEOI directory.
 
 ## 5. Implement the withdraw/delete EOI confirmation modal (flow 3e)
 

--- a/docs/frontend/portal/user-flows-high-level.md
+++ b/docs/frontend/portal/user-flows-high-level.md
@@ -18,10 +18,10 @@
 ### 1) Unauthenticated Browsing (flow nodes & branches)
 - Start: Public Landing / Home
 - Node 1: RFP List (published) — filters & search
-  - Note: The current `GET /api/v1/Rfps` endpoint returns all RFPs with no server-side filtering. Until query parameters are added to the backend, the frontend must filter client-side to show only `Published` RFPs.
+  - Note: `GET /api/v1/Rfps` filters server-side — non-staff callers receive only `Published` RFPs. The frontend applies UI filters (search, department) on top of this.
 - Node 2: RFP Detail (read-only) — RFP metadata, department, publish date, public attachments are out-of-scope (do not reference attachments)
 - Branch: From landing or RFP list → Public Proposals List
-  - Note: The current `GET /api/v1/Proposals` endpoint returns all proposals with no server-side visibility or status filtering. Until query parameters are added to the backend, the frontend must filter client-side to show only proposals with `Visibility = Public`.
+  - Note: `GET /api/v1/Proposals` filters server-side by visibility — anonymous callers receive only `Public` proposals; authenticated expats additionally receive `Shared` proposals. The frontend applies UI filters (search, status) on top of this.
 - Node 3: Proposal Detail (public) — summary, status, visible CFEOIs
 - Node 4: CFEOI Detail (public) — title, description, resource type, tags
 - Decision: Attempt to interact (Express Interest / Apply / Bookmark)?
@@ -125,7 +125,7 @@
 - EOI entity model respected: EOI statuses are `Pending`, `Approved`, `Rejected`. Withdrawal is not a status — it permanently deletes the EOI record.
 - EOI visibility values are `Private` and `Shared`. `Private` means visible to the submitter only; `Shared` means visible to the submitter and the proposal owner/relevant staff.
 - Proposal statuses are `Ideation`, `Resourcing`, `Submitted`, `UnderReview`, `Approved`, `Withdrawn`. `Withdrawn` is a terminal state reachable only from `Submitted` and cannot be reversed.
-- List endpoints (`GET /api/v1/Proposals`, `GET /api/v1/Rfps`, `GET /api/v1/Cfeoi`) do not yet accept filter query parameters for status or visibility. Until server-side filtering is implemented, the frontend must apply client-side filtering to respect visibility and status rules. This is a known backend gap that must be resolved before building the browse surfaces in production.
+- List endpoints (`GET /api/v1/Proposals`, `GET /api/v1/Rfps`, `GET /api/v1/Cfeoi`) enforce visibility and status rules server-side, so callers only receive records they are authorized to see. They also accept optional convenience filter query parameters (e.g. `status`, `proposalId`, `rfpId`) that the browse surfaces pass through. Client-side filtering is limited to UI concerns (search, tabs).
 
 ### Diagram organization & recommended next steps
 - Produce separate flowcharts for: Unauthenticated Browsing; Authentication; Proposal Creation; Proposal Lifecycle; CFEOI Publishing and Management; EOI Management (owner); CFEOI Browser/EOI Submission (contributor). Provide a master index diagram that links to each flowchart and highlights the Resourcing precondition for CFEOI publishing.
@@ -145,4 +145,4 @@
 - EOI status filter options in the owner's inbox are: `Pending`, `Approved`, `Rejected` — no other values.
 - Notification actions are shown only as clearly labelled placeholders (future infrastructure), not as required dependencies.
 - All features listed as out-of-scope by the PRD are removed from the flows. The "availability" field does not appear in the EOI submission form.
-- A note is included on list/browse surfaces flagging that server-side filtering is not yet implemented and client-side filtering is the interim approach.
+- List/browse surfaces rely on server-side visibility and status filtering; client-side filtering is limited to UI concerns (search, tabs).

--- a/frontend/portal/src/api/proposals.ts
+++ b/frontend/portal/src/api/proposals.ts
@@ -1,8 +1,8 @@
 import { apiClient } from './client';
 import type { Proposal, CreateProposalRequest, UpdateProposalRequest, ProposalStatus, ProposalVisibility } from '../types';
 
-export const listProposals = (): Promise<Proposal[]> =>
-  apiClient.get('/Proposals').then((r) => r.data);
+export const listProposals = (params?: { rfpId?: string }): Promise<Proposal[]> =>
+  apiClient.get('/Proposals', { params }).then((r) => r.data);
 
 export const getProposalById = (id: string): Promise<Proposal> =>
   apiClient.get(`/Proposals/${id}`).then((r) => r.data);

--- a/frontend/portal/src/pages/app/DashboardPage.tsx
+++ b/frontend/portal/src/pages/app/DashboardPage.tsx
@@ -47,7 +47,7 @@ export default function DashboardPage() {
   // TODO: filter by authorId client-side — backend list endpoint has no filter params yet
   const { data: allProposals = [], isLoading: proposalsLoading } = useQuery({
     queryKey: ['proposals'],
-    queryFn: listProposals,
+    queryFn: () => listProposals(),
   });
 
   const { data: myEois = [], isLoading: eoisLoading } = useQuery({

--- a/frontend/portal/src/pages/app/MyEoisPage.tsx
+++ b/frontend/portal/src/pages/app/MyEoisPage.tsx
@@ -33,7 +33,7 @@ export default function MyEoisPage() {
 
   const { data: proposals = [] } = useQuery({
     queryKey: ['proposals'],
-    queryFn: listProposals,
+    queryFn: () => listProposals(),
   });
 
   const cfeoiById = new Map(cfeois.map((c) => [c.id, c]));

--- a/frontend/portal/src/pages/app/MyProposalsPage.tsx
+++ b/frontend/portal/src/pages/app/MyProposalsPage.tsx
@@ -40,7 +40,7 @@ export default function MyProposalsPage() {
 
   const { data: allProposals = [], isLoading } = useQuery({
     queryKey: ['proposals'],
-    queryFn: listProposals,
+    queryFn: () => listProposals(),
   });
 
   const myProposals = allProposals.filter((p) => p.authorId === user?.id);

--- a/frontend/portal/src/pages/public/CfeoiDirectoryPage.tsx
+++ b/frontend/portal/src/pages/public/CfeoiDirectoryPage.tsx
@@ -10,16 +10,15 @@ import EmptyState from '../../components/EmptyState';
 export default function CfeoiDirectoryPage() {
   const [search, setSearch] = useState('');
 
-  // TODO: replace with server-side filtering once backend supports query parameters
+  // Parent-proposal visibility is enforced server-side; the directory shows only Open calls.
   const { data: cfeois, isLoading, isError } = useQuery({
-    queryKey: ['cfeois'],
-    queryFn: () => listCfeois(),
-    select: (data) => data.filter((c) => c.status === 'Open'),
+    queryKey: ['cfeois', { status: 'Open' }],
+    queryFn: () => listCfeois({ status: 'Open' }),
   });
 
   const { data: proposals } = useQuery({
     queryKey: ['proposals'],
-    queryFn: listProposals,
+    queryFn: () => listProposals(),
   });
 
   const proposalMap = Object.fromEntries((proposals ?? []).map((p) => [p.id, p.title]));

--- a/frontend/portal/src/pages/public/ProposalDetailPage.tsx
+++ b/frontend/portal/src/pages/public/ProposalDetailPage.tsx
@@ -85,9 +85,8 @@ export default function ProposalDetailPage() {
   });
 
   const { data: cfeois } = useQuery({
-    queryKey: ['cfeois'],
-    queryFn: () => listCfeois(),
-    select: (data) => data.filter((c) => c.status === 'Open' && c.proposalId === proposalId),
+    queryKey: ['cfeois', { status: 'Open', proposalId }],
+    queryFn: () => listCfeois({ status: 'Open', proposalId: proposalId! }),
     enabled: !!proposalId,
   });
 

--- a/frontend/portal/src/pages/public/ProposalListPage.tsx
+++ b/frontend/portal/src/pages/public/ProposalListPage.tsx
@@ -13,11 +13,11 @@ export default function ProposalListPage() {
   const [search, setSearch] = useState('');
   const [selectedStatuses, setSelectedStatuses] = useState<ProposalStatus[]>([]);
 
-  // TODO: replace with server-side filtering once backend supports query parameters
+  // Visibility is enforced server-side: anonymous callers receive only Public proposals,
+  // authenticated expats additionally receive Shared proposals.
   const { data: proposals, isLoading, isError } = useQuery({
     queryKey: ['proposals'],
-    queryFn: listProposals,
-    select: (data) => data.filter((p) => p.visibility === 'Public'),
+    queryFn: () => listProposals(),
   });
 
   const { data: orgs } = useQuery({

--- a/frontend/portal/src/pages/public/RfpDetailPage.tsx
+++ b/frontend/portal/src/pages/public/RfpDetailPage.tsx
@@ -36,14 +36,11 @@ export default function RfpDetailPage() {
     enabled: !!rfp?.organisationId,
   });
 
-  // TODO: replace with server-side filtering once backend supports query parameters
+  // Proposals for this RFP, scoped by visibility server-side; show at most three.
   const { data: relatedProposals } = useQuery({
-    queryKey: ['proposals'],
-    queryFn: listProposals,
-    select: (data) =>
-      data
-        .filter((p) => p.visibility === 'Public' && p.rfpId === rfpId)
-        .slice(0, 3),
+    queryKey: ['proposals', { rfpId }],
+    queryFn: () => listProposals({ rfpId: rfpId! }),
+    select: (data) => data.slice(0, 3),
     enabled: !!rfpId,
   });
 

--- a/frontend/portal/src/pages/public/RfpListPage.tsx
+++ b/frontend/portal/src/pages/public/RfpListPage.tsx
@@ -16,11 +16,10 @@ export default function RfpListPage() {
     );
   };
 
-  // TODO: replace with server-side filtering once backend supports query parameters
+  // Status visibility is enforced server-side: non-staff callers receive only Published RFPs.
   const { data: rfps, isLoading, isError } = useQuery({
     queryKey: ['rfps'],
     queryFn: listRfps,
-    select: (data) => data.filter((rfp) => rfp.status === 'Published'),
   });
 
   const { data: orgs } = useQuery({

--- a/src/Herit.Api/Controllers/ProposalsController.cs
+++ b/src/Herit.Api/Controllers/ProposalsController.cs
@@ -29,8 +29,8 @@ public class ProposalsController : ControllerBase
 
     [HttpGet]
     [AllowAnonymous]
-    public async Task<IActionResult> List(CancellationToken ct)
-        => Ok(await _mediator.Send(new ListProposalsQuery(), ct));
+    public async Task<IActionResult> List([FromQuery] Guid? rfpId, CancellationToken ct)
+        => Ok(await _mediator.Send(new ListProposalsQuery(rfpId), ct));
 
     [HttpGet("{id:guid}")]
     [AllowAnonymous]

--- a/src/Herit.Api/Services/CurrentUserService.cs
+++ b/src/Herit.Api/Services/CurrentUserService.cs
@@ -22,6 +22,26 @@ public class CurrentUserService : ICurrentUserService
         _mediator = mediator;
     }
 
+    public async Task<User?> GetCurrentUserOrNullAsync(CancellationToken ct = default)
+    {
+        if (_cachedUser is not null)
+            return _cachedUser;
+
+        var claimsPrincipal = _httpContextAccessor.HttpContext?.User;
+        if (claimsPrincipal?.Identity is not { IsAuthenticated: true })
+            return null;
+
+        var externalId = ResolveExternalId(claimsPrincipal);
+        if (externalId is null)
+            return null;
+
+        var user = await _userRepository.GetByExternalIdAsync(externalId, ct);
+        if (user is not null)
+            _cachedUser = user;
+
+        return user;
+    }
+
     public async Task<User> GetCurrentUserAsync(CancellationToken ct = default)
     {
         if (_cachedUser is not null)
@@ -30,12 +50,7 @@ public class CurrentUserService : ICurrentUserService
         var claimsPrincipal = _httpContextAccessor.HttpContext?.User
             ?? throw new UnauthorizedAccessException("No HTTP context available.");
 
-        static string? NonEmpty(string? s) => string.IsNullOrWhiteSpace(s) ? null : s;
-
-        var externalId =
-            NonEmpty(claimsPrincipal.FindFirst("oid")?.Value)
-            ?? NonEmpty(claimsPrincipal.FindFirst("http://schemas.microsoft.com/identity/claims/objectidentifier")?.Value)
-            ?? NonEmpty(claimsPrincipal.FindFirst("sub")?.Value)
+        var externalId = ResolveExternalId(claimsPrincipal)
             ?? throw new UnauthorizedAccessException("Subject claim could not be determined.");
 
         var user = await _userRepository.GetByExternalIdAsync(externalId, ct);
@@ -61,5 +76,14 @@ public class CurrentUserService : ICurrentUserService
 
         _cachedUser = user;
         return _cachedUser;
+    }
+
+    private static string? ResolveExternalId(System.Security.Claims.ClaimsPrincipal claimsPrincipal)
+    {
+        static string? NonEmpty(string? s) => string.IsNullOrWhiteSpace(s) ? null : s;
+
+        return NonEmpty(claimsPrincipal.FindFirst("oid")?.Value)
+            ?? NonEmpty(claimsPrincipal.FindFirst("http://schemas.microsoft.com/identity/claims/objectidentifier")?.Value)
+            ?? NonEmpty(claimsPrincipal.FindFirst("sub")?.Value);
     }
 }

--- a/src/Herit.Application/Authorization/VisibilityPolicy.cs
+++ b/src/Herit.Application/Authorization/VisibilityPolicy.cs
@@ -1,0 +1,69 @@
+using Herit.Domain.Entities;
+using Herit.Domain.Enums;
+
+namespace Herit.Application.Authorization;
+
+/// <summary>
+/// Central authorization rules that decide which records a caller may see on the
+/// public list endpoints. These mirror the visibility and access rules in the PRD (§8)
+/// and the portal user-flow spec, and are enforced server-side so that content is never
+/// delivered to a caller who is not permitted to view it.
+/// </summary>
+public static class VisibilityPolicy
+{
+    /// <summary>
+    /// Government/administrative users (anyone who is not an <see cref="UserRole.Expat"/>)
+    /// have privileged read access across the platform.
+    /// </summary>
+    public static bool IsStaff(User? user)
+        => user is not null && user.Role != UserRole.Expat;
+
+    /// <summary>
+    /// Proposal visibility: Public → everyone (including anonymous); Shared → any
+    /// authenticated user; Private → the owner only. Staff may view all proposals.
+    /// </summary>
+    public static bool CanViewProposal(Proposal proposal, User? user)
+    {
+        if (IsStaff(user))
+            return true;
+
+        return proposal.Visibility switch
+        {
+            ProposalVisibility.Public => true,
+            ProposalVisibility.Shared => user is not null,
+            ProposalVisibility.Private => user is not null && proposal.AuthorId == user.Id,
+            _ => false
+        };
+    }
+
+    /// <summary>
+    /// RFP visibility: only Published RFPs are visible to non-staff callers. Staff may
+    /// view RFPs in any status.
+    /// </summary>
+    public static bool CanViewRfp(Rfp rfp, User? user)
+    {
+        if (IsStaff(user))
+            return true;
+
+        return rfp.Status == RfpStatus.Published;
+    }
+
+    /// <summary>
+    /// EOI visibility: the submitter always sees their own EOI; relevant staff see all
+    /// EOIs; the parent proposal's owner sees Shared EOIs. Private EOIs are otherwise
+    /// visible to the submitter only.
+    /// </summary>
+    public static bool CanViewEoi(Eoi eoi, User? user, Guid proposalOwnerId)
+    {
+        if (user is null)
+            return false;
+
+        if (eoi.SubmittedById == user.Id)
+            return true;
+
+        if (IsStaff(user))
+            return true;
+
+        return eoi.Visibility == EoiVisibility.Shared && proposalOwnerId == user.Id;
+    }
+}

--- a/src/Herit.Application/Features/Cfeoi/Queries/ListCfeois/ListCfeoisQuery.cs
+++ b/src/Herit.Application/Features/Cfeoi/Queries/ListCfeois/ListCfeoisQuery.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Authorization;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
 using MediatR;
@@ -9,12 +10,32 @@ public record ListCfeoisQuery(CfeoiStatus? Status = null, Guid? ProposalId = nul
 public class ListCfeoisQueryHandler : IRequestHandler<ListCfeoisQuery, IEnumerable<Herit.Domain.Entities.Cfeoi>>
 {
     private readonly ICfeoiRepository _cfeoiRepository;
+    private readonly IProposalRepository _proposalRepository;
+    private readonly ICurrentUserService _currentUserService;
 
-    public ListCfeoisQueryHandler(ICfeoiRepository cfeoiRepository)
+    public ListCfeoisQueryHandler(
+        ICfeoiRepository cfeoiRepository,
+        IProposalRepository proposalRepository,
+        ICurrentUserService currentUserService)
     {
         _cfeoiRepository = cfeoiRepository;
+        _proposalRepository = proposalRepository;
+        _currentUserService = currentUserService;
     }
 
-    public Task<IEnumerable<Herit.Domain.Entities.Cfeoi>> Handle(ListCfeoisQuery request, CancellationToken cancellationToken)
-        => _cfeoiRepository.ListAsync(request.Status, request.ProposalId, cancellationToken);
+    public async Task<IEnumerable<Herit.Domain.Entities.Cfeoi>> Handle(ListCfeoisQuery request, CancellationToken cancellationToken)
+    {
+        var user = await _currentUserService.GetCurrentUserOrNullAsync(cancellationToken);
+        var cfeois = await _cfeoiRepository.ListAsync(request.Status, request.ProposalId, cancellationToken);
+
+        // A CFEOI inherits its parent proposal's visibility, so it is only visible when
+        // the caller is permitted to see that proposal.
+        var proposals = await _proposalRepository.ListAsync(cancellationToken);
+        var visibleProposalIds = proposals
+            .Where(p => VisibilityPolicy.CanViewProposal(p, user))
+            .Select(p => p.Id)
+            .ToHashSet();
+
+        return cfeois.Where(c => visibleProposalIds.Contains(c.ProposalId)).ToList();
+    }
 }

--- a/src/Herit.Application/Features/Eoi/Queries/ListEoisByCfeoi/ListEoisByCfeoiQuery.cs
+++ b/src/Herit.Application/Features/Eoi/Queries/ListEoisByCfeoi/ListEoisByCfeoiQuery.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Authorization;
 using Herit.Application.Interfaces;
 using MediatR;
 
@@ -8,12 +9,36 @@ public record ListEoisByCfeoiQuery(Guid CfeoiId) : IRequest<IEnumerable<Herit.Do
 public class ListEoisByCfeoiQueryHandler : IRequestHandler<ListEoisByCfeoiQuery, IEnumerable<Herit.Domain.Entities.Eoi>>
 {
     private readonly IEoiRepository _eoiRepository;
+    private readonly ICfeoiRepository _cfeoiRepository;
+    private readonly IProposalRepository _proposalRepository;
+    private readonly ICurrentUserService _currentUserService;
 
-    public ListEoisByCfeoiQueryHandler(IEoiRepository eoiRepository)
+    public ListEoisByCfeoiQueryHandler(
+        IEoiRepository eoiRepository,
+        ICfeoiRepository cfeoiRepository,
+        IProposalRepository proposalRepository,
+        ICurrentUserService currentUserService)
     {
         _eoiRepository = eoiRepository;
+        _cfeoiRepository = cfeoiRepository;
+        _proposalRepository = proposalRepository;
+        _currentUserService = currentUserService;
     }
 
-    public Task<IEnumerable<Herit.Domain.Entities.Eoi>> Handle(ListEoisByCfeoiQuery request, CancellationToken cancellationToken)
-        => _eoiRepository.ListByCfeoiAsync(request.CfeoiId, cancellationToken);
+    public async Task<IEnumerable<Herit.Domain.Entities.Eoi>> Handle(ListEoisByCfeoiQuery request, CancellationToken cancellationToken)
+    {
+        var user = await _currentUserService.GetCurrentUserOrNullAsync(cancellationToken);
+        var eois = await _eoiRepository.ListByCfeoiAsync(request.CfeoiId, cancellationToken);
+
+        // Resolve the parent proposal's owner so that Shared EOIs are surfaced to them.
+        var cfeoi = await _cfeoiRepository.GetByIdAsync(request.CfeoiId, cancellationToken);
+        var proposalOwnerId = Guid.Empty;
+        if (cfeoi is not null)
+        {
+            var proposal = await _proposalRepository.GetByIdAsync(cfeoi.ProposalId, cancellationToken);
+            proposalOwnerId = proposal?.AuthorId ?? Guid.Empty;
+        }
+
+        return eois.Where(e => VisibilityPolicy.CanViewEoi(e, user, proposalOwnerId)).ToList();
+    }
 }

--- a/src/Herit.Application/Features/Proposal/Queries/ListProposals/ListProposalsQuery.cs
+++ b/src/Herit.Application/Features/Proposal/Queries/ListProposals/ListProposalsQuery.cs
@@ -1,19 +1,32 @@
+using Herit.Application.Authorization;
 using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.Proposal.Queries.ListProposals;
 
-public record ListProposalsQuery() : IRequest<IEnumerable<Herit.Domain.Entities.Proposal>>;
+public record ListProposalsQuery(Guid? RfpId = null) : IRequest<IEnumerable<Herit.Domain.Entities.Proposal>>;
 
 public class ListProposalsQueryHandler : IRequestHandler<ListProposalsQuery, IEnumerable<Herit.Domain.Entities.Proposal>>
 {
     private readonly IProposalRepository _proposalRepository;
+    private readonly ICurrentUserService _currentUserService;
 
-    public ListProposalsQueryHandler(IProposalRepository proposalRepository)
+    public ListProposalsQueryHandler(IProposalRepository proposalRepository, ICurrentUserService currentUserService)
     {
         _proposalRepository = proposalRepository;
+        _currentUserService = currentUserService;
     }
 
-    public Task<IEnumerable<Herit.Domain.Entities.Proposal>> Handle(ListProposalsQuery request, CancellationToken cancellationToken)
-        => _proposalRepository.ListAsync(cancellationToken);
+    public async Task<IEnumerable<Herit.Domain.Entities.Proposal>> Handle(ListProposalsQuery request, CancellationToken cancellationToken)
+    {
+        var user = await _currentUserService.GetCurrentUserOrNullAsync(cancellationToken);
+        var proposals = await _proposalRepository.ListAsync(cancellationToken);
+
+        var visible = proposals.Where(p => VisibilityPolicy.CanViewProposal(p, user));
+
+        if (request.RfpId is not null)
+            visible = visible.Where(p => p.RfpId == request.RfpId);
+
+        return visible.ToList();
+    }
 }

--- a/src/Herit.Application/Features/Rfp/Queries/ListRfps/ListRfpsQuery.cs
+++ b/src/Herit.Application/Features/Rfp/Queries/ListRfps/ListRfpsQuery.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Authorization;
 using Herit.Application.Interfaces;
 using MediatR;
 
@@ -8,12 +9,19 @@ public record ListRfpsQuery() : IRequest<IEnumerable<Herit.Domain.Entities.Rfp>>
 public class ListRfpsQueryHandler : IRequestHandler<ListRfpsQuery, IEnumerable<Herit.Domain.Entities.Rfp>>
 {
     private readonly IRfpRepository _repository;
+    private readonly ICurrentUserService _currentUserService;
 
-    public ListRfpsQueryHandler(IRfpRepository repository)
+    public ListRfpsQueryHandler(IRfpRepository repository, ICurrentUserService currentUserService)
     {
         _repository = repository;
+        _currentUserService = currentUserService;
     }
 
-    public Task<IEnumerable<Herit.Domain.Entities.Rfp>> Handle(ListRfpsQuery request, CancellationToken cancellationToken)
-        => _repository.ListAsync(cancellationToken);
+    public async Task<IEnumerable<Herit.Domain.Entities.Rfp>> Handle(ListRfpsQuery request, CancellationToken cancellationToken)
+    {
+        var user = await _currentUserService.GetCurrentUserOrNullAsync(cancellationToken);
+        var rfps = await _repository.ListAsync(cancellationToken);
+
+        return rfps.Where(r => VisibilityPolicy.CanViewRfp(r, user)).ToList();
+    }
 }

--- a/src/Herit.Application/Interfaces/ICurrentUserService.cs
+++ b/src/Herit.Application/Interfaces/ICurrentUserService.cs
@@ -5,4 +5,11 @@ namespace Herit.Application.Interfaces;
 public interface ICurrentUserService
 {
     Task<User> GetCurrentUserAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Resolves the caller's <see cref="User"/> record without side effects, returning
+    /// <c>null</c> when the request is unauthenticated or no matching user exists.
+    /// Use this on read paths (e.g. list queries) where anonymous access is permitted.
+    /// </summary>
+    Task<User?> GetCurrentUserOrNullAsync(CancellationToken ct = default);
 }

--- a/tests/Herit.Application.Tests/Features/Cfeoi/Queries/ListCfeois/ListCfeoisQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Cfeoi/Queries/ListCfeois/ListCfeoisQueryHandlerTests.cs
@@ -1,31 +1,97 @@
 using Herit.Application.Features.Cfeoi.Queries.ListCfeois;
 using Herit.Application.Interfaces;
+using Herit.Domain.Entities;
+using UserEntity = Herit.Domain.Entities.User;
 using Herit.Domain.Enums;
 using NSubstitute;
 using CfeoiEntity = Herit.Domain.Entities.Cfeoi;
+using ProposalEntity = Herit.Domain.Entities.Proposal;
 
 namespace Herit.Application.Tests.Features.Cfeoi.Queries.ListCfeois;
 
 public class ListCfeoisQueryHandlerTests
 {
     private readonly ICfeoiRepository _cfeoiRepository = Substitute.For<ICfeoiRepository>();
+    private readonly IProposalRepository _proposalRepository = Substitute.For<IProposalRepository>();
+    private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
     private readonly ListCfeoisQueryHandler _handler;
+
+    private readonly Guid _ownerId = Guid.NewGuid();
+    private readonly ProposalEntity _publicProposal;
+    private readonly ProposalEntity _sharedProposal;
+    private readonly ProposalEntity _privateProposal;
+    private readonly CfeoiEntity _underPublic;
+    private readonly CfeoiEntity _underShared;
+    private readonly CfeoiEntity _underPrivate;
 
     public ListCfeoisQueryHandlerTests()
     {
-        _handler = new ListCfeoisQueryHandler(_cfeoiRepository);
+        _handler = new ListCfeoisQueryHandler(_cfeoiRepository, _proposalRepository, _currentUserService);
+
+        _publicProposal = MakeProposal(ProposalVisibility.Public, _ownerId);
+        _sharedProposal = MakeProposal(ProposalVisibility.Shared, _ownerId);
+        _privateProposal = MakeProposal(ProposalVisibility.Private, _ownerId);
+
+        _underPublic = MakeCfeoi(_publicProposal.Id);
+        _underShared = MakeCfeoi(_sharedProposal.Id);
+        _underPrivate = MakeCfeoi(_privateProposal.Id);
+
+        _proposalRepository.ListAsync(Arg.Any<CancellationToken>())
+            .Returns(new[] { _publicProposal, _sharedProposal, _privateProposal });
+        _cfeoiRepository.ListAsync(null, null, Arg.Any<CancellationToken>())
+            .Returns(new[] { _underPublic, _underShared, _underPrivate });
+    }
+
+    private static ProposalEntity MakeProposal(ProposalVisibility visibility, Guid authorId)
+    {
+        var proposal = ProposalEntity.Create(Guid.NewGuid(), "Title", "Short", authorId, Guid.NewGuid(), "Long");
+        proposal.SetVisibility(visibility);
+        return proposal;
+    }
+
+    private static CfeoiEntity MakeCfeoi(Guid proposalId)
+        => CfeoiEntity.Create(Guid.NewGuid(), "CFEOI", "Description", CfeoiResourceType.Human, proposalId);
+
+    private static UserEntity MakeUser(Guid id, UserRole role)
+        => UserEntity.Create(id, $"ext-{id}", "user@example.com", "User", role);
+
+    private void CurrentUser(UserEntity? user)
+        => _currentUserService.GetCurrentUserOrNullAsync(Arg.Any<CancellationToken>()).Returns(user);
+
+    [Fact]
+    public async Task Handle_Anonymous_ReturnsOnlyCfeoisUnderPublicProposals()
+    {
+        CurrentUser(null);
+
+        var result = await _handler.Handle(new ListCfeoisQuery(), CancellationToken.None);
+
+        Assert.Equal(new[] { _underPublic.Id }, result.Select(c => c.Id));
     }
 
     [Fact]
-    public async Task Handle_NoFilters_ReturnsAllCfeois()
+    public async Task Handle_NonOwnerExpat_ReturnsCfeoisUnderPublicAndShared()
     {
-        var cfeois = new[]
-        {
-            CfeoiEntity.Create(Guid.NewGuid(), "Title 1", "Description 1", CfeoiResourceType.Human, Guid.NewGuid()),
-            CfeoiEntity.Create(Guid.NewGuid(), "Title 2", "Description 2", CfeoiResourceType.NonHuman, Guid.NewGuid()),
-            CfeoiEntity.Create(Guid.NewGuid(), "Title 3", "Description 3", CfeoiResourceType.Human, Guid.NewGuid())
-        };
-        _cfeoiRepository.ListAsync(null, null, Arg.Any<CancellationToken>()).Returns(cfeois);
+        CurrentUser(MakeUser(Guid.NewGuid(), UserRole.Expat));
+
+        var result = await _handler.Handle(new ListCfeoisQuery(), CancellationToken.None);
+
+        Assert.Equal(new[] { _underPublic.Id, _underShared.Id }, result.Select(c => c.Id));
+    }
+
+    [Fact]
+    public async Task Handle_ProposalOwner_ReturnsCfeoiUnderOwnPrivateProposal()
+    {
+        CurrentUser(MakeUser(_ownerId, UserRole.Expat));
+
+        var result = await _handler.Handle(new ListCfeoisQuery(), CancellationToken.None);
+
+        Assert.Contains(result, c => c.Id == _underPrivate.Id);
+    }
+
+    [Fact]
+    public async Task Handle_Staff_ReturnsAllCfeois()
+    {
+        CurrentUser(MakeUser(Guid.NewGuid(), UserRole.Staff));
 
         var result = await _handler.Handle(new ListCfeoisQuery(), CancellationToken.None);
 
@@ -35,12 +101,9 @@ public class ListCfeoisQueryHandlerTests
     [Fact]
     public async Task Handle_FilterByStatus_PassesStatusToRepository()
     {
-        var proposalId = Guid.NewGuid();
-        var cfeois = new[]
-        {
-            CfeoiEntity.Create(Guid.NewGuid(), "Open CFEOI", "Description", CfeoiResourceType.Human, proposalId)
-        };
-        _cfeoiRepository.ListAsync(CfeoiStatus.Open, null, Arg.Any<CancellationToken>()).Returns(cfeois);
+        _cfeoiRepository.ListAsync(CfeoiStatus.Open, null, Arg.Any<CancellationToken>())
+            .Returns(new[] { _underPublic });
+        CurrentUser(MakeUser(Guid.NewGuid(), UserRole.Staff));
 
         var result = await _handler.Handle(new ListCfeoisQuery(Status: CfeoiStatus.Open), CancellationToken.None);
 
@@ -51,24 +114,21 @@ public class ListCfeoisQueryHandlerTests
     [Fact]
     public async Task Handle_FilterByProposalId_PassesProposalIdToRepository()
     {
-        var proposalId = Guid.NewGuid();
-        var cfeois = new[]
-        {
-            CfeoiEntity.Create(Guid.NewGuid(), "Title A", "Description", CfeoiResourceType.Human, proposalId),
-            CfeoiEntity.Create(Guid.NewGuid(), "Title B", "Description", CfeoiResourceType.NonHuman, proposalId)
-        };
-        _cfeoiRepository.ListAsync(null, proposalId, Arg.Any<CancellationToken>()).Returns(cfeois);
+        _cfeoiRepository.ListAsync(null, _publicProposal.Id, Arg.Any<CancellationToken>())
+            .Returns(new[] { _underPublic });
+        CurrentUser(MakeUser(Guid.NewGuid(), UserRole.Staff));
 
-        var result = await _handler.Handle(new ListCfeoisQuery(ProposalId: proposalId), CancellationToken.None);
+        var result = await _handler.Handle(new ListCfeoisQuery(ProposalId: _publicProposal.Id), CancellationToken.None);
 
-        Assert.Equal(2, result.Count());
-        await _cfeoiRepository.Received(1).ListAsync(null, proposalId, Arg.Any<CancellationToken>());
+        Assert.Single(result);
+        await _cfeoiRepository.Received(1).ListAsync(null, _publicProposal.Id, Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task Handle_EmptyList_ReturnsEmptyEnumerable()
     {
         _cfeoiRepository.ListAsync(null, null, Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<CfeoiEntity>());
+        CurrentUser(MakeUser(Guid.NewGuid(), UserRole.Staff));
 
         var result = await _handler.Handle(new ListCfeoisQuery(), CancellationToken.None);
 

--- a/tests/Herit.Application.Tests/Features/Eoi/Queries/ListEoisByCfeoiQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Eoi/Queries/ListEoisByCfeoiQueryHandlerTests.cs
@@ -1,44 +1,114 @@
 using Herit.Application.Features.Eoi.Queries.ListEoisByCfeoi;
 using Herit.Application.Interfaces;
+using Herit.Domain.Entities;
+using UserEntity = Herit.Domain.Entities.User;
+using Herit.Domain.Enums;
 using NSubstitute;
+using CfeoiEntity = Herit.Domain.Entities.Cfeoi;
 using EoiEntity = Herit.Domain.Entities.Eoi;
+using ProposalEntity = Herit.Domain.Entities.Proposal;
 
 namespace Herit.Application.Tests.Features.Eoi.Queries;
 
 public class ListEoisByCfeoiQueryHandlerTests
 {
     private readonly IEoiRepository _eoiRepository = Substitute.For<IEoiRepository>();
+    private readonly ICfeoiRepository _cfeoiRepository = Substitute.For<ICfeoiRepository>();
+    private readonly IProposalRepository _proposalRepository = Substitute.For<IProposalRepository>();
+    private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
     private readonly ListEoisByCfeoiQueryHandler _handler;
+
+    private readonly Guid _cfeoiId = Guid.NewGuid();
+    private readonly Guid _proposalOwnerId = Guid.NewGuid();
+    private readonly Guid _submitterAId = Guid.NewGuid();
+    private readonly Guid _submitterBId = Guid.NewGuid();
+
+    private readonly EoiEntity _privateByA;
+    private readonly EoiEntity _sharedByB;
+    private readonly EoiEntity _privateByB;
 
     public ListEoisByCfeoiQueryHandlerTests()
     {
-        _handler = new ListEoisByCfeoiQueryHandler(_eoiRepository);
+        _handler = new ListEoisByCfeoiQueryHandler(
+            _eoiRepository, _cfeoiRepository, _proposalRepository, _currentUserService);
+
+        var proposal = ProposalEntity.Create(Guid.NewGuid(), "Title", "Short", _proposalOwnerId, Guid.NewGuid(), "Long");
+        var cfeoi = CfeoiEntity.Create(_cfeoiId, "CFEOI", "Description", CfeoiResourceType.Human, proposal.Id);
+
+        _privateByA = MakeEoi(_submitterAId, EoiVisibility.Private);
+        _sharedByB = MakeEoi(_submitterBId, EoiVisibility.Shared);
+        _privateByB = MakeEoi(_submitterBId, EoiVisibility.Private);
+
+        _cfeoiRepository.GetByIdAsync(_cfeoiId, Arg.Any<CancellationToken>()).Returns(cfeoi);
+        _proposalRepository.GetByIdAsync(proposal.Id, Arg.Any<CancellationToken>()).Returns(proposal);
+        _eoiRepository.ListByCfeoiAsync(_cfeoiId, Arg.Any<CancellationToken>())
+            .Returns(new[] { _privateByA, _sharedByB, _privateByB });
     }
 
-    [Fact]
-    public async Task Handle_NonEmptyList_ReturnsAllEois()
+    private EoiEntity MakeEoi(Guid submittedById, EoiVisibility visibility)
     {
-        var cfeoiId = Guid.NewGuid();
-        var eois = new[]
-        {
-            EoiEntity.Create(Guid.NewGuid(), Guid.NewGuid(), "Message 1", cfeoiId),
-            EoiEntity.Create(Guid.NewGuid(), Guid.NewGuid(), "Message 2", cfeoiId)
-        };
-        _eoiRepository.ListByCfeoiAsync(cfeoiId, Arg.Any<CancellationToken>()).Returns(eois);
-
-        var result = await _handler.Handle(new ListEoisByCfeoiQuery(cfeoiId), CancellationToken.None);
-
-        Assert.Equal(2, result.Count());
+        var eoi = EoiEntity.Create(Guid.NewGuid(), submittedById, "Message", _cfeoiId);
+        if (visibility == EoiVisibility.Shared)
+            eoi.SetVisibility(EoiVisibility.Shared);
+        return eoi;
     }
 
-    [Fact]
-    public async Task Handle_EmptyList_ReturnsEmptyEnumerable()
-    {
-        var cfeoiId = Guid.NewGuid();
-        _eoiRepository.ListByCfeoiAsync(cfeoiId, Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<EoiEntity>());
+    private static UserEntity MakeUser(Guid id, UserRole role)
+        => UserEntity.Create(id, $"ext-{id}", "user@example.com", "User", role);
 
-        var result = await _handler.Handle(new ListEoisByCfeoiQuery(cfeoiId), CancellationToken.None);
+    private void CurrentUser(UserEntity? user)
+        => _currentUserService.GetCurrentUserOrNullAsync(Arg.Any<CancellationToken>()).Returns(user);
+
+    [Fact]
+    public async Task Handle_Anonymous_ReturnsNothing()
+    {
+        CurrentUser(null);
+
+        var result = await _handler.Handle(new ListEoisByCfeoiQuery(_cfeoiId), CancellationToken.None);
 
         Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task Handle_Submitter_ReturnsOnlyOwnEois()
+    {
+        CurrentUser(MakeUser(_submitterAId, UserRole.Expat));
+
+        var result = await _handler.Handle(new ListEoisByCfeoiQuery(_cfeoiId), CancellationToken.None);
+
+        Assert.Equal(new[] { _privateByA.Id }, result.Select(e => e.Id));
+    }
+
+    [Fact]
+    public async Task Handle_ProposalOwner_ReturnsSharedEoisOnly()
+    {
+        CurrentUser(MakeUser(_proposalOwnerId, UserRole.Expat));
+
+        var result = await _handler.Handle(new ListEoisByCfeoiQuery(_cfeoiId), CancellationToken.None);
+
+        Assert.Equal(new[] { _sharedByB.Id }, result.Select(e => e.Id));
+    }
+
+    [Fact]
+    public async Task Handle_UnrelatedExpat_ReturnsNothing()
+    {
+        CurrentUser(MakeUser(Guid.NewGuid(), UserRole.Expat));
+
+        var result = await _handler.Handle(new ListEoisByCfeoiQuery(_cfeoiId), CancellationToken.None);
+
+        Assert.Empty(result);
+    }
+
+    [Theory]
+    [InlineData(UserRole.Staff)]
+    [InlineData(UserRole.OrganisationAdmin)]
+    [InlineData(UserRole.SuperAdmin)]
+    public async Task Handle_Staff_ReturnsAllEois(UserRole role)
+    {
+        CurrentUser(MakeUser(Guid.NewGuid(), role));
+
+        var result = await _handler.Handle(new ListEoisByCfeoiQuery(_cfeoiId), CancellationToken.None);
+
+        Assert.Equal(3, result.Count());
     }
 }

--- a/tests/Herit.Application.Tests/Features/Proposal/Queries/ListProposalsQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Proposal/Queries/ListProposalsQueryHandlerTests.cs
@@ -1,5 +1,8 @@
 using Herit.Application.Features.Proposal.Queries.ListProposals;
 using Herit.Application.Interfaces;
+using Herit.Domain.Entities;
+using UserEntity = Herit.Domain.Entities.User;
+using Herit.Domain.Enums;
 using NSubstitute;
 using ProposalEntity = Herit.Domain.Entities.Proposal;
 
@@ -8,35 +11,109 @@ namespace Herit.Application.Tests.Features.Proposal.Queries;
 public class ListProposalsQueryHandlerTests
 {
     private readonly IProposalRepository _proposalRepository = Substitute.For<IProposalRepository>();
+    private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
     private readonly ListProposalsQueryHandler _handler;
+
+    private readonly Guid _ownerId = Guid.NewGuid();
+    private readonly ProposalEntity _public;
+    private readonly ProposalEntity _shared;
+    private readonly ProposalEntity _privateOwned;
 
     public ListProposalsQueryHandlerTests()
     {
-        _handler = new ListProposalsQueryHandler(_proposalRepository);
+        _handler = new ListProposalsQueryHandler(_proposalRepository, _currentUserService);
+
+        _public = MakeProposal(ProposalVisibility.Public, _ownerId);
+        _shared = MakeProposal(ProposalVisibility.Shared, _ownerId);
+        _privateOwned = MakeProposal(ProposalVisibility.Private, _ownerId);
+
+        _proposalRepository.ListAsync(Arg.Any<CancellationToken>())
+            .Returns(new[] { _public, _shared, _privateOwned });
     }
 
-    [Fact]
-    public async Task Handle_NonEmptyList_ReturnsAllProposals()
+    private static ProposalEntity MakeProposal(ProposalVisibility visibility, Guid authorId)
     {
-        var proposals = new[]
-        {
-            ProposalEntity.Create(Guid.NewGuid(), "Title 1", "Short 1", Guid.NewGuid(), Guid.NewGuid(), "Long 1"),
-            ProposalEntity.Create(Guid.NewGuid(), "Title 2", "Short 2", Guid.NewGuid(), Guid.NewGuid(), "Long 2")
-        };
-        _proposalRepository.ListAsync(Arg.Any<CancellationToken>()).Returns(proposals);
+        var proposal = ProposalEntity.Create(Guid.NewGuid(), "Title", "Short", authorId, Guid.NewGuid(), "Long");
+        proposal.SetVisibility(visibility);
+        return proposal;
+    }
+
+    private static UserEntity MakeUser(Guid id, UserRole role)
+        => UserEntity.Create(id, $"ext-{id}", "user@example.com", "User", role);
+
+    private void CurrentUser(UserEntity? user)
+        => _currentUserService.GetCurrentUserOrNullAsync(Arg.Any<CancellationToken>()).Returns(user);
+
+    [Fact]
+    public async Task Handle_Anonymous_ReturnsOnlyPublic()
+    {
+        CurrentUser(null);
 
         var result = await _handler.Handle(new ListProposalsQuery(), CancellationToken.None);
 
-        Assert.Equal(2, result.Count());
+        Assert.Equal(new[] { _public.Id }, result.Select(p => p.Id));
     }
 
     [Fact]
-    public async Task Handle_EmptyList_ReturnsEmptyEnumerable()
+    public async Task Handle_AuthenticatedNonOwnerExpat_ReturnsPublicAndShared()
     {
-        _proposalRepository.ListAsync(Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<ProposalEntity>());
+        CurrentUser(MakeUser(Guid.NewGuid(), UserRole.Expat));
 
         var result = await _handler.Handle(new ListProposalsQuery(), CancellationToken.None);
 
-        Assert.Empty(result);
+        Assert.Equal(new[] { _public.Id, _shared.Id }, result.Select(p => p.Id));
+    }
+
+    [Fact]
+    public async Task Handle_OwnerExpat_ReturnsPublicSharedAndOwnPrivate()
+    {
+        CurrentUser(MakeUser(_ownerId, UserRole.Expat));
+
+        var result = await _handler.Handle(new ListProposalsQuery(), CancellationToken.None);
+
+        Assert.Equal(
+            new[] { _public.Id, _shared.Id, _privateOwned.Id },
+            result.Select(p => p.Id));
+    }
+
+    [Fact]
+    public async Task Handle_NonOwnerExpat_DoesNotReturnOthersPrivate()
+    {
+        CurrentUser(MakeUser(Guid.NewGuid(), UserRole.Expat));
+
+        var result = await _handler.Handle(new ListProposalsQuery(), CancellationToken.None);
+
+        Assert.DoesNotContain(result, p => p.Id == _privateOwned.Id);
+    }
+
+    [Theory]
+    [InlineData(UserRole.Staff)]
+    [InlineData(UserRole.OrganisationAdmin)]
+    [InlineData(UserRole.SuperAdmin)]
+    public async Task Handle_Staff_ReturnsAllRegardlessOfVisibility(UserRole role)
+    {
+        CurrentUser(MakeUser(Guid.NewGuid(), role));
+
+        var result = await _handler.Handle(new ListProposalsQuery(), CancellationToken.None);
+
+        Assert.Equal(3, result.Count());
+    }
+
+    [Fact]
+    public async Task Handle_WithRfpIdFilter_AppliesFilterOnTopOfAuthorization()
+    {
+        var rfpId = Guid.NewGuid();
+        var publicForRfp = ProposalEntity.Create(Guid.NewGuid(), "T", "S", _ownerId, Guid.NewGuid(), "L", rfpId);
+        publicForRfp.SetVisibility(ProposalVisibility.Public);
+        var privateForRfp = ProposalEntity.Create(Guid.NewGuid(), "T", "S", _ownerId, Guid.NewGuid(), "L", rfpId);
+        // stays Private (default)
+
+        _proposalRepository.ListAsync(Arg.Any<CancellationToken>())
+            .Returns(new[] { _public, publicForRfp, privateForRfp });
+        CurrentUser(null);
+
+        var result = await _handler.Handle(new ListProposalsQuery(rfpId), CancellationToken.None);
+
+        Assert.Equal(new[] { publicForRfp.Id }, result.Select(p => p.Id));
     }
 }

--- a/tests/Herit.Application.Tests/Features/Rfp/Queries/ListRfpsQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Rfp/Queries/ListRfpsQueryHandlerTests.cs
@@ -1,5 +1,8 @@
 using Herit.Application.Features.Rfp.Queries.ListRfps;
 using Herit.Application.Interfaces;
+using Herit.Domain.Entities;
+using UserEntity = Herit.Domain.Entities.User;
+using Herit.Domain.Enums;
 using NSubstitute;
 using RfpEntity = Herit.Domain.Entities.Rfp;
 
@@ -8,36 +11,82 @@ namespace Herit.Application.Tests.Features.Rfp.Queries;
 public class ListRfpsQueryHandlerTests
 {
     private readonly IRfpRepository _repository = Substitute.For<IRfpRepository>();
+    private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
     private readonly ListRfpsQueryHandler _handler;
+
+    private readonly RfpEntity _draft;
+    private readonly RfpEntity _approved;
+    private readonly RfpEntity _published;
 
     public ListRfpsQueryHandlerTests()
     {
-        _handler = new ListRfpsQueryHandler(_repository);
+        _handler = new ListRfpsQueryHandler(_repository, _currentUserService);
+
+        _draft = MakeRfp(RfpStatus.Draft);
+        _approved = MakeRfp(RfpStatus.Approved);
+        _published = MakeRfp(RfpStatus.Published);
+
+        _repository.ListAsync(Arg.Any<CancellationToken>())
+            .Returns(new[] { _draft, _approved, _published });
     }
 
-    [Fact]
-    public async Task Handle_WhenRepositoryReturnsItems_ReturnsAllItems()
+    private static RfpEntity MakeRfp(RfpStatus status)
     {
-        var rfps = new[]
-        {
-            RfpEntity.Create(Guid.NewGuid(), "RFP A", "Short A", Guid.NewGuid(), Guid.NewGuid(), "Long A"),
-            RfpEntity.Create(Guid.NewGuid(), "RFP B", "Short B", Guid.NewGuid(), Guid.NewGuid(), "Long B"),
-        };
-        _repository.ListAsync(Arg.Any<CancellationToken>()).Returns((IEnumerable<RfpEntity>)rfps);
+        var rfp = RfpEntity.Create(Guid.NewGuid(), "RFP", "Short", Guid.NewGuid(), Guid.NewGuid(), "Long");
+        if (status is RfpStatus.Approved or RfpStatus.Published)
+            rfp.TransitionStatus(RfpStatus.Approved);
+        if (status is RfpStatus.Published)
+            rfp.TransitionStatus(RfpStatus.Published);
+        return rfp;
+    }
+
+    private static UserEntity MakeUser(UserRole role)
+        => UserEntity.Create(Guid.NewGuid(), $"ext-{Guid.NewGuid()}", "user@example.com", "User", role);
+
+    private void CurrentUser(UserEntity? user)
+        => _currentUserService.GetCurrentUserOrNullAsync(Arg.Any<CancellationToken>()).Returns(user);
+
+    [Fact]
+    public async Task Handle_Anonymous_ReturnsOnlyPublished()
+    {
+        CurrentUser(null);
 
         var result = await _handler.Handle(new ListRfpsQuery(), CancellationToken.None);
 
-        Assert.Equal(2, result.Count());
+        Assert.Equal(new[] { _published.Id }, result.Select(r => r.Id));
     }
 
     [Fact]
-    public async Task Handle_WhenRepositoryReturnsEmpty_ReturnsEmptyCollection()
+    public async Task Handle_Expat_ReturnsOnlyPublished()
+    {
+        CurrentUser(MakeUser(UserRole.Expat));
+
+        var result = await _handler.Handle(new ListRfpsQuery(), CancellationToken.None);
+
+        Assert.Equal(new[] { _published.Id }, result.Select(r => r.Id));
+    }
+
+    [Theory]
+    [InlineData(UserRole.Staff)]
+    [InlineData(UserRole.OrganisationAdmin)]
+    [InlineData(UserRole.SuperAdmin)]
+    public async Task Handle_Staff_ReturnsAllStatuses(UserRole role)
+    {
+        CurrentUser(MakeUser(role));
+
+        var result = await _handler.Handle(new ListRfpsQuery(), CancellationToken.None);
+
+        Assert.Equal(3, result.Count());
+    }
+
+    [Fact]
+    public async Task Handle_EmptyList_ReturnsEmptyCollection()
     {
         _repository.ListAsync(Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<RfpEntity>());
+        CurrentUser(MakeUser(UserRole.Staff));
 
         var result = await _handler.Handle(new ListRfpsQuery(), CancellationToken.None);
 
-        Assert.NotNull(result);
         Assert.Empty(result);
     }
 }


### PR DESCRIPTION
## Description

The public list endpoints — `GET /api/v1/Proposals`, `GET /api/v1/Rfps`, `GET /api/v1/Cfeoi`, and `GET /api/v1/Eoi?cfeoiId=` — previously returned every record regardless of visibility or status, leaving the frontend to hide unauthorized content client-side. That is a data-exposure problem: Private/Shared proposals (and the CFEOIs that inherit their visibility) were delivered to unauthenticated browsers and merely hidden by the UI.

This PR moves the enforcement server-side, into the list query handlers.

### Backend
- New `VisibilityPolicy` (in `Herit.Application/Authorization`) centralises the rules from PRD §8:
  - **Proposals** — Public → everyone incl. anonymous; Shared → any authenticated user; Private → owner only; staff see all.
  - **RFPs** — only `Published` for non-staff callers; staff see all statuses.
  - **CFEOIs** — inherit the parent proposal's visibility.
  - **EOIs by CFEOI** — submitter always; relevant staff always; the parent proposal's owner for `Shared` EOIs.
- Added `ICurrentUserService.GetCurrentUserOrNullAsync` — a non-mutating resolver that returns `null` for anonymous callers (unlike `GetCurrentUserAsync`, which throws and auto-registers), suitable for read paths.
- Added an optional `rfpId` filter query parameter to the proposals list (convenience filtering on top of, never instead of, authorization).

### Frontend
- Removed the now-redundant client-side visibility/status filtering from the RFP list, proposal list, CFEOI directory, and detail pages; pass `status` / `proposalId` / `rfpId` query params instead. UI filters (tabs, search) stay.

### Docs
- Removed the interim client-side-filtering notes from `user-flows-high-level.md` and updated the flow3d/3e task notes.

## Linked Issue

Closes #266

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- Added an authorization-matrix test suite for all four handlers covering anonymous / authenticated non-owner / owner / staff across each visibility (and RFP status) value.
- `dotnet build` + `dotnet test` (Release): 255 tests pass.
- Frontend `npm run build` (tsc + vite) and `npm test` pass.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [x] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)