### PR TITLE
Add Playwright E2E suite covering the full portal journey and the visibility matrix

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -54,9 +54,66 @@ jobs:
         run: npm test -- --run
         working-directory: frontend/portal
 
+  e2e:
+    runs-on: ubuntu-latest
+    services:
+      mssql:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        env:
+          ACCEPT_EULA: 'Y'
+          MSSQL_SA_PASSWORD: 'HeritE2e!Passw0rd'
+        ports:
+          - 14330:1433
+        options: >-
+          --health-cmd "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'HeritE2e!Passw0rd' -C -Q 'SELECT 1' || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 12
+          --health-start-period 20s
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.x'
+
+      - name: Build API
+        run: dotnet build src/Herit.Api
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: frontend/portal/package-lock.json
+
+      - name: Install portal dependencies
+        run: npm ci
+        working-directory: frontend/portal
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+        working-directory: frontend/portal
+
+      - name: Run E2E suite
+        run: npm run e2e
+        working-directory: frontend/portal
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            frontend/portal/e2e/.report
+            frontend/portal/e2e/.results
+          retention-days: 7
+
   cd:
     runs-on: ubuntu-latest
-    needs: ci
+    needs: [ci, e2e]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     env:
       AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,11 @@ frontend/**/node_modules/
 frontend/**/.env*.local
 frontend/**/dist/
 
+# Playwright E2E artifacts (per-run state, traces, reports)
+frontend/portal/e2e/.state/
+frontend/portal/e2e/.results/
+frontend/portal/e2e/.report/
+
 # Claude Code task/design working files (kept local, not tracked)
 docs/frontend/portal/designs/flow3c-implementation-tasks.md
 docs/frontend/portal/designs/flow3c-review-tasks.md

--- a/docs/frontend/portal/e2e-testing.md
+++ b/docs/frontend/portal/e2e-testing.md
@@ -1,0 +1,109 @@
+# Portal E2E testing (Playwright)
+
+The Playwright suite in `frontend/portal/e2e/` exercises the full expat-portal journey
+against the real stack — API, SQL Server, and the Vite-served SPA — covering the seams
+between flows 1, 2, and 3a–3e that unit tests cannot reach.
+
+## What is covered
+
+| Spec | Scenario |
+|---|---|
+| `full-loop.spec.ts` | The core journey: first-time sign-in (JIT registration) → create proposal → Resourcing → publish CFEOI → contributor B submits & shares an EOI → owner approves it → CFEOI closed → proposal submitted → withdrawn (terminal). |
+| `visibility-matrix.spec.ts` | Server-side visibility rules for Private/Shared/Public proposals across anonymous / non-owner / owner callers, CFEOI directory inheritance, and Private→Shared EOI inbox behaviour. Asserts on both UI state and API responses. |
+| `seams.spec.ts` | Already-submitted CTA swap (and its return after withdrawal), Closed-CFEOI behaviour for contributor vs owner, per-status Withdraw/Delete labels with the checkbox-gated modal, and auth/ownership guards. |
+| `unauthenticated.spec.ts` | Flow 1: RFP and public proposal/CFEOI browsing with no session, no leakage of unpublished RFPs, Express Interest prompting sign-in. |
+
+## Authentication strategy
+
+Production auth (MSAL/Entra External ID with Google federation) cannot be driven
+headlessly in CI, so E2E runs swap **both ends of the token exchange** for a test-only
+equivalent while leaving everything in between — axios interceptor, JIT registration,
+role resolution, visibility policies — untouched:
+
+- **API** (`src/Herit.Api/Authentication/TestAuthentication.cs`): when
+  `TestAuth:Enabled` is set **and the environment is not Production**, an additional
+  JWT bearer scheme accepts HS256 tokens signed with the checked-in key from
+  `appsettings.E2E.json`. A policy scheme routes tokens by issuer, so the regular
+  Entra scheme stays registered and untouched. The same flag swaps
+  `EntraExternalIdIdentityProviderService` (Microsoft Graph) for a deterministic
+  local fake, so the super-admin seeder and staff-creation endpoints work offline
+  (`externalId = "e2e-" + email`).
+- **SPA** (`src/auth/testAuth.ts`): the `e2e` Vite mode (`.env.e2e`,
+  `VITE_E2E_AUTH=true`) replaces `PublicClientApplication` with a fake that reads a
+  pre-minted token from localStorage (`herit.e2e.auth`, written via Playwright
+  `storageState`). `loginRedirect()` consumes a staged identity
+  (`herit.e2e.pendingAuth`) and reloads, simulating the redirect round-trip so tests
+  can drive the sign-in UI itself.
+- **Tokens** are minted in-process by the test harness (`e2e/support/tokens.ts`,
+  using `jose`) — no test-token endpoint is added to the API.
+
+**Not reachable in production:** `TestAuthentication.IsEnabled` hard-fails in the
+Production environment regardless of configuration, no shipped config sets the flag,
+and production SPA builds statically eliminate the stub (verified: `herit.e2e` does
+not appear in the default-mode bundle). The signing key only ever guards throwaway
+E2E identities in a disposable database.
+
+Three browser identities run per suite: an anonymous context, expat **user A**
+(owner; plus a never-registered **A1** for the JIT scenario), and expat **user B**
+(contributor). The **super admin** is API-only — it seeds via the CLI and bootstraps
+data through request contexts, never a browser session.
+
+## Test data lifecycle
+
+`e2e/global.setup.ts` builds the baseline through the same paths production uses
+(never direct DB writes), in dependency order:
+
+1. Super admin via the existing CLI seeder (`dotnet run --project src/Herit.Api --
+   --seed-super-admin …`) — idempotent.
+2. Organisation hierarchy (root ministry + child agency) via `OrganisationController`
+   as the super admin.
+3. A staff user (Graph replaced by the local fake) and a **Published** RFP.
+4. Expat users A and B, JIT-registered via `GET /api/v1/Users/me` with their test
+   tokens, then terms-accepted via `PATCH /api/v1/Users/me/profile`.
+
+Every record's title carries a per-run `runId`, so runs never depend on data left by
+previous runs. `e2e/global.teardown.ts` deletes what the API allows (EOIs via
+withdraw, deletable proposals, the RFP, staff user, organisations) and logs what it
+leaves behind (CFEOIs and withdrawn proposals have no delete path by design).
+
+## Running locally
+
+1. Start a disposable SQL Server (once):
+
+   ```bash
+   docker run -d --name herit-e2e-sql -e ACCEPT_EULA=Y \
+     -e MSSQL_SA_PASSWORD='HeritE2e!Passw0rd' -p 14330:1433 \
+     --platform linux/amd64 mcr.microsoft.com/mssql/server:2022-latest
+   ```
+
+2. Run the suite from `frontend/portal`:
+
+   ```bash
+   npm run e2e        # or: npm run e2e:ui
+   ```
+
+Playwright starts both servers itself (API on :5299 with
+`ASPNETCORE_ENVIRONMENT=E2E`, Vite on :5199 in `e2e` mode) and reuses them if
+already running. Migrations apply automatically on API startup. To reset the local
+E2E data entirely, drop the database:
+
+```bash
+docker exec herit-e2e-sql /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa \
+  -P 'HeritE2e!Passw0rd' -C -Q "DROP DATABASE IF EXISTS HeritE2E"
+```
+
+## CI
+
+The `e2e` job in `.github/workflows/azure-dev.yml` runs the suite against a SQL
+Server service container (mapped to the same port 14330 the E2E config expects) and
+uploads the Playwright report and traces on failure. The `cd` deploy job requires
+both `ci` and `e2e` to pass.
+
+## Conventions
+
+- Selectors prefer roles, labels, and visible text; no `data-testid`s were needed.
+- Specs run serially (one worker) because they share a database.
+- Fixture titles embed the runId plus the Playwright `workerIndex`, so a worker
+  restart after a failure re-seeds under fresh names instead of colliding.
+- Assert server-enforced behaviour (visibility, status filtering) on **both** the UI
+  and the API response — the API side is what #267 hardened.

--- a/frontend/portal/.env.e2e
+++ b/frontend/portal/.env.e2e
@@ -1,0 +1,10 @@
+# Vite `e2e` mode — used only by the Playwright E2E suite (npm run dev/build -- --mode e2e).
+# Enables the test-auth MSAL stub; the Azure values below are inert placeholders
+# needed only so msalConfig.ts can evaluate.
+VITE_E2E_AUTH=true
+VITE_API_BASE_URL=http://localhost:5299/api/v1
+VITE_AZURE_CLIENT_ID=00000000-0000-0000-0000-000000000001
+VITE_AZURE_TENANT_NAME=e2e-placeholder
+VITE_AZURE_AUTHORITY=https://e2e-placeholder.ciamlogin.com/e2e-placeholder.onmicrosoft.com/
+VITE_REDIRECT_URI=http://localhost:5199
+VITE_API_SCOPE=api://00000000-0000-0000-0000-000000000001/access_as_user

--- a/frontend/portal/e2e/full-loop.spec.ts
+++ b/frontend/portal/e2e/full-loop.spec.ts
@@ -1,0 +1,193 @@
+import { expect, test, type Page } from '@playwright/test';
+import { Api } from './support/api';
+import { openSession } from './support/session';
+import { readRunState, type RunState } from './support/run-state';
+
+/**
+ * Scenario 1 — the core journey, driven end-to-end through the UI:
+ * first-time sign-in (JIT registration) → create proposal → Resourcing →
+ * publish CFEOI → contributor B finds it, submits an EOI, shares it →
+ * owner approves it in the inbox → CFEOI closed → proposal submitted →
+ * proposal withdrawn (terminal).
+ *
+ * User A1 is minted in global setup but never registered, so the JIT
+ * registration form is genuinely first-time for every run.
+ */
+
+let state: RunState;
+
+test.beforeAll(() => {
+  state = readRunState();
+});
+
+const modal = (page: Page) => page.locator('div.fixed.inset-0').filter({ has: page.getByRole('checkbox') });
+
+test('full loop: JIT sign-in through proposal withdrawal', async ({ browser }) => {
+  test.setTimeout(300_000);
+
+  const proposalTitle = `Community Health Outreach (E2E ${state.runId})`;
+  const cfeoiTitle = `Data Platform Architect (E2E ${state.runId})`;
+  const eoiMessage = `I led two national FHIR rollouts and would love to contribute. (E2E ${state.runId})`;
+  let proposalId = '';
+  let cfeoiId = '';
+
+  // ---- User A1: anonymous, with the identity staged for the fake redirect ----
+  const a1 = await openSession(browser, 'userA1-pending');
+
+  await test.step('A1 signs in for the first time and lands on JIT registration', async () => {
+    await a1.page.goto('/sign-in');
+    // exact: the public nav renders its own "Sign In with Google" button.
+    await a1.page.getByRole('button', { name: 'Sign in with Google', exact: true }).click();
+    // The test-auth stub simulates the Entra redirect round-trip with a reload.
+    await expect(a1.page.getByRole('banner').getByRole('link', { name: 'Create Proposal' })).toBeVisible();
+
+    // First authenticated visit: not yet profiled → redirected to complete-profile.
+    await a1.page.goto('/dashboard');
+    await a1.page.waitForURL('**/auth/complete-profile');
+    await expect(a1.page.getByRole('heading', { name: 'Complete Your Profile' })).toBeVisible();
+
+    await a1.page.getByLabel('Full Name').fill('Expat User A1');
+    await a1.page.getByLabel('Home Country / Nationality').fill('Australia');
+    await a1.page.getByLabel('Current Residence').fill('Sydney, Australia');
+    await a1.page.getByLabel('Expertise Tags').fill('Health IT, Data Platforms');
+    await a1.page.getByLabel('I accept the terms and conditions').check();
+    await a1.page.getByRole('button', { name: 'Join Herit' }).click();
+    await a1.page.waitForURL('**/dashboard');
+  });
+
+  await test.step('A1 creates a standalone proposal (lands in Ideation)', async () => {
+    // The dashboard body has its own Create Proposal quick action; use the nav's.
+    await a1.page.getByRole('banner').getByRole('link', { name: 'Create Proposal' }).click();
+    await a1.page.waitForURL('**/proposals/new');
+    await a1.page.getByLabel('Proposal Title').fill(proposalTitle);
+    await a1.page.getByLabel('Short Description').fill('Mobile outreach clinics staffed by diaspora clinicians.');
+    await a1.page.getByLabel('Associated Organisation').selectOption({ label: state.childOrgName });
+    await a1.page.getByLabel('Detailed Proposal').fill('A rolling program of mobile outreach clinics, connecting diaspora health professionals with underserved districts.');
+    await a1.page.getByRole('button', { name: 'Save Proposal' }).click();
+
+    await a1.page.waitForURL(/\/proposals\/[0-9a-f-]+\?created=true/);
+    proposalId = /\/proposals\/([0-9a-f-]+)/.exec(a1.page.url())![1];
+    await expect(a1.page.getByText('Proposal created!')).toBeVisible();
+    await expect(a1.page.getByText('Ideation', { exact: true })).toBeVisible();
+  });
+
+  await test.step('A1 moves the proposal to Resourcing', async () => {
+    await a1.page.getByRole('button', { name: 'Move to Resourcing' }).click();
+    await expect(a1.page.getByRole('button', { name: 'Submit to Organisation' })).toBeVisible();
+    await expect(a1.page.getByText('Resourcing', { exact: true })).toBeVisible();
+  });
+
+  await test.step('A1 shares the proposal so contributors can find it', async () => {
+    await a1.page.getByRole('button', { name: 'Change' }).click();
+    await a1.page.getByRole('radio', { name: 'Shared' }).check();
+    await a1.page.getByRole('button', { name: 'Save', exact: true }).click();
+    await expect(a1.page.getByText('Visible to signed-in users')).toBeVisible();
+  });
+
+  await test.step('A1 publishes a CFEOI (immediately Open)', async () => {
+    await a1.page.getByRole('link', { name: 'Publish a CFEOI' }).click();
+    await a1.page.waitForURL('**/cfeois/new');
+    await a1.page.getByLabel('Title').fill(cfeoiTitle);
+    await a1.page.getByLabel('Description').fill('Architect the data-exchange layer for the outreach program.');
+    // "Non-Human" also contains "Human", so anchor the accessible-name match.
+    await a1.page.getByRole('radio', { name: /^Human/ }).check();
+    await a1.page.getByLabel('Tags').fill('System Architecture, FHIR');
+    await a1.page.getByRole('button', { name: 'Publish CFEOI' }).click();
+
+    await a1.page.waitForURL(/\/cfeois\/[0-9a-f-]+\?published=true/);
+    cfeoiId = /\/cfeois\/([0-9a-f-]+)/.exec(a1.page.url())![1];
+    await expect(a1.page.getByText('CFEOI published successfully')).toBeVisible();
+    await expect(a1.page.getByText('Open', { exact: true })).toBeVisible();
+  });
+
+  // ---- User B: registered contributor ----
+  const b = await openSession(browser, 'userB');
+
+  await test.step('B finds the CFEOI in the directory and submits an EOI', async () => {
+    await b.page.goto('/cfeois');
+    await b.page.getByPlaceholder('Search by title or tags…').fill(cfeoiTitle);
+    await expect(b.page.getByRole('heading', { name: cfeoiTitle })).toBeVisible();
+    await b.page.getByRole('link', { name: 'View Details' }).click();
+    await b.page.waitForURL(`**/cfeois/${cfeoiId}`);
+
+    await b.page.getByRole('link', { name: 'Express Interest' }).click();
+    await b.page.waitForURL(`**/cfeois/${cfeoiId}/eois/new`);
+    await b.page.getByLabel('Cover note').fill(eoiMessage);
+    await b.page.getByRole('button', { name: 'Submit expression of interest' }).click();
+
+    await b.page.waitForURL(`**/cfeois/${cfeoiId}?submitted=true`);
+    await expect(b.page.getByText('Your expression of interest was submitted')).toBeVisible();
+    await expect(b.page.getByRole('heading', { name: /You.ve expressed interest/ })).toBeVisible();
+  });
+
+  await test.step('the EOI is created Pending and Private (server state)', async () => {
+    const apiB = await Api.forToken(state.identities.userB.token);
+    const eoi = (await apiB.listMyEois()).find((e) => e.cfeoiId === cfeoiId);
+    expect(eoi).toBeDefined();
+    expect(eoi!.status).toBe('Pending');
+    expect(eoi!.visibility).toBe('Private');
+    await apiB.dispose();
+  });
+
+  await test.step('B shares the EOI from My EOIs', async () => {
+    await b.page.goto('/my-eois');
+    const card = b.page.locator('div.rounded-xl').filter({ has: b.page.getByRole('link', { name: cfeoiTitle }) });
+    await card.getByRole('button', { name: 'Shared', exact: true }).click();
+    await expect(card.getByRole('button', { name: 'Shared', exact: true })).toHaveClass(/bg-white/);
+
+    const apiB = await Api.forToken(state.identities.userB.token);
+    await expect
+      .poll(async () => (await apiB.listMyEois()).find((e) => e.cfeoiId === cfeoiId)?.visibility)
+      .toBe('Shared');
+    await apiB.dispose();
+  });
+
+  await test.step("A1 sees B's EOI in the inbox and approves it", async () => {
+    await a1.page.goto(`/cfeois/${cfeoiId}/eois`);
+    await expect(a1.page.getByRole('heading', { name: 'Expressions of Interest' })).toBeVisible();
+    const eoiCard = a1.page.locator('div.divide-y > div').filter({ hasText: eoiMessage });
+    await expect(eoiCard).toBeVisible();
+    await eoiCard.getByRole('button', { name: 'Approve' }).click();
+    await expect(eoiCard.getByText('Approved')).toBeVisible();
+  });
+
+  await test.step('A1 closes the CFEOI (terminal, checkbox-gated)', async () => {
+    await a1.page.goto(`/cfeois/${cfeoiId}`);
+    await a1.page.getByRole('button', { name: 'Close CFEOI' }).click();
+    const closeModal = modal(a1.page);
+    await expect(closeModal.getByRole('heading', { name: 'Close CFEOI?' })).toBeVisible();
+    await expect(closeModal.getByRole('button', { name: 'Close CFEOI' })).toBeDisabled();
+    await closeModal.getByRole('checkbox').check();
+    await closeModal.getByRole('button', { name: 'Close CFEOI' }).click();
+    await expect(a1.page.getByText('This CFEOI is now closed.')).toBeVisible();
+  });
+
+  await test.step('A1 submits the proposal, then withdraws it (terminal, read-only)', async () => {
+    await a1.page.goto(`/proposals/${proposalId}`);
+    await a1.page.getByRole('button', { name: 'Submit to Organisation' }).click();
+    await expect(a1.page.getByText('Submitted', { exact: true })).toBeVisible();
+
+    await a1.page.getByRole('button', { name: 'Withdraw Proposal' }).click();
+    const withdrawModal = modal(a1.page);
+    await expect(withdrawModal.getByRole('heading', { name: 'Withdraw proposal?' })).toBeVisible();
+    await expect(withdrawModal.getByRole('button', { name: 'Withdraw Proposal' })).toBeDisabled();
+    await withdrawModal.getByRole('checkbox').check();
+    await withdrawModal.getByRole('button', { name: 'Withdraw Proposal' }).click();
+
+    await expect(a1.page.getByText('Withdrawn', { exact: true })).toBeVisible();
+    await expect(a1.page.getByText('Proposal Withdrawn')).toBeVisible();
+    await expect(a1.page.getByRole('button', { name: 'Move to Resourcing' })).toBeHidden();
+    await expect(a1.page.getByRole('button', { name: 'Submit to Organisation' })).toBeHidden();
+    await expect(a1.page.getByRole('button', { name: 'Withdraw Proposal' })).toBeHidden();
+  });
+
+  await test.step("B's EOI reflects the approval", async () => {
+    const apiB = await Api.forToken(state.identities.userB.token);
+    const eoi = (await apiB.listMyEois()).find((e) => e.cfeoiId === cfeoiId);
+    expect(eoi?.status).toBe('Approved');
+    await apiB.dispose();
+  });
+
+  await a1.context.close();
+  await b.context.close();
+});

--- a/frontend/portal/e2e/global.setup.ts
+++ b/frontend/portal/e2e/global.setup.ts
@@ -1,0 +1,100 @@
+import { execFileSync } from 'node:child_process';
+import { test as setup } from '@playwright/test';
+import { API_PROJECT, REPO_ROOT, SUPER_ADMIN_EMAIL, SUPER_ADMIN_NAME } from './support/config';
+import { Api } from './support/api';
+import { externalIdFor, mintToken } from './support/tokens';
+import { writeRunState, writeStorageState, type TestIdentity } from './support/run-state';
+
+/**
+ * Builds the known-good baseline every spec depends on, going through the same
+ * paths production uses (CLI seeder + public API — never direct DB writes):
+ *
+ *  1. Super admin via the existing CLI seeder (`--seed-super-admin`). Only this
+ *     actor can bootstrap the organisation hierarchy. Idempotent across runs.
+ *  2. Organisation hierarchy (root ministry + child agency) as the super admin.
+ *  3. A staff user + a Published RFP, so unauthenticated RFP browsing has data.
+ *  4. Expat users A (owner) and B (contributor), registered through the same
+ *     JIT path the SPA uses (GET /Users/me) and terms-accepted via the API.
+ *     User A1 is minted but deliberately NOT registered — scenario 1 walks it
+ *     through the first-time JIT registration UI.
+ *
+ * All run-scoped records carry the runId in their titles so runs never depend
+ * on (or collide with) data left behind by earlier local runs.
+ */
+setup('seed the E2E baseline', async () => {
+  setup.setTimeout(180_000);
+
+  execFileSync('dotnet', [
+    'run', '--no-launch-profile', '--project', API_PROJECT, '--',
+    '--seed-super-admin', '--email', SUPER_ADMIN_EMAIL, '--display-name', SUPER_ADMIN_NAME,
+  ], {
+    cwd: REPO_ROOT,
+    stdio: 'inherit',
+    env: { ...process.env, ASPNETCORE_ENVIRONMENT: 'E2E' },
+  });
+
+  const runId = Date.now().toString(36);
+
+  const identityFor = async (slug: string, name: string): Promise<TestIdentity> => {
+    const email = `${slug}-${runId}@e2e.herit.local`;
+    return { email, name, externalId: externalIdFor(email), token: await mintToken(email, name) };
+  };
+
+  const superAdmin: TestIdentity = {
+    email: SUPER_ADMIN_EMAIL,
+    name: SUPER_ADMIN_NAME,
+    externalId: externalIdFor(SUPER_ADMIN_EMAIL),
+    token: await mintToken(SUPER_ADMIN_EMAIL, SUPER_ADMIN_NAME),
+  };
+  const staff = await identityFor('staff', 'E2E Staff Member');
+  const userA = await identityFor('user-a', 'Expat User A');
+  const userB = await identityFor('user-b', 'Expat User B');
+  const userA1 = await identityFor('user-a1', 'Expat User A1');
+
+  const admin = await Api.forToken(superAdmin.token);
+
+  const rootOrgName = `Ministry of Health (E2E ${runId})`;
+  const rootOrgId = await admin.createOrganisation(rootOrgName);
+  const childOrgName = `Digital Health Agency (E2E ${runId})`;
+  const childOrgId = await admin.createOrganisation(childOrgName, rootOrgId);
+
+  const staffUserId = await admin.createStaffUser(staff.email, staff.name, rootOrgId);
+  const staffApi = await Api.forToken(staff.token);
+  const rfpTitle = `National Health Data Platform (E2E ${runId})`;
+  const rfpId = await staffApi.createRfp({
+    title: rfpTitle,
+    shortDescription: 'Modernise the national health data exchange.',
+    organisationId: rootOrgId,
+    longDescription: 'The ministry seeks proposals to build an interoperable national health data platform.',
+    tags: 'Health, Data, Interoperability',
+  });
+  await staffApi.updateRfpStatus(rfpId, 'Approved');
+  await staffApi.updateRfpStatus(rfpId, 'Published');
+
+  // JIT-register A and B, then accept terms so ProtectedRoute lets them in.
+  for (const identity of [userA, userB]) {
+    const api = await Api.forToken(identity.token);
+    await api.getMe();
+    await api.acceptTerms({ email: identity.email, nationality: 'Australia', location: 'Sydney', expertiseTags: 'Health IT' });
+    await api.dispose();
+  }
+
+  writeStorageState('userA', userA);
+  writeStorageState('userB', userB);
+  writeStorageState('userA1-pending', userA1, { pending: true });
+
+  writeRunState({
+    runId,
+    rootOrgId,
+    rootOrgName,
+    childOrgId,
+    childOrgName,
+    rfpId,
+    rfpTitle,
+    staffUserId,
+    identities: { superAdmin, staff, userA, userB, userA1 },
+  });
+
+  await admin.dispose();
+  await staffApi.dispose();
+});

--- a/frontend/portal/e2e/global.teardown.ts
+++ b/frontend/portal/e2e/global.teardown.ts
@@ -1,0 +1,47 @@
+import { test as teardown } from '@playwright/test';
+import { Api } from './support/api';
+import { readRunState } from './support/run-state';
+
+/**
+ * Best-effort cleanup through the public API. Some records intentionally have
+ * no delete path (CFEOIs, withdrawn proposals, expat users), so anything that
+ * refuses deletion is left behind — every record carries the runId in its
+ * title, so later runs neither depend on nor collide with leftovers. CI
+ * databases are ephemeral; local databases can be reset by recreating the
+ * HeritE2E database (see docs/frontend/portal/e2e-testing.md).
+ */
+teardown('clean up run-scoped data', async () => {
+  const state = readRunState();
+  const attempt = async (label: string, action: () => Promise<unknown>) => {
+    try {
+      await action();
+    } catch {
+      console.log(`[e2e teardown] left behind: ${label}`);
+    }
+  };
+
+  for (const key of ['userA', 'userA1', 'userB'] as const) {
+    const api = await Api.forToken(state.identities[key].token);
+    // Withdraw the user's remaining EOIs (withdrawal deletes the record).
+    await attempt(`${key} EOIs`, async () => {
+      for (const eoi of await api.listMyEois()) await attempt(`EOI ${eoi.id}`, () => api.withdrawEoi(eoi.id));
+    });
+    // Delete the user's proposals still in a deletable state.
+    await attempt(`${key} proposals`, async () => {
+      const me = await api.getMe();
+      const mine = (await api.listProposals()).filter((p) => p.authorId === me.id);
+      for (const proposal of mine) await attempt(`proposal "${proposal.title}"`, () => api.deleteProposal(proposal.id));
+    });
+    await api.dispose();
+  }
+
+  const staffApi = await Api.forToken(state.identities.staff.token);
+  await attempt(`RFP "${state.rfpTitle}"`, () => staffApi.deleteRfp(state.rfpId));
+  await staffApi.dispose();
+
+  const admin = await Api.forToken(state.identities.superAdmin.token);
+  await attempt('staff user', () => admin.deleteStaffUser(state.staffUserId));
+  await attempt(`organisation "${state.childOrgName}"`, () => admin.deleteOrganisation(state.childOrgId));
+  await attempt(`organisation "${state.rootOrgName}"`, () => admin.deleteOrganisation(state.rootOrgId));
+  await admin.dispose();
+});

--- a/frontend/portal/e2e/seams.spec.ts
+++ b/frontend/portal/e2e/seams.spec.ts
@@ -1,0 +1,151 @@
+import { expect, test, type Page } from '@playwright/test';
+import { Api } from './support/api';
+import { openSession } from './support/session';
+import { readRunState, type RunState } from './support/run-state';
+
+/**
+ * Scenario 3 — seams and terminal states: the already-submitted CTA swap (and
+ * its return after withdraw), Closed-CFEOI behaviour for contributor vs owner,
+ * per-status Withdraw/Delete labels with the checkbox-gated modal, and the
+ * auth/ownership guards on owner routes.
+ */
+
+let state: RunState;
+let apiA: Api;
+let apiB: Api;
+
+let revisitCfeoiId = '';
+let closedCfeoiId = '';
+let pendingCfeoiTitle = '';
+let approvedCfeoiTitle = '';
+let rejectedCfeoiTitle = '';
+let pendingCfeoiId = '';
+
+let scope = '';
+
+test.beforeAll(async ({}, testInfo) => {
+  state = readRunState();
+  // Worker-scoped suffix: if Playwright restarts the worker after a failure,
+  // beforeAll runs again — fresh titles keep re-seeded fixtures unambiguous.
+  scope = `${state.runId}-w${testInfo.workerIndex}`;
+  apiA = await Api.forToken(state.identities.userA.token);
+  apiB = await Api.forToken(state.identities.userB.token);
+
+  const proposalId = await apiA.createProposal({
+    title: `Seams host proposal (E2E ${scope})`,
+    shortDescription: 'Host proposal for seam and terminal-state fixtures.',
+    longDescription: 'Fixture proposal owning the CFEOIs used by scenario 3.',
+    organisationId: state.childOrgId,
+  });
+  await apiA.setProposalVisibility(proposalId, 'Shared');
+  await apiA.setProposalStatus(proposalId, 'Resourcing');
+
+  const publish = (label: string) =>
+    apiA.publishCfeoi({
+      title: `Seams ${label} role (E2E ${scope})`,
+      description: `Fixture CFEOI (${label}).`,
+      resourceType: 'Human',
+      proposalId,
+    });
+
+  revisitCfeoiId = await publish('revisit');
+  closedCfeoiId = await publish('closing');
+  pendingCfeoiId = await publish('pending');
+  const approvedCfeoiId = await publish('approved');
+  const rejectedCfeoiId = await publish('rejected');
+  pendingCfeoiTitle = `Seams pending role (E2E ${scope})`;
+  approvedCfeoiTitle = `Seams approved role (E2E ${scope})`;
+  rejectedCfeoiTitle = `Seams rejected role (E2E ${scope})`;
+
+  // B's EOIs in each reviewable status.
+  await apiB.submitEoi(pendingCfeoiId, `Seams pending EOI (E2E ${state.runId})`);
+  const approvedEoiId = await apiB.submitEoi(approvedCfeoiId, `Seams approved EOI (E2E ${state.runId})`);
+  await apiB.setEoiVisibility(approvedEoiId, 'Shared');
+  await apiA.setEoiStatus(approvedEoiId, 'Approved');
+  const rejectedEoiId = await apiB.submitEoi(rejectedCfeoiId, `Seams rejected EOI (E2E ${state.runId})`);
+  await apiB.setEoiVisibility(rejectedEoiId, 'Shared');
+  await apiA.setEoiStatus(rejectedEoiId, 'Rejected');
+
+  // A shared EOI on a CFEOI the owner then closes.
+  const closedEoiId = await apiB.submitEoi(closedCfeoiId, `Seams closed-role EOI (E2E ${state.runId})`);
+  await apiB.setEoiVisibility(closedEoiId, 'Shared');
+  await apiA.setCfeoiStatus(closedCfeoiId, 'Closed');
+});
+
+test.afterAll(async () => {
+  await Promise.all([apiA.dispose(), apiB.dispose()]);
+});
+
+const myEoiCard = (page: Page, cfeoiTitle: string) =>
+  page.locator('div.rounded-xl').filter({ has: page.getByRole('link', { name: cfeoiTitle }) });
+
+test('Express Interest is replaced after submission and returns after withdrawal', async ({ browser }) => {
+  const eoiId = await apiB.submitEoi(revisitCfeoiId, `Seams revisit EOI (E2E ${state.runId})`);
+
+  const { context, page } = await openSession(browser, 'userB');
+  await page.goto(`/cfeois/${revisitCfeoiId}`);
+  await expect(page.getByRole('heading', { name: /You.ve expressed interest/ })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Express Interest' })).toBeHidden();
+  await expect(page.getByRole('link', { name: 'View in My EOIs' })).toBeVisible();
+
+  // Withdraw-then-revisit: the CTA returns.
+  await apiB.withdrawEoi(eoiId);
+  await page.reload();
+  await expect(page.getByRole('link', { name: 'Express Interest' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: /You.ve expressed interest/ })).toBeHidden();
+  await context.close();
+});
+
+test('a Closed CFEOI accepts no interest but stays reviewable for the owner', async ({ browser }) => {
+  const b = await openSession(browser, 'userB');
+  await b.page.goto(`/cfeois/${closedCfeoiId}`);
+  await expect(b.page.getByText('This CFEOI is now closed.')).toBeVisible();
+  await expect(b.page.getByRole('heading', { name: 'This role is closed' })).toBeVisible();
+  await expect(b.page.getByRole('link', { name: 'Express Interest' })).toBeHidden();
+  await expect(b.page.getByRole('button', { name: 'Sign In to Express Interest' })).toBeHidden();
+  await b.context.close();
+
+  const a = await openSession(browser, 'userA');
+  await a.page.goto(`/cfeois/${closedCfeoiId}/eois`);
+  await expect(a.page.getByRole('heading', { name: 'Expressions of Interest' })).toBeVisible();
+  await expect(a.page.getByText('This CFEOI is now closed.')).toBeVisible();
+  await expect(a.page.getByText(`Seams closed-role EOI (E2E ${state.runId})`)).toBeVisible();
+  await a.context.close();
+});
+
+test('My EOIs labels the removal action per status and gates it behind the checkbox', async ({ browser }) => {
+  const { context, page } = await openSession(browser, 'userB');
+  await page.goto('/my-eois');
+
+  await expect(myEoiCard(page, pendingCfeoiTitle).getByRole('button', { name: 'Withdraw' })).toBeVisible();
+  await expect(myEoiCard(page, approvedCfeoiTitle).getByRole('button', { name: 'Withdraw' })).toBeVisible();
+  await expect(myEoiCard(page, rejectedCfeoiTitle).getByRole('button', { name: 'Delete' })).toBeVisible();
+
+  // Delete the rejected EOI through the checkbox-gated confirmation modal.
+  await myEoiCard(page, rejectedCfeoiTitle).getByRole('button', { name: 'Delete' }).click();
+  await expect(page.getByRole('heading', { name: 'Delete expression of interest?' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Delete EOI' })).toBeDisabled();
+  await page.getByRole('checkbox').check();
+  await page.getByRole('button', { name: 'Delete EOI' }).click();
+
+  await expect(page.getByText('Your expression of interest was deleted.')).toBeVisible();
+  await expect(myEoiCard(page, rejectedCfeoiTitle)).toBeHidden();
+  await context.close();
+});
+
+test('unauthenticated visits to owner routes redirect to sign-in', async ({ browser }) => {
+  const { context, page } = await openSession(browser);
+  await page.goto('/my-eois');
+  await page.waitForURL('**/sign-in');
+  await page.goto('/dashboard');
+  await page.waitForURL('**/sign-in');
+  await context.close();
+});
+
+test("a non-owner cannot reach another user's EOI inbox", async ({ browser }) => {
+  const { context, page } = await openSession(browser, 'userB');
+  await page.goto(`/cfeois/${pendingCfeoiId}/eois`);
+  await expect(page.getByRole('heading', { name: 'Cannot view this inbox' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Approve' })).toBeHidden();
+  await context.close();
+});

--- a/frontend/portal/e2e/support/api.ts
+++ b/frontend/portal/e2e/support/api.ts
@@ -1,0 +1,201 @@
+import { request, type APIRequestContext, type APIResponse } from '@playwright/test';
+import { API_HOST } from './config';
+
+export interface ProposalDto {
+  id: string;
+  title: string;
+  shortDescription: string;
+  longDescription: string;
+  authorId: string;
+  organisationId: string;
+  rfpId: string | null;
+  status: string;
+  visibility: string;
+}
+
+export interface CfeoiDto {
+  id: string;
+  title: string;
+  description: string;
+  resourceType: string;
+  proposalId: string;
+  status: string;
+  tags: string | null;
+}
+
+export interface EoiDto {
+  id: string;
+  submittedById: string;
+  message: string;
+  cfeoiId: string;
+  status: string;
+  visibility: string;
+}
+
+export interface UserDto {
+  id: string;
+  externalId: string;
+  email: string;
+  fullName: string;
+  role: string;
+  termsAcceptedAt: string | null;
+}
+
+export interface RfpDto {
+  id: string;
+  title: string;
+  status: string;
+}
+
+/**
+ * Thin typed wrapper over the Herit API for seeding and network-level
+ * assertions. Every identity (anonymous, expat A/B, staff, super admin) gets
+ * its own instance so requests carry the right bearer token.
+ */
+export class Api {
+  private constructor(private readonly ctx: APIRequestContext) {}
+
+  static async forToken(token: string): Promise<Api> {
+    return new Api(await request.newContext({
+      baseURL: API_HOST,
+      extraHTTPHeaders: { Authorization: `Bearer ${token}` },
+    }));
+  }
+
+  static async anonymous(): Promise<Api> {
+    return new Api(await request.newContext({ baseURL: API_HOST }));
+  }
+
+  async dispose(): Promise<void> {
+    await this.ctx.dispose();
+  }
+
+  private async send(method: string, url: string, data?: unknown): Promise<APIResponse> {
+    // Content type is set explicitly so pre-serialized bodies (bare enum strings
+    // like `"Resourcing"`, mirroring what the app's axios client sends) parse as JSON.
+    const response = await this.ctx.fetch(`/api/v1${url}`, {
+      method,
+      data,
+      headers: { 'Content-Type': 'application/json' },
+    });
+    if (!response.ok()) {
+      throw new Error(`${method} ${url} failed with ${response.status()}: ${await response.text()}`);
+    }
+    return response;
+  }
+
+  /** Raw fetch that does not throw — for asserting on status codes. */
+  async raw(method: string, url: string, data?: unknown): Promise<APIResponse> {
+    return this.ctx.fetch(`/api/v1${url}`, { method, data });
+  }
+
+  // --- Users ---
+
+  /** JIT-registers the caller on first call, exactly like the app does. */
+  async getMe(): Promise<UserDto> {
+    return (await this.send('GET', '/Users/me')).json();
+  }
+
+  async acceptTerms(profile: { email: string; nationality?: string; location?: string; expertiseTags?: string }): Promise<void> {
+    await this.send('PATCH', '/Users/me/profile', { ...profile, termsAcceptedAt: new Date().toISOString() });
+  }
+
+  async createStaffUser(email: string, fullName: string, organisationId: string): Promise<string> {
+    return (await this.send('POST', '/Users/staff', { email, fullName, organisationId })).json();
+  }
+
+  async deleteStaffUser(id: string): Promise<void> {
+    await this.send('DELETE', `/Users/staff/${id}`);
+  }
+
+  // --- Organisations ---
+
+  async createOrganisation(name: string, parentId?: string): Promise<string> {
+    return (await this.send('POST', '/Organisations', { name, parentId })).json();
+  }
+
+  async deleteOrganisation(id: string): Promise<void> {
+    await this.send('DELETE', `/Organisations/${id}`);
+  }
+
+  // --- RFPs ---
+
+  async createRfp(rfp: { title: string; shortDescription: string; organisationId: string; longDescription: string; tags?: string }): Promise<string> {
+    return (await this.send('POST', '/Rfps', rfp)).json();
+  }
+
+  async updateRfpStatus(id: string, newStatus: string): Promise<void> {
+    await this.send('PATCH', `/Rfps/${id}/status`, { newStatus });
+  }
+
+  async deleteRfp(id: string): Promise<void> {
+    await this.send('DELETE', `/Rfps/${id}`);
+  }
+
+  async listRfps(): Promise<RfpDto[]> {
+    return (await this.send('GET', '/Rfps')).json();
+  }
+
+  // --- Proposals ---
+
+  async createProposal(proposal: { title: string; shortDescription: string; longDescription: string; organisationId: string; rfpId?: string }): Promise<string> {
+    return (await this.send('POST', '/Proposals', proposal)).json();
+  }
+
+  async setProposalStatus(id: string, status: string): Promise<void> {
+    await this.send('PATCH', `/Proposals/${id}/status`, JSON.stringify(status));
+  }
+
+  async setProposalVisibility(id: string, visibility: string): Promise<void> {
+    await this.send('PATCH', `/Proposals/${id}/visibility`, JSON.stringify(visibility));
+  }
+
+  async deleteProposal(id: string): Promise<void> {
+    await this.send('DELETE', `/Proposals/${id}`);
+  }
+
+  async listProposals(): Promise<ProposalDto[]> {
+    return (await this.send('GET', '/Proposals')).json();
+  }
+
+  // --- CFEOIs ---
+
+  async publishCfeoi(cfeoi: { title: string; description: string; resourceType: string; proposalId: string; tags?: string }): Promise<string> {
+    return (await this.send('POST', '/Cfeoi', cfeoi)).json();
+  }
+
+  async setCfeoiStatus(id: string, newStatus: string): Promise<void> {
+    await this.send('PATCH', `/Cfeoi/${id}/status`, { newStatus });
+  }
+
+  async listCfeois(params?: { status?: string; proposalId?: string }): Promise<CfeoiDto[]> {
+    const query = new URLSearchParams(params as Record<string, string>).toString();
+    return (await this.send('GET', `/Cfeoi${query ? `?${query}` : ''}`)).json();
+  }
+
+  // --- EOIs ---
+
+  async submitEoi(cfeoiId: string, message: string): Promise<string> {
+    return (await this.send('POST', '/Eoi', { cfeoiId, message })).json();
+  }
+
+  async setEoiVisibility(id: string, visibility: string): Promise<void> {
+    await this.send('PATCH', `/Eoi/${id}/visibility`, JSON.stringify(visibility));
+  }
+
+  async setEoiStatus(id: string, newStatus: string): Promise<void> {
+    await this.send('PATCH', `/Eoi/${id}/status`, { newStatus });
+  }
+
+  async withdrawEoi(id: string): Promise<void> {
+    await this.send('PATCH', `/Eoi/${id}/withdraw`);
+  }
+
+  async listMyEois(): Promise<EoiDto[]> {
+    return (await this.send('GET', '/Eoi/my')).json();
+  }
+
+  async listEoisByCfeoi(cfeoiId: string): Promise<EoiDto[]> {
+    return (await this.send('GET', `/Eoi?cfeoiId=${cfeoiId}`)).json();
+  }
+}

--- a/frontend/portal/e2e/support/config.ts
+++ b/frontend/portal/e2e/support/config.ts
@@ -1,0 +1,26 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+export const WEB_PORT = 5199;
+export const API_PORT = 5299;
+export const WEB_URL = `http://localhost:${WEB_PORT}`;
+export const API_HOST = `http://localhost:${API_PORT}`;
+
+/** Must match TestAuth settings in src/Herit.Api/appsettings.E2E.json. */
+export const SIGNING_KEY = 'herit-e2e-signing-key-not-a-secret-0123456789abcdef0123456789abcdef';
+export const TOKEN_ISSUER = 'https://herit-e2e.local';
+export const TOKEN_AUDIENCE = 'herit-api-e2e';
+
+export const SUPER_ADMIN_EMAIL = 'superadmin@e2e.herit.local';
+export const SUPER_ADMIN_NAME = 'E2E Super Admin';
+
+export const REPO_ROOT = path.resolve(here, '../../../..');
+export const API_PROJECT = path.join(REPO_ROOT, 'src/Herit.Api');
+
+/** Per-run artifacts (storage states, run metadata). Gitignored. */
+export const STATE_DIR = path.resolve(here, '../.state');
+export const RUN_FILE = path.join(STATE_DIR, 'run.json');
+
+export const storageStatePath = (name: string): string => path.join(STATE_DIR, `${name}.storage.json`);

--- a/frontend/portal/e2e/support/run-state.ts
+++ b/frontend/portal/e2e/support/run-state.ts
@@ -1,0 +1,63 @@
+import fs from 'node:fs';
+import { RUN_FILE, STATE_DIR, WEB_URL, storageStatePath } from './config';
+
+export interface TestIdentity {
+  email: string;
+  name: string;
+  externalId: string;
+  token: string;
+}
+
+export interface RunState {
+  runId: string;
+  rootOrgId: string;
+  rootOrgName: string;
+  childOrgId: string;
+  childOrgName: string;
+  rfpId: string;
+  rfpTitle: string;
+  staffUserId: string;
+  identities: {
+    superAdmin: TestIdentity;
+    staff: TestIdentity;
+    /** Registered expat — proposal owner in most specs. */
+    userA: TestIdentity;
+    /** Registered expat — contributor. */
+    userB: TestIdentity;
+    /** NOT registered; scenario 1 exercises the first-time JIT flow with it. */
+    userA1: TestIdentity;
+  };
+}
+
+export function writeRunState(state: RunState): void {
+  fs.mkdirSync(STATE_DIR, { recursive: true });
+  fs.writeFileSync(RUN_FILE, JSON.stringify(state, null, 2));
+}
+
+export function readRunState(): RunState {
+  return JSON.parse(fs.readFileSync(RUN_FILE, 'utf8')) as RunState;
+}
+
+/** localStorage payload the app's test-auth MSAL stub reads (see src/auth/testAuth.ts). */
+const identityPayload = (identity: TestIdentity): string =>
+  JSON.stringify({
+    token: identity.token,
+    account: { externalId: identity.externalId, email: identity.email, name: identity.name },
+  });
+
+/**
+ * Writes a Playwright storageState file whose localStorage signs the identity
+ * in (key `herit.e2e.auth`), or — with `pending: true` — stages it so the next
+ * loginRedirect() call signs it in (key `herit.e2e.pendingAuth`), which lets
+ * tests drive the sign-in UI itself.
+ */
+export function writeStorageState(name: string, identity: TestIdentity, options?: { pending?: boolean }): string {
+  const key = options?.pending ? 'herit.e2e.pendingAuth' : 'herit.e2e.auth';
+  const statePath = storageStatePath(name);
+  fs.mkdirSync(STATE_DIR, { recursive: true });
+  fs.writeFileSync(statePath, JSON.stringify({
+    cookies: [],
+    origins: [{ origin: WEB_URL, localStorage: [{ name: key, value: identityPayload(identity) }] }],
+  }, null, 2));
+  return statePath;
+}

--- a/frontend/portal/e2e/support/session.ts
+++ b/frontend/portal/e2e/support/session.ts
@@ -1,0 +1,16 @@
+import type { Browser, BrowserContext, Page } from '@playwright/test';
+import { storageStatePath } from './config';
+
+/**
+ * Opens an isolated browser context for one of the identities whose storage
+ * state global.setup.ts wrote ('userA', 'userB', 'userA1-pending'), or an
+ * anonymous context when no name is given. Callers should close the returned
+ * context (or rely on worker shutdown at the end of the run).
+ */
+export async function openSession(browser: Browser, stateName?: string): Promise<{ context: BrowserContext; page: Page }> {
+  const context = await browser.newContext(
+    stateName ? { storageState: storageStatePath(stateName) } : {},
+  );
+  const page = await context.newPage();
+  return { context, page };
+}

--- a/frontend/portal/e2e/support/tokens.ts
+++ b/frontend/portal/e2e/support/tokens.ts
@@ -1,0 +1,22 @@
+import { SignJWT } from 'jose';
+import { SIGNING_KEY, TOKEN_AUDIENCE, TOKEN_ISSUER } from './config';
+
+/**
+ * External IDs are derived from the email exactly like the API's
+ * LocalTestIdentityProviderService does, so tokens minted here resolve to the
+ * users the seeder/staff endpoints create.
+ */
+export const externalIdFor = (email: string): string => `e2e-${email}`;
+
+/** Mint an HS256 bearer token the API's TestAuth scheme accepts. */
+export async function mintToken(email: string, name: string): Promise<string> {
+  const key = new TextEncoder().encode(SIGNING_KEY);
+  return new SignJWT({ oid: externalIdFor(email), email, name })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuer(TOKEN_ISSUER)
+    .setAudience(TOKEN_AUDIENCE)
+    .setSubject(externalIdFor(email))
+    .setIssuedAt()
+    .setExpirationTime('2h')
+    .sign(key);
+}

--- a/frontend/portal/e2e/unauthenticated.spec.ts
+++ b/frontend/portal/e2e/unauthenticated.spec.ts
@@ -1,0 +1,117 @@
+import { expect, test } from '@playwright/test';
+import { Api } from './support/api';
+import { openSession } from './support/session';
+import { readRunState, type RunState } from './support/run-state';
+
+/**
+ * Scenario 4 — flow 1, unauthenticated browsing: published RFPs and Public
+ * proposals/CFEOIs are fully readable with no session, unpublished RFPs never
+ * leak, and any attempt to interact prompts sign-in.
+ */
+
+let state: RunState;
+let apiA: Api;
+let staffApi: Api;
+
+let publicProposalTitle = '';
+let publicCfeoiTitle = '';
+let draftRfpTitle = '';
+let draftRfpId = '';
+
+test.beforeAll(async ({}, testInfo) => {
+  state = readRunState();
+  // Worker-scoped suffix: if Playwright restarts the worker after a failure,
+  // beforeAll runs again — fresh titles keep re-seeded fixtures unambiguous.
+  const scope = `${state.runId}-w${testInfo.workerIndex}`;
+  apiA = await Api.forToken(state.identities.userA.token);
+  staffApi = await Api.forToken(state.identities.staff.token);
+
+  publicProposalTitle = `Unauth public proposal (E2E ${scope})`;
+  publicCfeoiTitle = `Unauth public role (E2E ${scope})`;
+  const proposalId = await apiA.createProposal({
+    title: publicProposalTitle,
+    shortDescription: 'Public fixture proposal for unauthenticated browsing.',
+    longDescription: 'Anyone — including anonymous visitors — should be able to read this.',
+    organisationId: state.childOrgId,
+  });
+  await apiA.setProposalVisibility(proposalId, 'Public');
+  await apiA.setProposalStatus(proposalId, 'Resourcing');
+  await apiA.publishCfeoi({
+    title: publicCfeoiTitle,
+    description: 'Open role under the public fixture proposal.',
+    resourceType: 'Human',
+    proposalId,
+  });
+
+  draftRfpTitle = `Unauth draft RFP (E2E ${scope})`;
+  draftRfpId = await staffApi.createRfp({
+    title: draftRfpTitle,
+    shortDescription: 'Draft RFP that must never be visible to the public.',
+    organisationId: state.rootOrgId,
+    longDescription: 'Unpublished fixture RFP.',
+  });
+});
+
+test.afterAll(async () => {
+  try {
+    await staffApi.deleteRfp(draftRfpId);
+  } catch {
+    // best-effort; run-scoped title keeps future runs unaffected
+  }
+  await Promise.all([apiA.dispose(), staffApi.dispose()]);
+});
+
+test('anonymous visitors see published RFPs only, and can read the detail', async ({ browser }) => {
+  // Server-side: only Published RFPs are returned to anonymous callers.
+  const anon = await Api.anonymous();
+  const rfps = await anon.listRfps();
+  expect(rfps.map((r) => r.title)).toContain(state.rfpTitle);
+  expect(rfps.map((r) => r.title)).not.toContain(draftRfpTitle);
+  expect(rfps.every((r) => r.status === 'Published')).toBe(true);
+  await anon.dispose();
+
+  const { context, page } = await openSession(browser);
+  await page.goto('/rfps');
+  await page.getByPlaceholder('Search by title, organisation, or tags…').fill(state.rfpTitle);
+  await expect(page.getByRole('heading', { name: state.rfpTitle })).toBeVisible();
+  await page.getByRole('link', { name: 'View Details' }).click();
+
+  await expect(page.getByRole('heading', { name: state.rfpTitle, level: 1 })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Sign in to contribute' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Sign in with Google', exact: true })).toBeVisible();
+  await context.close();
+});
+
+test('anonymous visitors can browse a Public proposal end-to-end', async ({ browser }) => {
+  const { context, page } = await openSession(browser);
+  await page.goto('/proposals');
+  await page.getByPlaceholder('Search proposals by title or description...').fill(publicProposalTitle);
+  await expect(page.getByRole('heading', { name: publicProposalTitle })).toBeVisible();
+  await page.getByRole('link', { name: 'View Details' }).click();
+
+  await expect(page.getByRole('heading', { name: publicProposalTitle, level: 1 })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Join the Team' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Sign in with Google', exact: true })).toBeVisible();
+  await context.close();
+});
+
+test('Express Interest prompts sign-in for anonymous visitors', async ({ browser }) => {
+  const { context, page } = await openSession(browser);
+  await page.goto('/cfeois');
+  await page.getByPlaceholder('Search by title or tags…').fill(publicCfeoiTitle);
+  await expect(page.getByRole('heading', { name: publicCfeoiTitle })).toBeVisible();
+  await page.getByRole('link', { name: 'View Details' }).click();
+
+  await page.getByRole('button', { name: 'Sign In to Express Interest' }).click();
+  const dialog = page.getByRole('dialog');
+  await expect(dialog.getByRole('heading', { name: 'Sign in required' })).toBeVisible();
+  await dialog.getByRole('button', { name: 'Sign in with Google', exact: true }).click();
+
+  // The test-auth stub records the sign-in attempt; the session stays anonymous
+  // because no identity was staged.
+  await expect
+    .poll(() => page.evaluate(() => window.sessionStorage.getItem('herit.e2e.loginRequested')))
+    .not.toBeNull();
+  expect(await page.evaluate(() => window.localStorage.getItem('herit.e2e.auth'))).toBeNull();
+  await context.close();
+});

--- a/frontend/portal/e2e/visibility-matrix.spec.ts
+++ b/frontend/portal/e2e/visibility-matrix.spec.ts
@@ -1,0 +1,172 @@
+import { expect, test, type Page } from '@playwright/test';
+import { Api, type CfeoiDto, type ProposalDto } from './support/api';
+import { openSession } from './support/session';
+import { readRunState, type RunState } from './support/run-state';
+
+/**
+ * Scenario 2 — the server-side visibility rules hardened in #267, asserted on
+ * both the UI and the API responses (the point is that filtering happens
+ * server-side, not in the client).
+ *
+ * Fixtures (created via the API as user A): one proposal per visibility level,
+ * each in Resourcing with one Open CFEOI, so the CFEOI directory can be checked
+ * against the parent proposal's visibility.
+ */
+
+let state: RunState;
+let apiA: Api;
+let apiB: Api;
+let anon: Api;
+
+const titles = { Public: '', Shared: '', Private: '' };
+const cfeoiTitles = { Public: '', Shared: '', Private: '' };
+let publicCfeoiId = '';
+
+let scope = '';
+
+test.beforeAll(async ({}, testInfo) => {
+  state = readRunState();
+  // Worker-scoped suffix: if Playwright restarts the worker after a failure,
+  // beforeAll runs again — fresh titles keep re-seeded fixtures unambiguous.
+  scope = `${state.runId}-w${testInfo.workerIndex}`;
+  apiA = await Api.forToken(state.identities.userA.token);
+  apiB = await Api.forToken(state.identities.userB.token);
+  anon = await Api.anonymous();
+
+  for (const visibility of ['Public', 'Shared', 'Private'] as const) {
+    titles[visibility] = `VM ${visibility} proposal (E2E ${scope})`;
+    cfeoiTitles[visibility] = `VM ${visibility} role (E2E ${scope})`;
+    const proposalId = await apiA.createProposal({
+      title: titles[visibility],
+      shortDescription: `Visibility-matrix fixture (${visibility}).`,
+      longDescription: 'Fixture proposal for the visibility matrix.',
+      organisationId: state.childOrgId,
+    });
+    await apiA.setProposalVisibility(proposalId, visibility);
+    await apiA.setProposalStatus(proposalId, 'Resourcing');
+    const cfeoiId = await apiA.publishCfeoi({
+      title: cfeoiTitles[visibility],
+      description: `Fixture CFEOI under the ${visibility} proposal.`,
+      resourceType: 'Human',
+      proposalId,
+    });
+    if (visibility === 'Public') publicCfeoiId = cfeoiId;
+  }
+});
+
+test.afterAll(async () => {
+  await Promise.all([apiA.dispose(), apiB.dispose(), anon.dispose()]);
+});
+
+const proposalTitles = (proposals: ProposalDto[]) => proposals.map((p) => p.title);
+const cfeoiNames = (cfeois: CfeoiDto[]) => cfeois.map((c) => c.title);
+
+async function searchProposals(page: Page, query: string) {
+  await page.goto('/proposals');
+  await page.getByPlaceholder('Search proposals by title or description...').fill(query);
+}
+
+async function searchCfeois(page: Page, query: string) {
+  await page.goto('/cfeois');
+  await page.getByPlaceholder('Search by title or tags…').fill(query);
+}
+
+test('anonymous callers receive only Public proposals (API + UI)', async ({ browser }) => {
+  const returned = proposalTitles(await anon.listProposals());
+  expect(returned).toContain(titles.Public);
+  expect(returned).not.toContain(titles.Shared);
+  expect(returned).not.toContain(titles.Private);
+
+  const { context, page } = await openSession(browser);
+  await searchProposals(page, `VM`);
+  await expect(page.getByRole('heading', { name: titles.Public })).toBeVisible();
+  await expect(page.getByRole('heading', { name: titles.Shared })).toBeHidden();
+  await expect(page.getByRole('heading', { name: titles.Private })).toBeHidden();
+  await context.close();
+});
+
+test('authenticated non-owner receives Public + Shared, never Private (API + UI)', async ({ browser }) => {
+  const returned = proposalTitles(await apiB.listProposals());
+  expect(returned).toContain(titles.Public);
+  expect(returned).toContain(titles.Shared);
+  expect(returned).not.toContain(titles.Private);
+
+  const { context, page } = await openSession(browser, 'userB');
+  await searchProposals(page, `VM`);
+  await expect(page.getByRole('heading', { name: titles.Public })).toBeVisible();
+  await expect(page.getByRole('heading', { name: titles.Shared })).toBeVisible();
+  await expect(page.getByRole('heading', { name: titles.Private })).toBeHidden();
+  await context.close();
+});
+
+test('the owner sees all three visibility levels (API + UI)', async ({ browser }) => {
+  const returned = proposalTitles(await apiA.listProposals());
+  expect(returned).toEqual(expect.arrayContaining([titles.Public, titles.Shared, titles.Private]));
+
+  const { context, page } = await openSession(browser, 'userA');
+  await searchProposals(page, `VM`);
+  await expect(page.getByRole('heading', { name: titles.Public })).toBeVisible();
+  await expect(page.getByRole('heading', { name: titles.Shared })).toBeVisible();
+  await expect(page.getByRole('heading', { name: titles.Private })).toBeVisible();
+  await context.close();
+});
+
+test('the CFEOI directory follows the parent proposal visibility', async ({ browser }) => {
+  const anonReturned = cfeoiNames(await anon.listCfeois({ status: 'Open' }));
+  expect(anonReturned).toContain(cfeoiTitles.Public);
+  expect(anonReturned).not.toContain(cfeoiTitles.Shared);
+  expect(anonReturned).not.toContain(cfeoiTitles.Private);
+
+  const bReturned = cfeoiNames(await apiB.listCfeois({ status: 'Open' }));
+  expect(bReturned).toContain(cfeoiTitles.Public);
+  expect(bReturned).toContain(cfeoiTitles.Shared);
+  expect(bReturned).not.toContain(cfeoiTitles.Private);
+
+  const aReturned = cfeoiNames(await apiA.listCfeois({ status: 'Open' }));
+  expect(aReturned).toEqual(expect.arrayContaining([cfeoiTitles.Public, cfeoiTitles.Shared, cfeoiTitles.Private]));
+
+  const anonSession = await openSession(browser);
+  await searchCfeois(anonSession.page, 'VM');
+  await expect(anonSession.page.getByRole('heading', { name: cfeoiTitles.Public })).toBeVisible();
+  await expect(anonSession.page.getByRole('heading', { name: cfeoiTitles.Shared })).toBeHidden();
+  await expect(anonSession.page.getByRole('heading', { name: cfeoiTitles.Private })).toBeHidden();
+  await anonSession.context.close();
+
+  const bSession = await openSession(browser, 'userB');
+  await searchCfeois(bSession.page, 'VM');
+  await expect(bSession.page.getByRole('heading', { name: cfeoiTitles.Public })).toBeVisible();
+  await expect(bSession.page.getByRole('heading', { name: cfeoiTitles.Shared })).toBeVisible();
+  await expect(bSession.page.getByRole('heading', { name: cfeoiTitles.Private })).toBeHidden();
+  await bSession.context.close();
+});
+
+test('a Private proposal detail is not rendered for anonymous visitors', async ({ browser }) => {
+  const privateProposal = (await apiA.listProposals()).find((p) => p.title === titles.Private)!;
+  const { context, page } = await openSession(browser);
+  await page.goto(`/proposals/${privateProposal.id}`);
+  await expect(page.getByText('This proposal is not publicly available.')).toBeVisible();
+  await context.close();
+});
+
+test("a Private EOI stays out of the owner's inbox until it is Shared", async ({ browser }) => {
+  const message = `VM inbox-privacy EOI (E2E ${state.runId})`;
+  const eoiId = await apiB.submitEoi(publicCfeoiId, message);
+
+  // While Private: not in the owner's inbox — UI and API.
+  const a = await openSession(browser, 'userA');
+  await a.page.goto(`/cfeois/${publicCfeoiId}/eois`);
+  await expect(a.page.getByText('No expressions of interest have been shared for this CFEOI yet.')).toBeVisible();
+  const whilePrivate = await apiA.listEoisByCfeoi(publicCfeoiId);
+  expect(whilePrivate.map((e) => e.id)).not.toContain(eoiId);
+
+  // After B flips it to Shared: visible to the owner — API and UI.
+  await apiB.setEoiVisibility(eoiId, 'Shared');
+  const whileShared = await apiA.listEoisByCfeoi(publicCfeoiId);
+  expect(whileShared.map((e) => e.id)).toContain(eoiId);
+
+  await a.page.reload();
+  await expect(a.page.getByText(message)).toBeVisible();
+  await a.context.close();
+
+  await apiB.withdrawEoi(eoiId);
+});

--- a/frontend/portal/package-lock.json
+++ b/frontend/portal/package-lock.json
@@ -24,6 +24,7 @@
         "tailwind-merge": "^2.6.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.1.0",
         "@testing-library/user-event": "^14.5.2",
@@ -31,6 +32,7 @@
         "@types/react-dom": "^18.3.5",
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "^10.4.20",
+        "jose": "^6.2.3",
         "jsdom": "^26.0.0",
         "postcss": "^8.4.49",
         "tailwindcss": "^3.4.17",
@@ -1017,6 +1019,21 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -3261,6 +3278,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3594,6 +3620,50 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/portal/package.json
+++ b/frontend/portal/package.json
@@ -10,7 +10,9 @@
     "preview": "vite preview",
     "test": "vitest",
     "test:ui": "vitest --ui",
-    "test:run": "vitest run"
+    "test:run": "vitest run",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@azure/msal-browser": "^3.27.0",
@@ -29,6 +31,7 @@
     "tailwind-merge": "^2.6.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",
@@ -36,6 +39,7 @@
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.20",
+    "jose": "^6.2.3",
     "jsdom": "^26.0.0",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",

--- a/frontend/portal/playwright.config.ts
+++ b/frontend/portal/playwright.config.ts
@@ -1,0 +1,64 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * E2E suite for the expat portal. Boots the real stack:
+ *  - Herit API in the dedicated E2E environment (test-auth scheme enabled,
+ *    SQL Server from appsettings.E2E.json — locally a Docker container on
+ *    port 14330, in CI a service container),
+ *  - the portal via Vite in `e2e` mode (test-auth MSAL stub enabled).
+ *
+ * See docs/frontend/portal/e2e-testing.md for the auth strategy and local setup.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  outputDir: './e2e/.results',
+  // Specs share one database and one seeded baseline; run serially.
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  forbidOnly: !!process.env.CI,
+  timeout: 90_000,
+  expect: { timeout: 10_000 },
+  reporter: process.env.CI
+    ? [['list'], ['html', { open: 'never', outputFolder: 'e2e/.report' }]]
+    : [['list']],
+  use: {
+    baseURL: 'http://localhost:5199',
+    trace: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'setup',
+      testMatch: /global\.setup\.ts/,
+      teardown: 'cleanup',
+    },
+    {
+      name: 'cleanup',
+      testMatch: /global\.teardown\.ts/,
+    },
+    {
+      name: 'chromium',
+      testMatch: /.*\.spec\.ts/,
+      use: { ...devices['Desktop Chrome'] },
+      dependencies: ['setup'],
+    },
+  ],
+  webServer: [
+    {
+      command: 'dotnet run --no-launch-profile --project ../../src/Herit.Api',
+      url: 'http://localhost:5299/api/v1/Organisations',
+      reuseExistingServer: !process.env.CI,
+      timeout: 240_000,
+      env: {
+        ASPNETCORE_ENVIRONMENT: 'E2E',
+        ASPNETCORE_URLS: 'http://localhost:5299',
+      },
+    },
+    {
+      command: 'npx vite --mode e2e --port 5199 --strictPort',
+      url: 'http://localhost:5199',
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+    },
+  ],
+});

--- a/frontend/portal/src/api/cfeois.ts
+++ b/frontend/portal/src/api/cfeois.ts
@@ -14,4 +14,4 @@ export const updateCfeoi = (id: string, data: PublishCfeoiRequest): Promise<void
   apiClient.put(`/Cfeoi/${id}`, data).then((r) => r.data);
 
 export const updateCfeoiStatus = (id: string, status: CfeoiStatus): Promise<void> =>
-  apiClient.patch(`/Cfeoi/${id}/status`, { status }).then((r) => r.data);
+  apiClient.patch(`/Cfeoi/${id}/status`, { newStatus: status }).then((r) => r.data);

--- a/frontend/portal/src/api/client.ts
+++ b/frontend/portal/src/api/client.ts
@@ -1,9 +1,15 @@
 import axios from 'axios';
-import { PublicClientApplication } from '@azure/msal-browser';
+import { PublicClientApplication, type IPublicClientApplication } from '@azure/msal-browser';
 import { msalConfig } from '../auth/msalConfig';
 import { apiScopes } from '../auth/authScopes';
+import { createTestMsalInstance } from '../auth/testAuth';
 
-const msalInstance = new PublicClientApplication(msalConfig);
+// The E2E branch is statically false outside the `e2e` Vite mode, so production
+// builds tree-shake the test-auth stub away entirely.
+const msalInstance: IPublicClientApplication =
+  import.meta.env.VITE_E2E_AUTH === 'true'
+    ? createTestMsalInstance()
+    : new PublicClientApplication(msalConfig);
 
 export const apiClient = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,

--- a/frontend/portal/src/auth/testAuth.ts
+++ b/frontend/portal/src/auth/testAuth.ts
@@ -1,0 +1,153 @@
+/**
+ * Test-only MSAL replacement for the Playwright E2E suite.
+ *
+ * When the app is built/served with VITE_E2E_AUTH=true (the `e2e` Vite mode),
+ * `client.ts` swaps the real PublicClientApplication for the fake returned by
+ * `createTestMsalInstance`. The fake reads a pre-minted API token and account
+ * details from localStorage (written by Playwright via storageState), so the
+ * rest of the app — MsalProvider, useIsAuthenticated, the axios interceptor —
+ * runs unchanged. Production builds never set VITE_E2E_AUTH, the conditional
+ * is statically false, and this module is tree-shaken out of the bundle; the
+ * API additionally refuses test tokens outside the E2E environment.
+ *
+ * localStorage contract (shared with frontend/portal/e2e):
+ * - `herit.e2e.auth`        — the signed-in identity: `{ token, account: { externalId, email, name } }`
+ * - `herit.e2e.pendingAuth` — identity that a call to loginRedirect() will sign
+ *                             in, simulating the Entra redirect round-trip.
+ * - `herit.e2e.loginRequested` — marker written whenever loginRedirect() is
+ *                             called, so tests can assert sign-in was prompted.
+ */
+import {
+  EventType,
+  InteractionType,
+  Logger,
+  LogLevel,
+  type AccountInfo,
+  type AuthenticationResult,
+  type EventCallbackFunction,
+  type EventMessage,
+  type IPublicClientApplication,
+} from '@azure/msal-browser';
+
+const AUTH_KEY = 'herit.e2e.auth';
+const PENDING_AUTH_KEY = 'herit.e2e.pendingAuth';
+const LOGIN_REQUESTED_KEY = 'herit.e2e.loginRequested';
+
+interface TestIdentity {
+  token: string;
+  account: {
+    externalId: string;
+    email: string;
+    name: string;
+  };
+}
+
+function readIdentity(key: string): TestIdentity | null {
+  const raw = window.localStorage.getItem(key);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as TestIdentity;
+  } catch {
+    return null;
+  }
+}
+
+function toAccountInfo(identity: TestIdentity): AccountInfo {
+  return {
+    homeAccountId: `${identity.account.externalId}.e2e`,
+    environment: 'e2e.local',
+    tenantId: 'e2e',
+    username: identity.account.email,
+    localAccountId: identity.account.externalId,
+    name: identity.account.name,
+  };
+}
+
+export function createTestMsalInstance(): IPublicClientApplication {
+  const eventCallbacks = new Map<string, EventCallbackFunction>();
+  let nextCallbackId = 0;
+
+  const emit = (eventType: EventType, payload: unknown = null) => {
+    const message: EventMessage = {
+      eventType,
+      interactionType: InteractionType.Redirect,
+      payload: payload as EventMessage['payload'],
+      error: null,
+      timestamp: Date.now(),
+    };
+    eventCallbacks.forEach((callback) => callback(message));
+  };
+
+  const getAccounts = (): AccountInfo[] => {
+    const identity = readIdentity(AUTH_KEY);
+    return identity ? [toAccountInfo(identity)] : [];
+  };
+
+  const fake = {
+    initialize: () => Promise.resolve(),
+    initializeWrapperLibrary: () => undefined,
+    handleRedirectPromise: () => Promise.resolve(null),
+
+    getLogger: () => new Logger({ loggerCallback: () => undefined, logLevel: LogLevel.Error }),
+    setLogger: () => undefined,
+
+    getAllAccounts: getAccounts,
+    getActiveAccount: () => getAccounts()[0] ?? null,
+    setActiveAccount: () => undefined,
+    getAccount: () => getAccounts()[0] ?? null,
+    getAccountByHomeId: () => getAccounts()[0] ?? null,
+    getAccountByLocalId: () => getAccounts()[0] ?? null,
+    getAccountByUsername: () => getAccounts()[0] ?? null,
+
+    addEventCallback: (callback: EventCallbackFunction) => {
+      const id = `e2e-callback-${nextCallbackId++}`;
+      eventCallbacks.set(id, callback);
+      return id;
+    },
+    removeEventCallback: (callbackId: string) => {
+      eventCallbacks.delete(callbackId);
+    },
+    enableAccountStorageEvents: () => undefined,
+    disableAccountStorageEvents: () => undefined,
+
+    acquireTokenSilent: (): Promise<AuthenticationResult> => {
+      const identity = readIdentity(AUTH_KEY);
+      if (!identity) return Promise.reject(new Error('E2E test auth: no signed-in identity.'));
+      return Promise.resolve({
+        accessToken: identity.token,
+        account: toAccountInfo(identity),
+        idToken: identity.token,
+        scopes: [],
+      } as unknown as AuthenticationResult);
+    },
+
+    loginRedirect: (request?: { scopes?: string[] }): Promise<void> => {
+      window.sessionStorage.setItem(
+        LOGIN_REQUESTED_KEY,
+        JSON.stringify({ scopes: request?.scopes ?? [], timestamp: Date.now() }),
+      );
+      const pending = readIdentity(PENDING_AUTH_KEY);
+      if (!pending) {
+        // No identity staged: record the attempt (asserted by tests) and stay put.
+        console.warn('[Herit E2E] loginRedirect called with no pending identity staged.');
+        return Promise.resolve();
+      }
+      window.localStorage.setItem(AUTH_KEY, JSON.stringify(pending));
+      window.localStorage.removeItem(PENDING_AUTH_KEY);
+      emit(EventType.LOGIN_SUCCESS, { account: toAccountInfo(pending) });
+      // Reload the current page: MSAL's redirect flow returns the user to the
+      // page that initiated the login (navigateToLoginRequestUrl default).
+      window.location.reload();
+      return Promise.resolve();
+    },
+
+    logoutRedirect: (request?: { postLogoutRedirectUri?: string | null }): Promise<void> => {
+      window.localStorage.removeItem(AUTH_KEY);
+      emit(EventType.LOGOUT_SUCCESS);
+      window.location.assign(request?.postLogoutRedirectUri ?? '/');
+      return Promise.resolve();
+    },
+  };
+
+  return fake as unknown as IPublicClientApplication;
+}

--- a/frontend/portal/src/routes/ProtectedRoute.tsx
+++ b/frontend/portal/src/routes/ProtectedRoute.tsx
@@ -1,5 +1,6 @@
 import { Navigate } from 'react-router-dom';
-import { useIsAuthenticated } from '@azure/msal-react';
+import { InteractionStatus } from '@azure/msal-browser';
+import { useIsAuthenticated, useMsal } from '@azure/msal-react';
 import { useCurrentUser } from '../hooks/useCurrentUser';
 
 interface ProtectedRouteProps {
@@ -8,7 +9,14 @@ interface ProtectedRouteProps {
 
 export default function ProtectedRoute({ children }: ProtectedRouteProps) {
   const isAuthenticated = useIsAuthenticated();
+  const { inProgress } = useMsal();
   const { user, isLoading, isNotFound, error } = useCurrentUser();
+
+  // useIsAuthenticated reports false until MSAL finishes starting up, so deciding
+  // before then would bounce signed-in users to /sign-in on a cold deep-link.
+  if (inProgress !== InteractionStatus.None) {
+    return null;
+  }
 
   if (!isAuthenticated) {
     return <Navigate to="/sign-in" replace />;

--- a/frontend/portal/vite.config.ts
+++ b/frontend/portal/vite.config.ts
@@ -7,5 +7,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './src/test-setup.ts',
+    // Playwright E2E specs live in e2e/ and are run by `npm run e2e`, not vitest.
+    exclude: ['node_modules/**', 'e2e/**'],
   },
 });

--- a/src/Herit.Api/Authentication/TestAuthentication.cs
+++ b/src/Herit.Api/Authentication/TestAuthentication.cs
@@ -1,0 +1,76 @@
+using System.Text;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Herit.Api.Authentication;
+
+/// <summary>
+/// Symmetric-key JWT authentication used exclusively by the Playwright E2E suite.
+/// Tokens are minted by the test harness with the shared signing key from
+/// <c>TestAuth:SigningKey</c> and carry the same claims the API reads from Entra
+/// tokens (<c>oid</c>, <c>email</c>, <c>name</c>), so the whole downstream pipeline
+/// (JIT registration, role resolution, visibility policies) runs unchanged.
+/// The scheme can never be active in Production: <see cref="IsEnabled"/> requires
+/// both the config flag and a non-Production environment, and no shipped
+/// configuration sets the flag.
+/// </summary>
+public static class TestAuthentication
+{
+    public const string Scheme = "TestAuth";
+    public const string Issuer = "https://herit-e2e.local";
+    public const string Audience = "herit-api-e2e";
+    private const string SelectorScheme = "TestAuthSelector";
+
+    public static bool IsEnabled(IConfiguration configuration, IHostEnvironment environment)
+        => configuration.GetValue<bool>("TestAuth:Enabled") && !environment.IsProduction();
+
+    public static void AddTestAuthentication(this WebApplicationBuilder builder)
+    {
+        var signingKey = builder.Configuration["TestAuth:SigningKey"];
+        if (string.IsNullOrWhiteSpace(signingKey))
+            throw new InvalidOperationException("TestAuth:SigningKey must be configured when TestAuth is enabled.");
+
+        builder.Services.AddAuthentication(options =>
+        {
+            options.DefaultAuthenticateScheme = SelectorScheme;
+            options.DefaultChallengeScheme = SelectorScheme;
+        })
+        .AddJwtBearer(Scheme, options =>
+        {
+            // Keep raw JWT claim names so ICurrentUserService sees "oid"/"email"/"name"
+            // exactly as it does for Entra-issued tokens.
+            options.MapInboundClaims = false;
+            options.TokenValidationParameters = new TokenValidationParameters
+            {
+                ValidIssuer = Issuer,
+                ValidAudience = Audience,
+                IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(signingKey)),
+                ValidateIssuer = true,
+                ValidateAudience = true,
+                ValidateIssuerSigningKey = true,
+                ValidateLifetime = true,
+            };
+        })
+        .AddPolicyScheme(SelectorScheme, SelectorScheme, options =>
+        {
+            // Route bearer tokens with the E2E issuer to the test scheme; everything
+            // else continues to the regular Entra JWT bearer scheme.
+            options.ForwardDefaultSelector = context =>
+                HasTestIssuer(context.Request.Headers.Authorization.ToString())
+                    ? Scheme
+                    : JwtBearerDefaults.AuthenticationScheme;
+        });
+    }
+
+    private static bool HasTestIssuer(string authorizationHeader)
+    {
+        const string bearerPrefix = "Bearer ";
+        if (!authorizationHeader.StartsWith(bearerPrefix, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var token = authorizationHeader[bearerPrefix.Length..];
+        var handler = new JsonWebTokenHandler();
+        return handler.CanReadToken(token) && new JsonWebToken(token).Issuer == Issuer;
+    }
+}

--- a/src/Herit.Api/Controllers/EoiController.cs
+++ b/src/Herit.Api/Controllers/EoiController.cs
@@ -71,7 +71,7 @@ public class EoiController : ControllerBase
     }
 
     [HttpPatch("{id:guid}/status")]
-    [Authorize(Policy = "Staff")]
+    [Authorize(Policy = "StaffOrExpat")]
     public async Task<IActionResult> UpdateStatus(Guid id, [FromBody] UpdateEoiStatusCommand command, CancellationToken ct)
     {
         await _mediator.Send(command with { Id = id }, ct);

--- a/src/Herit.Api/Middleware/GlobalExceptionHandler.cs
+++ b/src/Herit.Api/Middleware/GlobalExceptionHandler.cs
@@ -20,6 +20,12 @@ public class GlobalExceptionHandler(ILogger<GlobalExceptionHandler> logger) : IE
                 Title = "Not Found",
                 Detail = exception.Message
             },
+            ForbiddenException => new ProblemDetails
+            {
+                Status = StatusCodes.Status403Forbidden,
+                Title = "Forbidden",
+                Detail = exception.Message
+            },
             InvalidOperationException => new ProblemDetails
             {
                 Status = StatusCodes.Status400BadRequest,

--- a/src/Herit.Api/Program.cs
+++ b/src/Herit.Api/Program.cs
@@ -1,5 +1,6 @@
 using Azure.Identity;
 using FluentValidation;
+using Herit.Api.Authentication;
 using Herit.Api.Authorization;
 using Herit.Api.Middleware;
 using Herit.Api.Services;
@@ -10,6 +11,7 @@ using Herit.Application.Seeding;
 using Herit.Domain.Enums;
 using Herit.Infrastructure;
 using Herit.Infrastructure.Persistence;
+using Herit.Infrastructure.Services;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
@@ -52,6 +54,12 @@ var connectionString = (!string.IsNullOrEmpty(connectionStringKey)
     ?? builder.Configuration.GetConnectionString("DefaultConnection")!;
 
 builder.Services.AddInfrastructure(connectionString);
+
+if (TestAuthentication.IsEnabled(builder.Configuration, builder.Environment))
+{
+    builder.AddTestAuthentication();
+    builder.Services.AddScoped<IIdentityProviderService, LocalTestIdentityProviderService>();
+}
 
 builder.Services.AddAuthorizationBuilder()
     .AddPolicy("SuperAdmin", policy =>
@@ -132,6 +140,9 @@ static async Task<int> RunSeedSuperAdminAsync(string[] args)
 
     seedBuilder.Services.AddInfrastructure(seedConnectionString);
     seedBuilder.Services.AddScoped<SuperAdminSeeder>();
+
+    if (TestAuthentication.IsEnabled(seedBuilder.Configuration, seedBuilder.Environment))
+        seedBuilder.Services.AddScoped<IIdentityProviderService, LocalTestIdentityProviderService>();
 
     var seedApp = seedBuilder.Build();
 

--- a/src/Herit.Api/appsettings.E2E.json
+++ b/src/Herit.Api/appsettings.E2E.json
@@ -1,0 +1,32 @@
+{
+  // Configuration for running the API under the Playwright E2E suite
+  // (ASPNETCORE_ENVIRONMENT=E2E). Never used by production deployments.
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "Features": {
+    "EnableSwagger": false
+  },
+  "AllowedOrigins": [ "http://localhost:5199" ],
+  // Placeholder values: the Entra scheme is registered but no Entra tokens are
+  // ever presented during E2E runs — all requests carry TestAuth tokens.
+  "AzureAd": {
+    "Instance": "https://e2e-placeholder.ciamlogin.com",
+    "Domain": "e2e-placeholder.onmicrosoft.com",
+    "TenantId": "00000000-0000-0000-0000-000000000000",
+    "ClientId": "00000000-0000-0000-0000-000000000001"
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost,14330;Database=HeritE2E;User Id=sa;Password=HeritE2e!Passw0rd;TrustServerCertificate=True;Encrypt=False"
+  },
+  // This key only ever protects throwaway E2E identities; it is intentionally
+  // checked in so local runs and CI share it. TestAuth cannot be enabled in
+  // Production regardless of configuration.
+  "TestAuth": {
+    "Enabled": true,
+    "SigningKey": "herit-e2e-signing-key-not-a-secret-0123456789abcdef0123456789abcdef"
+  }
+}

--- a/src/Herit.Application/Exceptions/ForbiddenException.cs
+++ b/src/Herit.Application/Exceptions/ForbiddenException.cs
@@ -1,0 +1,6 @@
+namespace Herit.Application.Exceptions;
+
+public class ForbiddenException : Exception
+{
+    public ForbiddenException(string message) : base(message) { }
+}

--- a/src/Herit.Application/Features/Eoi/Commands/UpdateEoiStatus/UpdateEoiStatusCommand.cs
+++ b/src/Herit.Application/Features/Eoi/Commands/UpdateEoiStatus/UpdateEoiStatusCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Authorization;
 using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
@@ -10,10 +11,20 @@ public record UpdateEoiStatusCommand(Guid Id, EoiStatus NewStatus) : IRequest<Un
 public class UpdateEoiStatusCommandHandler : IRequestHandler<UpdateEoiStatusCommand, Unit>
 {
     private readonly IEoiRepository _repository;
+    private readonly ICfeoiRepository _cfeoiRepository;
+    private readonly IProposalRepository _proposalRepository;
+    private readonly ICurrentUserService _currentUserService;
 
-    public UpdateEoiStatusCommandHandler(IEoiRepository repository)
+    public UpdateEoiStatusCommandHandler(
+        IEoiRepository repository,
+        ICfeoiRepository cfeoiRepository,
+        IProposalRepository proposalRepository,
+        ICurrentUserService currentUserService)
     {
         _repository = repository;
+        _cfeoiRepository = cfeoiRepository;
+        _proposalRepository = proposalRepository;
+        _currentUserService = currentUserService;
     }
 
     public async Task<Unit> Handle(UpdateEoiStatusCommand request, CancellationToken cancellationToken)
@@ -21,6 +32,20 @@ public class UpdateEoiStatusCommandHandler : IRequestHandler<UpdateEoiStatusComm
         var eoi = await _repository.GetByIdAsync(request.Id, cancellationToken);
         if (eoi is null)
             throw new NotFoundException($"Eoi '{request.Id}' does not exist.");
+
+        // Staff may review any EOI; an expat may only review EOIs on CFEOIs that
+        // belong to a proposal they own (flow 3d).
+        var user = await _currentUserService.GetCurrentUserAsync(cancellationToken);
+        if (!VisibilityPolicy.IsStaff(user))
+        {
+            var cfeoi = await _cfeoiRepository.GetByIdAsync(eoi.CfeoiId, cancellationToken);
+            var proposal = cfeoi is null
+                ? null
+                : await _proposalRepository.GetByIdAsync(cfeoi.ProposalId, cancellationToken);
+
+            if (proposal is null || proposal.AuthorId != user.Id)
+                throw new ForbiddenException("Only the owner of the parent proposal may update the status of this EOI.");
+        }
 
         eoi.TransitionStatus(request.NewStatus);
         await _repository.UpdateAsync(eoi, cancellationToken);

--- a/src/Herit.Infrastructure/Services/LocalTestIdentityProviderService.cs
+++ b/src/Herit.Infrastructure/Services/LocalTestIdentityProviderService.cs
@@ -1,0 +1,20 @@
+using Herit.Application.Interfaces;
+
+namespace Herit.Infrastructure.Services;
+
+/// <summary>
+/// Deterministic in-process replacement for <see cref="EntraExternalIdIdentityProviderService"/>,
+/// registered only when E2E test authentication is enabled. It never talks to Microsoft Graph;
+/// the returned external ID is derived from the email so the test harness can mint matching
+/// tokens without reading seeder output.
+/// </summary>
+public class LocalTestIdentityProviderService : IIdentityProviderService
+{
+    public const string ExternalIdPrefix = "e2e-";
+
+    public Task<string> CreateUserAsync(string email, string displayName, CancellationToken ct)
+        => Task.FromResult(ExternalIdPrefix + email);
+
+    public Task DeleteUserAsync(string externalId, CancellationToken ct)
+        => Task.CompletedTask;
+}

--- a/tests/Herit.Application.Tests/Features/Eoi/Commands/UpdateEoiStatusCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Eoi/Commands/UpdateEoiStatusCommandHandlerTests.cs
@@ -3,29 +3,54 @@ using Herit.Application.Features.Eoi.Commands.UpdateEoiStatus;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
 using NSubstitute;
+using CfeoiEntity = Herit.Domain.Entities.Cfeoi;
 using EoiEntity = Herit.Domain.Entities.Eoi;
+using ProposalEntity = Herit.Domain.Entities.Proposal;
+using UserEntity = Herit.Domain.Entities.User;
 
 namespace Herit.Application.Tests.Features.Eoi.Commands;
 
 public class UpdateEoiStatusCommandHandlerTests
 {
     private readonly IEoiRepository _repository = Substitute.For<IEoiRepository>();
+    private readonly ICfeoiRepository _cfeoiRepository = Substitute.For<ICfeoiRepository>();
+    private readonly IProposalRepository _proposalRepository = Substitute.For<IProposalRepository>();
+    private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
     private readonly UpdateEoiStatusCommandHandler _handler;
+
+    private static readonly Guid OwnerId = Guid.NewGuid();
+    private static readonly Guid CfeoiId = Guid.NewGuid();
+    private static readonly Guid ProposalId = Guid.NewGuid();
 
     public UpdateEoiStatusCommandHandlerTests()
     {
-        _handler = new UpdateEoiStatusCommandHandler(_repository);
+        _handler = new UpdateEoiStatusCommandHandler(_repository, _cfeoiRepository, _proposalRepository, _currentUserService);
     }
 
     private static EoiEntity CreatePendingEoi(Guid id)
-        => EoiEntity.Create(id, Guid.NewGuid(), "Message", Guid.NewGuid());
+        => EoiEntity.Create(id, Guid.NewGuid(), "Message", CfeoiId);
+
+    private static UserEntity CreateUser(Guid id, UserRole role)
+        => UserEntity.Create(id, $"ext-{id}", "user@example.com", "Test User", role);
+
+    private void SetCurrentUser(UserEntity user)
+        => _currentUserService.GetCurrentUserAsync(Arg.Any<CancellationToken>()).Returns(user);
+
+    private void SetUpOwnedProposalChain()
+    {
+        _cfeoiRepository.GetByIdAsync(CfeoiId, Arg.Any<CancellationToken>())
+            .Returns(CfeoiEntity.Create(CfeoiId, "Title", "Description", CfeoiResourceType.Human, ProposalId));
+        _proposalRepository.GetByIdAsync(ProposalId, Arg.Any<CancellationToken>())
+            .Returns(ProposalEntity.Create(ProposalId, "Title", "Short", OwnerId, Guid.NewGuid(), "Long"));
+    }
 
     [Fact]
-    public async Task Handle_PendingToApproved_CallsUpdateAsyncOnce()
+    public async Task Handle_PendingToApproved_AsStaff_CallsUpdateAsyncOnce()
     {
         var id = Guid.NewGuid();
         var eoi = CreatePendingEoi(id);
         _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(eoi);
+        SetCurrentUser(CreateUser(Guid.NewGuid(), UserRole.Staff));
 
         var result = await _handler.Handle(new UpdateEoiStatusCommand(id, EoiStatus.Approved), CancellationToken.None);
 
@@ -35,17 +60,48 @@ public class UpdateEoiStatusCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_PendingToRejected_CallsUpdateAsyncOnce()
+    public async Task Handle_PendingToRejected_AsStaff_CallsUpdateAsyncOnce()
     {
         var id = Guid.NewGuid();
         var eoi = CreatePendingEoi(id);
         _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(eoi);
+        SetCurrentUser(CreateUser(Guid.NewGuid(), UserRole.Staff));
 
         var result = await _handler.Handle(new UpdateEoiStatusCommand(id, EoiStatus.Rejected), CancellationToken.None);
 
         Assert.Equal(MediatR.Unit.Value, result);
         Assert.Equal(EoiStatus.Rejected, eoi.Status);
         await _repository.Received(1).UpdateAsync(eoi, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_AsExpatProposalOwner_CallsUpdateAsyncOnce()
+    {
+        var id = Guid.NewGuid();
+        var eoi = CreatePendingEoi(id);
+        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(eoi);
+        SetCurrentUser(CreateUser(OwnerId, UserRole.Expat));
+        SetUpOwnedProposalChain();
+
+        var result = await _handler.Handle(new UpdateEoiStatusCommand(id, EoiStatus.Approved), CancellationToken.None);
+
+        Assert.Equal(MediatR.Unit.Value, result);
+        Assert.Equal(EoiStatus.Approved, eoi.Status);
+        await _repository.Received(1).UpdateAsync(eoi, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_AsExpatNonOwner_ThrowsForbiddenException()
+    {
+        var id = Guid.NewGuid();
+        var eoi = CreatePendingEoi(id);
+        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(eoi);
+        SetCurrentUser(CreateUser(Guid.NewGuid(), UserRole.Expat));
+        SetUpOwnedProposalChain();
+
+        await Assert.ThrowsAsync<ForbiddenException>(
+            () => _handler.Handle(new UpdateEoiStatusCommand(id, EoiStatus.Approved), CancellationToken.None));
+        await _repository.DidNotReceive().UpdateAsync(Arg.Any<EoiEntity>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -66,6 +122,7 @@ public class UpdateEoiStatusCommandHandlerTests
         var eoi = CreatePendingEoi(id);
         eoi.TransitionStatus(EoiStatus.Approved);
         _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(eoi);
+        SetCurrentUser(CreateUser(Guid.NewGuid(), UserRole.Staff));
 
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => _handler.Handle(new UpdateEoiStatusCommand(id, EoiStatus.Pending), CancellationToken.None));


### PR DESCRIPTION
## Description

Adds the Playwright E2E regression net from #270: 17 tests exercising the seams between portal flows 1, 2, and 3a–3e against the real stack (API + SQL Server + Vite-served SPA), plus the test-only auth plumbing it requires. Full write-up in `docs/frontend/portal/e2e-testing.md`.

### Authentication strategy (the design decision requested in the issue)

MSAL/Entra with Google federation can't be driven headlessly, so E2E runs swap **both ends of the token exchange** and leave everything in between (axios interceptor, JIT registration, role resolution, visibility policies) untouched:

- **API** — a test-only HS256 JWT bearer scheme (`TestAuthentication.cs`), enabled by `TestAuth:Enabled` in `appsettings.E2E.json` and **hard-disabled in the Production environment regardless of configuration**. A policy scheme routes tokens by issuer, so the Entra scheme stays registered unchanged. The same flag swaps the Microsoft Graph identity provider for a deterministic local fake (`externalId = "e2e-" + email`), which lets the existing CLI super-admin seeder and staff endpoints run offline.
- **SPA** — a fake `IPublicClientApplication` (`src/auth/testAuth.ts`) active only in the dedicated `e2e` Vite mode. It reads pre-minted tokens from localStorage via Playwright `storageState`; `loginRedirect()` consumes a staged identity and reloads, simulating the redirect round-trip so scenario 1 drives the real sign-in UI. Production builds statically eliminate the stub (verified the bundle contains no trace of it).
- **Tokens** are minted in-process by the harness with `jose` — no test-token endpoint was added.

This supports the required identities per run: anonymous, expat A (owner) + a never-registered A1 for genuine first-time JIT, expat B (contributor), and an API-only super admin used in setup.

### Seeding

Global setup goes through the same paths production uses, in dependency order: CLI super-admin seeder → organisation hierarchy via `OrganisationController` → staff user + Published RFP → expats JIT-registered via `GET /Users/me` + terms via `PATCH /Users/me/profile`. All data is run-scoped by ID; teardown is best-effort via the API (documented: CFEOIs and withdrawn proposals have no delete path).

### Product bugs the suite caught (fixed here — scenario 1 cannot pass otherwise)

1. **EOI approve/reject was Staff-only** (`PATCH /Eoi/{id}/status`), 403-ing the expat proposal owner that flow 3d says reviews the inbox. Now `StaffOrExpat` with an ownership check in the handler (non-staff caller must own the parent proposal; new `ForbiddenException` → 403). Unit tests extended.
2. **`ProtectedRoute` bounced signed-in cold deep-links to `/sign-in`** — `useIsAuthenticated()` reports `false` while MSAL is starting up. It now waits for `InteractionStatus.None` before deciding.
3. **Close CFEOI always failed**: the client sent `{ status }` where the API binds `newStatus`, deserialising to the default `Open` and rejecting the transition.

### CI

New `e2e` job with a SQL Server 2022 service container; Playwright report/traces uploaded on failure; the `cd` deploy job now requires both `ci` and `e2e`.

## Linked Issue

Closes #270

## Type of Change

- [x] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- Full suite green locally (17/17, ~25s) including a cold start where Playwright boots API + Vite itself, against a fresh SQL Server container.
- `dotnet build`/`dotnet test` Release: 257 tests pass. Portal `npm run build` + vitest pass; verified the prod bundle contains no test-auth stub.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [x] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)