### PR TITLE
Enforce per-actor authorization on mutating command handlers

### DIFF
--- a/docs/frontend/portal/user-flows-high-level.md
+++ b/docs/frontend/portal/user-flows-high-level.md
@@ -30,6 +30,7 @@
 - Note: Email subscription for unauthenticated users is out-of-scope and is not shown.
 
 ### 2) Authentication (Sign in with Google → JIT registration)
+- Note (implementation clarification): "Sign in with Google" means Google acts as a **federated identity provider through Microsoft Entra ID** — it is not a direct Google OAuth integration. The frontend authenticates via MSAL (`frontend/portal/src/auth/msalConfig.ts`), the API validates Entra-issued tokens via Microsoft.Identity.Web (`AddMicrosoftIdentityWebApiAuthentication` in `Program.cs`), and user roles are resolved from the application database (`ICurrentUserService`), not from token claims. The "Sign in with Google" label remains correct from the user's perspective.
 - Start: Sign in with Google
 - Node 1: Google OAuth flow (success/failure)
   - Failure → Error / retry or Contact Support (end)

--- a/frontend/portal/e2e/seams.spec.ts
+++ b/frontend/portal/e2e/seams.spec.ts
@@ -20,6 +20,7 @@ let pendingCfeoiTitle = '';
 let approvedCfeoiTitle = '';
 let rejectedCfeoiTitle = '';
 let pendingCfeoiId = '';
+let hostProposalId = '';
 
 let scope = '';
 
@@ -37,6 +38,7 @@ test.beforeAll(async ({}, testInfo) => {
     longDescription: 'Fixture proposal owning the CFEOIs used by scenario 3.',
     organisationId: state.childOrgId,
   });
+  hostProposalId = proposalId;
   await apiA.setProposalVisibility(proposalId, 'Shared');
   await apiA.setProposalStatus(proposalId, 'Resourcing');
 
@@ -148,4 +150,9 @@ test("a non-owner cannot reach another user's EOI inbox", async ({ browser }) =>
   await expect(page.getByRole('heading', { name: 'Cannot view this inbox' })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Approve' })).toBeHidden();
   await context.close();
+});
+
+test("expat B mutating expat A's proposal is rejected with 403 at the API", async () => {
+  const response = await apiB.raw('PATCH', `/Proposals/${hostProposalId}/status`, JSON.stringify('Submitted'));
+  expect(response.status()).toBe(403);
 });

--- a/frontend/portal/e2e/support/api.ts
+++ b/frontend/portal/e2e/support/api.ts
@@ -86,7 +86,11 @@ export class Api {
 
   /** Raw fetch that does not throw — for asserting on status codes. */
   async raw(method: string, url: string, data?: unknown): Promise<APIResponse> {
-    return this.ctx.fetch(`/api/v1${url}`, { method, data });
+    return this.ctx.fetch(`/api/v1${url}`, {
+      method,
+      data,
+      headers: { 'Content-Type': 'application/json' },
+    });
   }
 
   // --- Users ---

--- a/src/Herit.Application/Authorization/MutationPolicy.cs
+++ b/src/Herit.Application/Authorization/MutationPolicy.cs
@@ -1,0 +1,61 @@
+using Herit.Domain.Entities;
+using Herit.Domain.Enums;
+
+namespace Herit.Application.Authorization;
+
+/// <summary>
+/// Central authorization rules that decide which caller may perform a given mutation.
+/// These mirror the actor rules in the portal user-flow spec (§3b–3e) and the PRD
+/// (§3.3–3.4, §6) and are enforced server-side, alongside <see cref="VisibilityPolicy"/>,
+/// so that ownership and role are never assumed from a coarse controller-level policy alone.
+/// </summary>
+public static class MutationPolicy
+{
+    /// <summary>
+    /// Proposal content, visibility, and delete are owner actions; staff may also delete
+    /// a proposal (PRD §6.1 S7).
+    /// </summary>
+    public static bool CanUpdateProposal(Proposal proposal, User user)
+        => proposal.AuthorId == user.Id;
+
+    public static bool CanSetProposalVisibility(Proposal proposal, User user)
+        => proposal.AuthorId == user.Id;
+
+    public static bool CanDeleteProposal(Proposal proposal, User user)
+        => proposal.AuthorId == user.Id || VisibilityPolicy.IsStaff(user);
+
+    /// <summary>
+    /// Per-transition actor rules for proposal status (flow 3b): the owner drives
+    /// Ideation → Resourcing → Submitted and Submitted → Withdrawn; staff drive
+    /// Submitted → UnderReview → Approved. An owner may not approve their own
+    /// proposal, and staff may not withdraw a proposal on the owner's behalf.
+    /// </summary>
+    public static bool CanTransitionProposalStatus(Proposal proposal, User user, ProposalStatus newStatus)
+    {
+        var isOwner = proposal.AuthorId == user.Id;
+        var isStaff = VisibilityPolicy.IsStaff(user);
+
+        return newStatus switch
+        {
+            ProposalStatus.Resourcing => isOwner,
+            ProposalStatus.Submitted => isOwner,
+            ProposalStatus.Withdrawn => isOwner,
+            ProposalStatus.UnderReview => isStaff,
+            ProposalStatus.Approved => isStaff,
+            _ => false
+        };
+    }
+
+    /// <summary>
+    /// CFEOI update/close are actions for the owner of the parent proposal; staff may
+    /// also publish, update, and close CFEOIs (PRD §6.1 S8).
+    /// </summary>
+    public static bool CanMutateCfeoi(Proposal parentProposal, User user)
+        => parentProposal.AuthorId == user.Id || VisibilityPolicy.IsStaff(user);
+
+    /// <summary>
+    /// EOI visibility and withdrawal are actions for the submitter only (flow 3e).
+    /// </summary>
+    public static bool CanMutateEoi(Eoi eoi, User user)
+        => eoi.SubmittedById == user.Id;
+}

--- a/src/Herit.Application/Features/Cfeoi/Commands/PublishCfeoi/PublishCfeoiCommand.cs
+++ b/src/Herit.Application/Features/Cfeoi/Commands/PublishCfeoi/PublishCfeoiCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Authorization;
 using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
@@ -17,11 +18,16 @@ public class PublishCfeoiCommandHandler : IRequestHandler<PublishCfeoiCommand, G
 {
     private readonly ICfeoiRepository _cfeoiRepository;
     private readonly IProposalRepository _proposalRepository;
+    private readonly ICurrentUserService _currentUserService;
 
-    public PublishCfeoiCommandHandler(ICfeoiRepository cfeoiRepository, IProposalRepository proposalRepository)
+    public PublishCfeoiCommandHandler(
+        ICfeoiRepository cfeoiRepository,
+        IProposalRepository proposalRepository,
+        ICurrentUserService currentUserService)
     {
         _cfeoiRepository = cfeoiRepository;
         _proposalRepository = proposalRepository;
+        _currentUserService = currentUserService;
     }
 
     public async Task<Guid> Handle(PublishCfeoiCommand request, CancellationToken cancellationToken)
@@ -29,6 +35,10 @@ public class PublishCfeoiCommandHandler : IRequestHandler<PublishCfeoiCommand, G
         var proposal = await _proposalRepository.GetByIdAsync(request.ProposalId, cancellationToken);
         if (proposal is null)
             throw new NotFoundException($"Proposal '{request.ProposalId}' does not exist.");
+
+        var user = await _currentUserService.GetCurrentUserAsync(cancellationToken);
+        if (!MutationPolicy.CanMutateCfeoi(proposal, user))
+            throw new ForbiddenException("Only the owner of this proposal, or staff, may publish a CFEOI under it.");
 
         var id = Guid.NewGuid();
         var cfeoi = CfeoiEntity.Create(

--- a/src/Herit.Application/Features/Cfeoi/Commands/UpdateCfeoi/UpdateCfeoiCommand.cs
+++ b/src/Herit.Application/Features/Cfeoi/Commands/UpdateCfeoi/UpdateCfeoiCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Authorization;
 using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
@@ -15,10 +16,17 @@ public record UpdateCfeoiCommand(
 public class UpdateCfeoiCommandHandler : IRequestHandler<UpdateCfeoiCommand, Unit>
 {
     private readonly ICfeoiRepository _cfeoiRepository;
+    private readonly IProposalRepository _proposalRepository;
+    private readonly ICurrentUserService _currentUserService;
 
-    public UpdateCfeoiCommandHandler(ICfeoiRepository cfeoiRepository)
+    public UpdateCfeoiCommandHandler(
+        ICfeoiRepository cfeoiRepository,
+        IProposalRepository proposalRepository,
+        ICurrentUserService currentUserService)
     {
         _cfeoiRepository = cfeoiRepository;
+        _proposalRepository = proposalRepository;
+        _currentUserService = currentUserService;
     }
 
     public async Task<Unit> Handle(UpdateCfeoiCommand request, CancellationToken cancellationToken)
@@ -26,6 +34,11 @@ public class UpdateCfeoiCommandHandler : IRequestHandler<UpdateCfeoiCommand, Uni
         var cfeoi = await _cfeoiRepository.GetByIdAsync(request.Id, cancellationToken);
         if (cfeoi is null)
             throw new NotFoundException($"Cfeoi '{request.Id}' does not exist.");
+
+        var user = await _currentUserService.GetCurrentUserAsync(cancellationToken);
+        var proposal = await _proposalRepository.GetByIdAsync(cfeoi.ProposalId, cancellationToken);
+        if (proposal is null || !MutationPolicy.CanMutateCfeoi(proposal, user))
+            throw new ForbiddenException("Only the owner of the parent proposal, or staff, may update this CFEOI.");
 
         cfeoi.Update(
             request.Title,

--- a/src/Herit.Application/Features/Cfeoi/Commands/UpdateCfeoiStatus/UpdateCfeoiStatusCommand.cs
+++ b/src/Herit.Application/Features/Cfeoi/Commands/UpdateCfeoiStatus/UpdateCfeoiStatusCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Authorization;
 using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
@@ -10,10 +11,17 @@ public record UpdateCfeoiStatusCommand(Guid Id, CfeoiStatus NewStatus) : IReques
 public class UpdateCfeoiStatusCommandHandler : IRequestHandler<UpdateCfeoiStatusCommand, Unit>
 {
     private readonly ICfeoiRepository _repository;
+    private readonly IProposalRepository _proposalRepository;
+    private readonly ICurrentUserService _currentUserService;
 
-    public UpdateCfeoiStatusCommandHandler(ICfeoiRepository repository)
+    public UpdateCfeoiStatusCommandHandler(
+        ICfeoiRepository repository,
+        IProposalRepository proposalRepository,
+        ICurrentUserService currentUserService)
     {
         _repository = repository;
+        _proposalRepository = proposalRepository;
+        _currentUserService = currentUserService;
     }
 
     public async Task<Unit> Handle(UpdateCfeoiStatusCommand request, CancellationToken cancellationToken)
@@ -21,6 +29,11 @@ public class UpdateCfeoiStatusCommandHandler : IRequestHandler<UpdateCfeoiStatus
         var cfeoi = await _repository.GetByIdAsync(request.Id, cancellationToken);
         if (cfeoi is null)
             throw new NotFoundException($"Cfeoi '{request.Id}' does not exist.");
+
+        var user = await _currentUserService.GetCurrentUserAsync(cancellationToken);
+        var proposal = await _proposalRepository.GetByIdAsync(cfeoi.ProposalId, cancellationToken);
+        if (proposal is null || !MutationPolicy.CanMutateCfeoi(proposal, user))
+            throw new ForbiddenException("Only the owner of the parent proposal, or staff, may close this CFEOI.");
 
         cfeoi.TransitionStatus(request.NewStatus);
         await _repository.UpdateAsync(cfeoi, cancellationToken);

--- a/src/Herit.Application/Features/Eoi/Commands/SetEoiVisibility/SetEoiVisibilityCommand.cs
+++ b/src/Herit.Application/Features/Eoi/Commands/SetEoiVisibility/SetEoiVisibilityCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Authorization;
 using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
@@ -10,10 +11,12 @@ public record SetEoiVisibilityCommand(Guid Id, EoiVisibility Visibility) : IRequ
 public class SetEoiVisibilityCommandHandler : IRequestHandler<SetEoiVisibilityCommand, Unit>
 {
     private readonly IEoiRepository _eoiRepository;
+    private readonly ICurrentUserService _currentUserService;
 
-    public SetEoiVisibilityCommandHandler(IEoiRepository eoiRepository)
+    public SetEoiVisibilityCommandHandler(IEoiRepository eoiRepository, ICurrentUserService currentUserService)
     {
         _eoiRepository = eoiRepository;
+        _currentUserService = currentUserService;
     }
 
     public async Task<Unit> Handle(SetEoiVisibilityCommand request, CancellationToken cancellationToken)
@@ -21,6 +24,10 @@ public class SetEoiVisibilityCommandHandler : IRequestHandler<SetEoiVisibilityCo
         var eoi = await _eoiRepository.GetByIdAsync(request.Id, cancellationToken);
         if (eoi is null)
             throw new NotFoundException($"Eoi '{request.Id}' does not exist.");
+
+        var user = await _currentUserService.GetCurrentUserAsync(cancellationToken);
+        if (!MutationPolicy.CanMutateEoi(eoi, user))
+            throw new ForbiddenException("Only the submitter of this EOI may change its visibility.");
 
         eoi.SetVisibility(request.Visibility);
         await _eoiRepository.UpdateAsync(eoi, cancellationToken);

--- a/src/Herit.Application/Features/Eoi/Commands/WithdrawEoi/WithdrawEoiCommand.cs
+++ b/src/Herit.Application/Features/Eoi/Commands/WithdrawEoi/WithdrawEoiCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Authorization;
 using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using MediatR;
@@ -9,10 +10,12 @@ public record WithdrawEoiCommand(Guid Id) : IRequest<Unit>;
 public class WithdrawEoiCommandHandler : IRequestHandler<WithdrawEoiCommand, Unit>
 {
     private readonly IEoiRepository _eoiRepository;
+    private readonly ICurrentUserService _currentUserService;
 
-    public WithdrawEoiCommandHandler(IEoiRepository eoiRepository)
+    public WithdrawEoiCommandHandler(IEoiRepository eoiRepository, ICurrentUserService currentUserService)
     {
         _eoiRepository = eoiRepository;
+        _currentUserService = currentUserService;
     }
 
     public async Task<Unit> Handle(WithdrawEoiCommand request, CancellationToken cancellationToken)
@@ -20,6 +23,10 @@ public class WithdrawEoiCommandHandler : IRequestHandler<WithdrawEoiCommand, Uni
         var eoi = await _eoiRepository.GetByIdAsync(request.Id, cancellationToken);
         if (eoi is null)
             throw new NotFoundException($"Eoi '{request.Id}' does not exist.");
+
+        var user = await _currentUserService.GetCurrentUserAsync(cancellationToken);
+        if (!MutationPolicy.CanMutateEoi(eoi, user))
+            throw new ForbiddenException("Only the submitter of this EOI may withdraw it.");
 
         await _eoiRepository.DeleteAsync(request.Id, cancellationToken);
         return Unit.Value;

--- a/src/Herit.Application/Features/Proposal/Commands/DeleteProposal/DeleteProposalCommand.cs
+++ b/src/Herit.Application/Features/Proposal/Commands/DeleteProposal/DeleteProposalCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Authorization;
 using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using MediatR;
@@ -9,10 +10,12 @@ public record DeleteProposalCommand(Guid Id) : IRequest<Unit>;
 public class DeleteProposalCommandHandler : IRequestHandler<DeleteProposalCommand, Unit>
 {
     private readonly IProposalRepository _proposalRepository;
+    private readonly ICurrentUserService _currentUserService;
 
-    public DeleteProposalCommandHandler(IProposalRepository proposalRepository)
+    public DeleteProposalCommandHandler(IProposalRepository proposalRepository, ICurrentUserService currentUserService)
     {
         _proposalRepository = proposalRepository;
+        _currentUserService = currentUserService;
     }
 
     public async Task<Unit> Handle(DeleteProposalCommand request, CancellationToken cancellationToken)
@@ -20,6 +23,10 @@ public class DeleteProposalCommandHandler : IRequestHandler<DeleteProposalComman
         var proposal = await _proposalRepository.GetByIdAsync(request.Id, cancellationToken);
         if (proposal is null)
             throw new NotFoundException($"Proposal '{request.Id}' does not exist.");
+
+        var user = await _currentUserService.GetCurrentUserAsync(cancellationToken);
+        if (!MutationPolicy.CanDeleteProposal(proposal, user))
+            throw new ForbiddenException("Only the owner of this proposal, or staff, may delete it.");
 
         await _proposalRepository.DeleteAsync(request.Id, cancellationToken);
         return Unit.Value;

--- a/src/Herit.Application/Features/Proposal/Commands/SetProposalVisibility/SetProposalVisibilityCommand.cs
+++ b/src/Herit.Application/Features/Proposal/Commands/SetProposalVisibility/SetProposalVisibilityCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Authorization;
 using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
@@ -10,10 +11,12 @@ public record SetProposalVisibilityCommand(Guid Id, ProposalVisibility Visibilit
 public class SetProposalVisibilityCommandHandler : IRequestHandler<SetProposalVisibilityCommand, Unit>
 {
     private readonly IProposalRepository _proposalRepository;
+    private readonly ICurrentUserService _currentUserService;
 
-    public SetProposalVisibilityCommandHandler(IProposalRepository proposalRepository)
+    public SetProposalVisibilityCommandHandler(IProposalRepository proposalRepository, ICurrentUserService currentUserService)
     {
         _proposalRepository = proposalRepository;
+        _currentUserService = currentUserService;
     }
 
     public async Task<Unit> Handle(SetProposalVisibilityCommand request, CancellationToken cancellationToken)
@@ -21,6 +24,10 @@ public class SetProposalVisibilityCommandHandler : IRequestHandler<SetProposalVi
         var proposal = await _proposalRepository.GetByIdAsync(request.Id, cancellationToken);
         if (proposal is null)
             throw new NotFoundException($"Proposal '{request.Id}' does not exist.");
+
+        var user = await _currentUserService.GetCurrentUserAsync(cancellationToken);
+        if (!MutationPolicy.CanSetProposalVisibility(proposal, user))
+            throw new ForbiddenException("Only the owner of this proposal may change its visibility.");
 
         proposal.SetVisibility(request.Visibility);
         await _proposalRepository.UpdateAsync(proposal, cancellationToken);

--- a/src/Herit.Application/Features/Proposal/Commands/UpdateProposal/UpdateProposalCommand.cs
+++ b/src/Herit.Application/Features/Proposal/Commands/UpdateProposal/UpdateProposalCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Authorization;
 using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using MediatR;
@@ -13,10 +14,12 @@ public record UpdateProposalCommand(
 public class UpdateProposalCommandHandler : IRequestHandler<UpdateProposalCommand, Unit>
 {
     private readonly IProposalRepository _proposalRepository;
+    private readonly ICurrentUserService _currentUserService;
 
-    public UpdateProposalCommandHandler(IProposalRepository proposalRepository)
+    public UpdateProposalCommandHandler(IProposalRepository proposalRepository, ICurrentUserService currentUserService)
     {
         _proposalRepository = proposalRepository;
+        _currentUserService = currentUserService;
     }
 
     public async Task<Unit> Handle(UpdateProposalCommand request, CancellationToken cancellationToken)
@@ -24,6 +27,10 @@ public class UpdateProposalCommandHandler : IRequestHandler<UpdateProposalComman
         var proposal = await _proposalRepository.GetByIdAsync(request.Id, cancellationToken);
         if (proposal is null)
             throw new NotFoundException($"Proposal '{request.Id}' does not exist.");
+
+        var user = await _currentUserService.GetCurrentUserAsync(cancellationToken);
+        if (!MutationPolicy.CanUpdateProposal(proposal, user))
+            throw new ForbiddenException("Only the owner of this proposal may update it.");
 
         proposal.Update(request.Title, request.ShortDescription, request.LongDescription);
         await _proposalRepository.UpdateAsync(proposal, cancellationToken);

--- a/src/Herit.Application/Features/Proposal/Commands/UpdateProposalStatus/UpdateProposalStatusCommand.cs
+++ b/src/Herit.Application/Features/Proposal/Commands/UpdateProposalStatus/UpdateProposalStatusCommand.cs
@@ -1,3 +1,4 @@
+using Herit.Application.Authorization;
 using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
@@ -10,10 +11,12 @@ public record UpdateProposalStatusCommand(Guid Id, ProposalStatus NewStatus) : I
 public class UpdateProposalStatusCommandHandler : IRequestHandler<UpdateProposalStatusCommand, Unit>
 {
     private readonly IProposalRepository _proposalRepository;
+    private readonly ICurrentUserService _currentUserService;
 
-    public UpdateProposalStatusCommandHandler(IProposalRepository proposalRepository)
+    public UpdateProposalStatusCommandHandler(IProposalRepository proposalRepository, ICurrentUserService currentUserService)
     {
         _proposalRepository = proposalRepository;
+        _currentUserService = currentUserService;
     }
 
     public async Task<Unit> Handle(UpdateProposalStatusCommand request, CancellationToken cancellationToken)
@@ -21,6 +24,10 @@ public class UpdateProposalStatusCommandHandler : IRequestHandler<UpdateProposal
         var proposal = await _proposalRepository.GetByIdAsync(request.Id, cancellationToken);
         if (proposal is null)
             throw new NotFoundException($"Proposal '{request.Id}' does not exist.");
+
+        var user = await _currentUserService.GetCurrentUserAsync(cancellationToken);
+        if (!MutationPolicy.CanTransitionProposalStatus(proposal, user, request.NewStatus))
+            throw new ForbiddenException("You are not permitted to move this proposal to the requested status.");
 
         proposal.TransitionStatus(request.NewStatus);
         await _proposalRepository.UpdateAsync(proposal, cancellationToken);

--- a/tests/Herit.Application.Tests/Features/Cfeoi/Commands/PublishCfeoiCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Cfeoi/Commands/PublishCfeoiCommandHandlerTests.cs
@@ -5,6 +5,7 @@ using Herit.Domain.Enums;
 using NSubstitute;
 using CfeoiEntity = Herit.Domain.Entities.Cfeoi;
 using ProposalEntity = Herit.Domain.Entities.Proposal;
+using UserEntity = Herit.Domain.Entities.User;
 
 namespace Herit.Application.Tests.Features.Cfeoi.Commands;
 
@@ -12,22 +13,31 @@ public class PublishCfeoiCommandHandlerTests
 {
     private readonly ICfeoiRepository _cfeoiRepository = Substitute.For<ICfeoiRepository>();
     private readonly IProposalRepository _proposalRepository = Substitute.For<IProposalRepository>();
+    private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
     private readonly PublishCfeoiCommandHandler _handler;
 
     public PublishCfeoiCommandHandlerTests()
     {
-        _handler = new PublishCfeoiCommandHandler(_cfeoiRepository, _proposalRepository);
+        _handler = new PublishCfeoiCommandHandler(_cfeoiRepository, _proposalRepository, _currentUserService);
     }
 
     private static PublishCfeoiCommand BuildCommand(Guid proposalId, string? tags = null) =>
         new("CFEOI Title", "Description", CfeoiResourceType.Human, proposalId, tags);
 
+    private static UserEntity CreateUser(Guid id, UserRole role)
+        => UserEntity.Create(id, $"ext-{id}", "user@example.com", "Test User", role);
+
+    private void SetCurrentUser(UserEntity user)
+        => _currentUserService.GetCurrentUserAsync(Arg.Any<CancellationToken>()).Returns(user);
+
     [Fact]
-    public async Task Handle_HappyPath_ReturnsValidGuidAndCallsAddAsync()
+    public async Task Handle_AsProposalOwner_ReturnsValidGuidAndCallsAddAsync()
     {
         var proposalId = Guid.NewGuid();
+        var authorId = Guid.NewGuid();
         _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>())
-            .Returns(ProposalEntity.Create(proposalId, "Title", "Short", Guid.NewGuid(), Guid.NewGuid(), "Long"));
+            .Returns(ProposalEntity.Create(proposalId, "Title", "Short", authorId, Guid.NewGuid(), "Long"));
+        SetCurrentUser(CreateUser(authorId, UserRole.Expat));
 
         var result = await _handler.Handle(BuildCommand(proposalId, "heritage,culture"), CancellationToken.None);
 
@@ -38,6 +48,32 @@ public class PublishCfeoiCommandHandlerTests
                 c.ProposalId == proposalId &&
                 c.Tags == "heritage,culture"),
             Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_AsStaff_ReturnsValidGuidAndCallsAddAsync()
+    {
+        var proposalId = Guid.NewGuid();
+        _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>())
+            .Returns(ProposalEntity.Create(proposalId, "Title", "Short", Guid.NewGuid(), Guid.NewGuid(), "Long"));
+        SetCurrentUser(CreateUser(Guid.NewGuid(), UserRole.Staff));
+
+        var result = await _handler.Handle(BuildCommand(proposalId), CancellationToken.None);
+
+        Assert.NotEqual(Guid.Empty, result);
+        await _cfeoiRepository.Received(1).AddAsync(Arg.Any<CfeoiEntity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_AsNonOwnerExpat_ThrowsForbiddenException()
+    {
+        var proposalId = Guid.NewGuid();
+        _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>())
+            .Returns(ProposalEntity.Create(proposalId, "Title", "Short", Guid.NewGuid(), Guid.NewGuid(), "Long"));
+        SetCurrentUser(CreateUser(Guid.NewGuid(), UserRole.Expat));
+
+        await Assert.ThrowsAsync<ForbiddenException>(() => _handler.Handle(BuildCommand(proposalId), CancellationToken.None));
+        await _cfeoiRepository.DidNotReceive().AddAsync(Arg.Any<CfeoiEntity>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/Herit.Application.Tests/Features/Cfeoi/Commands/UpdateCfeoiCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Cfeoi/Commands/UpdateCfeoiCommandHandlerTests.cs
@@ -4,28 +4,47 @@ using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
 using NSubstitute;
 using CfeoiEntity = Herit.Domain.Entities.Cfeoi;
+using ProposalEntity = Herit.Domain.Entities.Proposal;
+using UserEntity = Herit.Domain.Entities.User;
 
 namespace Herit.Application.Tests.Features.Cfeoi.Commands;
 
 public class UpdateCfeoiCommandHandlerTests
 {
     private readonly ICfeoiRepository _cfeoiRepository = Substitute.For<ICfeoiRepository>();
+    private readonly IProposalRepository _proposalRepository = Substitute.For<IProposalRepository>();
+    private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
     private readonly UpdateCfeoiCommandHandler _handler;
+
+    private static readonly Guid ProposalId = Guid.NewGuid();
+    private static readonly Guid OwnerId = Guid.NewGuid();
 
     public UpdateCfeoiCommandHandlerTests()
     {
-        _handler = new UpdateCfeoiCommandHandler(_cfeoiRepository);
+        _handler = new UpdateCfeoiCommandHandler(_cfeoiRepository, _proposalRepository, _currentUserService);
     }
 
     private static CfeoiEntity CreateCfeoi(Guid id) =>
-        CfeoiEntity.Create(id, "Original Title", "Original Desc", CfeoiResourceType.Human, Guid.NewGuid());
+        CfeoiEntity.Create(id, "Original Title", "Original Desc", CfeoiResourceType.Human, ProposalId);
+
+    private static UserEntity CreateUser(Guid id, UserRole role)
+        => UserEntity.Create(id, $"ext-{id}", "user@example.com", "Test User", role);
+
+    private void SetCurrentUser(UserEntity user)
+        => _currentUserService.GetCurrentUserAsync(Arg.Any<CancellationToken>()).Returns(user);
+
+    private void SetUpOwnedProposal()
+        => _proposalRepository.GetByIdAsync(ProposalId, Arg.Any<CancellationToken>())
+            .Returns(ProposalEntity.Create(ProposalId, "Title", "Short", OwnerId, Guid.NewGuid(), "Long"));
 
     [Fact]
-    public async Task Handle_HappyPath_UpdatesFieldsAndCallsUpdateAsync()
+    public async Task Handle_AsProposalOwner_UpdatesFieldsAndCallsUpdateAsync()
     {
         var id = Guid.NewGuid();
         var cfeoi = CreateCfeoi(id);
         _cfeoiRepository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(cfeoi);
+        SetCurrentUser(CreateUser(OwnerId, UserRole.Expat));
+        SetUpOwnedProposal();
 
         var command = new UpdateCfeoiCommand(id, "New Title", "New Desc", CfeoiResourceType.NonHuman, "music,dance");
 
@@ -37,6 +56,38 @@ public class UpdateCfeoiCommandHandlerTests
         Assert.Equal(CfeoiResourceType.NonHuman, cfeoi.ResourceType);
         Assert.Equal("music,dance", cfeoi.Tags);
         await _cfeoiRepository.Received(1).UpdateAsync(cfeoi, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_AsStaff_UpdatesFieldsAndCallsUpdateAsync()
+    {
+        var id = Guid.NewGuid();
+        var cfeoi = CreateCfeoi(id);
+        _cfeoiRepository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(cfeoi);
+        SetCurrentUser(CreateUser(Guid.NewGuid(), UserRole.Staff));
+        SetUpOwnedProposal();
+
+        var command = new UpdateCfeoiCommand(id, "New Title", "New Desc", CfeoiResourceType.NonHuman, "music,dance");
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.Equal(MediatR.Unit.Value, result);
+        await _cfeoiRepository.Received(1).UpdateAsync(cfeoi, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_AsNonOwnerExpat_ThrowsForbiddenException()
+    {
+        var id = Guid.NewGuid();
+        var cfeoi = CreateCfeoi(id);
+        _cfeoiRepository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(cfeoi);
+        SetCurrentUser(CreateUser(Guid.NewGuid(), UserRole.Expat));
+        SetUpOwnedProposal();
+
+        var command = new UpdateCfeoiCommand(id, "New Title", "New Desc", CfeoiResourceType.NonHuman, "music,dance");
+
+        await Assert.ThrowsAsync<ForbiddenException>(() => _handler.Handle(command, CancellationToken.None));
+        await _cfeoiRepository.DidNotReceive().UpdateAsync(Arg.Any<CfeoiEntity>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/Herit.Application.Tests/Features/Cfeoi/Commands/UpdateCfeoiStatusCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Cfeoi/Commands/UpdateCfeoiStatusCommandHandlerTests.cs
@@ -4,34 +4,82 @@ using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
 using NSubstitute;
 using CfeoiEntity = Herit.Domain.Entities.Cfeoi;
+using ProposalEntity = Herit.Domain.Entities.Proposal;
+using UserEntity = Herit.Domain.Entities.User;
 
 namespace Herit.Application.Tests.Features.Cfeoi.Commands;
 
 public class UpdateCfeoiStatusCommandHandlerTests
 {
     private readonly ICfeoiRepository _repository = Substitute.For<ICfeoiRepository>();
+    private readonly IProposalRepository _proposalRepository = Substitute.For<IProposalRepository>();
+    private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
     private readonly UpdateCfeoiStatusCommandHandler _handler;
+
+    private static readonly Guid ProposalId = Guid.NewGuid();
+    private static readonly Guid OwnerId = Guid.NewGuid();
 
     public UpdateCfeoiStatusCommandHandlerTests()
     {
-        _handler = new UpdateCfeoiStatusCommandHandler(_repository);
+        _handler = new UpdateCfeoiStatusCommandHandler(_repository, _proposalRepository, _currentUserService);
     }
 
     private static CfeoiEntity CreateOpenCfeoi(Guid id)
-        => CfeoiEntity.Create(id, "Title", "Description", CfeoiResourceType.Human, Guid.NewGuid());
+        => CfeoiEntity.Create(id, "Title", "Description", CfeoiResourceType.Human, ProposalId);
+
+    private static UserEntity CreateUser(Guid id, UserRole role)
+        => UserEntity.Create(id, $"ext-{id}", "user@example.com", "Test User", role);
+
+    private void SetCurrentUser(UserEntity user)
+        => _currentUserService.GetCurrentUserAsync(Arg.Any<CancellationToken>()).Returns(user);
+
+    private void SetUpOwnedProposal()
+        => _proposalRepository.GetByIdAsync(ProposalId, Arg.Any<CancellationToken>())
+            .Returns(ProposalEntity.Create(ProposalId, "Title", "Short", OwnerId, Guid.NewGuid(), "Long"));
 
     [Fact]
-    public async Task Handle_OpenToClosed_CallsUpdateAsyncOnce()
+    public async Task Handle_OpenToClosed_AsProposalOwner_CallsUpdateAsyncOnce()
     {
         var id = Guid.NewGuid();
         var cfeoi = CreateOpenCfeoi(id);
         _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(cfeoi);
+        SetCurrentUser(CreateUser(OwnerId, UserRole.Expat));
+        SetUpOwnedProposal();
 
         var result = await _handler.Handle(new UpdateCfeoiStatusCommand(id, CfeoiStatus.Closed), CancellationToken.None);
 
         Assert.Equal(MediatR.Unit.Value, result);
         Assert.Equal(CfeoiStatus.Closed, cfeoi.Status);
         await _repository.Received(1).UpdateAsync(cfeoi, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_OpenToClosed_AsStaff_CallsUpdateAsyncOnce()
+    {
+        var id = Guid.NewGuid();
+        var cfeoi = CreateOpenCfeoi(id);
+        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(cfeoi);
+        SetCurrentUser(CreateUser(Guid.NewGuid(), UserRole.Staff));
+        SetUpOwnedProposal();
+
+        var result = await _handler.Handle(new UpdateCfeoiStatusCommand(id, CfeoiStatus.Closed), CancellationToken.None);
+
+        Assert.Equal(MediatR.Unit.Value, result);
+        await _repository.Received(1).UpdateAsync(cfeoi, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_OpenToClosed_AsNonOwnerExpat_ThrowsForbiddenException()
+    {
+        var id = Guid.NewGuid();
+        var cfeoi = CreateOpenCfeoi(id);
+        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(cfeoi);
+        SetCurrentUser(CreateUser(Guid.NewGuid(), UserRole.Expat));
+        SetUpOwnedProposal();
+
+        await Assert.ThrowsAsync<ForbiddenException>(
+            () => _handler.Handle(new UpdateCfeoiStatusCommand(id, CfeoiStatus.Closed), CancellationToken.None));
+        await _repository.DidNotReceive().UpdateAsync(Arg.Any<CfeoiEntity>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -52,6 +100,8 @@ public class UpdateCfeoiStatusCommandHandlerTests
         var cfeoi = CreateOpenCfeoi(id);
         cfeoi.TransitionStatus(CfeoiStatus.Closed);
         _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(cfeoi);
+        SetCurrentUser(CreateUser(OwnerId, UserRole.Expat));
+        SetUpOwnedProposal();
 
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => _handler.Handle(new UpdateCfeoiStatusCommand(id, CfeoiStatus.Open), CancellationToken.None));

--- a/tests/Herit.Application.Tests/Features/Eoi/Commands/SetEoiVisibilityCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Eoi/Commands/SetEoiVisibilityCommandHandlerTests.cs
@@ -5,31 +5,54 @@ using Herit.Domain.Enums;
 using MediatR;
 using NSubstitute;
 using EoiEntity = Herit.Domain.Entities.Eoi;
+using UserEntity = Herit.Domain.Entities.User;
 
 namespace Herit.Application.Tests.Features.Eoi.Commands;
 
 public class SetEoiVisibilityCommandHandlerTests
 {
     private readonly IEoiRepository _eoiRepository = Substitute.For<IEoiRepository>();
+    private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
     private readonly SetEoiVisibilityCommandHandler _handler;
 
     public SetEoiVisibilityCommandHandlerTests()
     {
-        _handler = new SetEoiVisibilityCommandHandler(_eoiRepository);
+        _handler = new SetEoiVisibilityCommandHandler(_eoiRepository, _currentUserService);
     }
 
+    private static UserEntity CreateUser(Guid id, UserRole role)
+        => UserEntity.Create(id, $"ext-{id}", "user@example.com", "Test User", role);
+
+    private void SetCurrentUser(UserEntity user)
+        => _currentUserService.GetCurrentUserAsync(Arg.Any<CancellationToken>()).Returns(user);
+
     [Fact]
-    public async Task Handle_HappyPath_SetsVisibilityAndCallsUpdateAsync()
+    public async Task Handle_AsSubmitter_SetsVisibilityAndCallsUpdateAsync()
     {
         var eoiId = Guid.NewGuid();
-        var eoi = EoiEntity.Create(eoiId, Guid.NewGuid(), "Message", Guid.NewGuid());
+        var submitterId = Guid.NewGuid();
+        var eoi = EoiEntity.Create(eoiId, submitterId, "Message", Guid.NewGuid());
         _eoiRepository.GetByIdAsync(eoiId, Arg.Any<CancellationToken>()).Returns(eoi);
+        SetCurrentUser(CreateUser(submitterId, UserRole.Expat));
 
         var result = await _handler.Handle(new SetEoiVisibilityCommand(eoiId, EoiVisibility.Shared), CancellationToken.None);
 
         Assert.Equal(Unit.Value, result);
         Assert.Equal(EoiVisibility.Shared, eoi.Visibility);
         await _eoiRepository.Received(1).UpdateAsync(eoi, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_AsNonSubmitter_ThrowsForbiddenException()
+    {
+        var eoiId = Guid.NewGuid();
+        var eoi = EoiEntity.Create(eoiId, Guid.NewGuid(), "Message", Guid.NewGuid());
+        _eoiRepository.GetByIdAsync(eoiId, Arg.Any<CancellationToken>()).Returns(eoi);
+        SetCurrentUser(CreateUser(Guid.NewGuid(), UserRole.Expat));
+
+        await Assert.ThrowsAsync<ForbiddenException>(
+            () => _handler.Handle(new SetEoiVisibilityCommand(eoiId, EoiVisibility.Shared), CancellationToken.None));
+        await _eoiRepository.DidNotReceive().UpdateAsync(Arg.Any<EoiEntity>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/Herit.Application.Tests/Features/Eoi/Commands/WithdrawEoiCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Eoi/Commands/WithdrawEoiCommandHandlerTests.cs
@@ -1,33 +1,70 @@
 using Herit.Application.Exceptions;
 using Herit.Application.Features.Eoi.Commands.WithdrawEoi;
 using Herit.Application.Interfaces;
+using Herit.Domain.Enums;
 using MediatR;
 using NSubstitute;
 using EoiEntity = Herit.Domain.Entities.Eoi;
+using UserEntity = Herit.Domain.Entities.User;
 
 namespace Herit.Application.Tests.Features.Eoi.Commands;
 
 public class WithdrawEoiCommandHandlerTests
 {
     private readonly IEoiRepository _eoiRepository = Substitute.For<IEoiRepository>();
+    private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
     private readonly WithdrawEoiCommandHandler _handler;
 
     public WithdrawEoiCommandHandlerTests()
     {
-        _handler = new WithdrawEoiCommandHandler(_eoiRepository);
+        _handler = new WithdrawEoiCommandHandler(_eoiRepository, _currentUserService);
     }
 
+    private static UserEntity CreateUser(Guid id, UserRole role)
+        => UserEntity.Create(id, $"ext-{id}", "user@example.com", "Test User", role);
+
+    private void SetCurrentUser(UserEntity user)
+        => _currentUserService.GetCurrentUserAsync(Arg.Any<CancellationToken>()).Returns(user);
+
     [Fact]
-    public async Task Handle_HappyPath_CallsDeleteAsync()
+    public async Task Handle_AsSubmitter_CallsDeleteAsync()
     {
         var eoiId = Guid.NewGuid();
-        var eoi = EoiEntity.Create(eoiId, Guid.NewGuid(), "Message", Guid.NewGuid());
+        var submitterId = Guid.NewGuid();
+        var eoi = EoiEntity.Create(eoiId, submitterId, "Message", Guid.NewGuid());
         _eoiRepository.GetByIdAsync(eoiId, Arg.Any<CancellationToken>()).Returns(eoi);
+        SetCurrentUser(CreateUser(submitterId, UserRole.Expat));
 
         var result = await _handler.Handle(new WithdrawEoiCommand(eoiId), CancellationToken.None);
 
         Assert.Equal(Unit.Value, result);
         await _eoiRepository.Received(1).DeleteAsync(eoiId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_AsNonSubmitter_ThrowsForbiddenException()
+    {
+        var eoiId = Guid.NewGuid();
+        var eoi = EoiEntity.Create(eoiId, Guid.NewGuid(), "Message", Guid.NewGuid());
+        _eoiRepository.GetByIdAsync(eoiId, Arg.Any<CancellationToken>()).Returns(eoi);
+        SetCurrentUser(CreateUser(Guid.NewGuid(), UserRole.Expat));
+
+        await Assert.ThrowsAsync<ForbiddenException>(
+            () => _handler.Handle(new WithdrawEoiCommand(eoiId), CancellationToken.None));
+        await _eoiRepository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_AsStaffNonSubmitter_ThrowsForbiddenException()
+    {
+        var eoiId = Guid.NewGuid();
+        var eoi = EoiEntity.Create(eoiId, Guid.NewGuid(), "Message", Guid.NewGuid());
+        _eoiRepository.GetByIdAsync(eoiId, Arg.Any<CancellationToken>()).Returns(eoi);
+        SetCurrentUser(CreateUser(Guid.NewGuid(), UserRole.Staff));
+
+        await Assert.ThrowsAsync<ForbiddenException>(
+            () => _handler.Handle(new WithdrawEoiCommand(eoiId), CancellationToken.None));
+        await _eoiRepository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/Herit.Application.Tests/Features/Proposal/Commands/DeleteProposalCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Proposal/Commands/DeleteProposalCommandHandlerTests.cs
@@ -1,37 +1,76 @@
 using Herit.Application.Exceptions;
 using Herit.Application.Features.Proposal.Commands.DeleteProposal;
 using Herit.Application.Interfaces;
+using Herit.Domain.Enums;
 using MediatR;
 using NSubstitute;
 using ProposalEntity = Herit.Domain.Entities.Proposal;
+using UserEntity = Herit.Domain.Entities.User;
 
 namespace Herit.Application.Tests.Features.Proposal.Commands;
 
 public class DeleteProposalCommandHandlerTests
 {
     private readonly IProposalRepository _proposalRepository = Substitute.For<IProposalRepository>();
+    private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
     private readonly DeleteProposalCommandHandler _handler;
 
     public DeleteProposalCommandHandlerTests()
     {
-        _handler = new DeleteProposalCommandHandler(_proposalRepository);
+        _handler = new DeleteProposalCommandHandler(_proposalRepository, _currentUserService);
     }
 
+    private static UserEntity CreateUser(Guid id, UserRole role)
+        => UserEntity.Create(id, $"ext-{id}", "user@example.com", "Test User", role);
+
+    private void SetCurrentUser(UserEntity user)
+        => _currentUserService.GetCurrentUserAsync(Arg.Any<CancellationToken>()).Returns(user);
+
     [Fact]
-    public async Task Handle_HappyPath_CallsDeleteAsync()
+    public async Task Handle_AsOwner_CallsDeleteAsync()
     {
         var proposalId = Guid.NewGuid();
         var authorId = Guid.NewGuid();
         var organisationId = Guid.NewGuid();
         var proposal = ProposalEntity.Create(proposalId, "Title", "Short", authorId, organisationId, "Long", null);
         _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>()).Returns(proposal);
+        SetCurrentUser(CreateUser(authorId, UserRole.Expat));
 
-        var command = new DeleteProposalCommand(proposalId);
-
-        var result = await _handler.Handle(command, CancellationToken.None);
+        var result = await _handler.Handle(new DeleteProposalCommand(proposalId), CancellationToken.None);
 
         Assert.Equal(Unit.Value, result);
         await _proposalRepository.Received(1).DeleteAsync(proposalId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_AsStaffNonOwner_CallsDeleteAsync()
+    {
+        var proposalId = Guid.NewGuid();
+        var authorId = Guid.NewGuid();
+        var organisationId = Guid.NewGuid();
+        var proposal = ProposalEntity.Create(proposalId, "Title", "Short", authorId, organisationId, "Long", null);
+        _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>()).Returns(proposal);
+        SetCurrentUser(CreateUser(Guid.NewGuid(), UserRole.Staff));
+
+        var result = await _handler.Handle(new DeleteProposalCommand(proposalId), CancellationToken.None);
+
+        Assert.Equal(Unit.Value, result);
+        await _proposalRepository.Received(1).DeleteAsync(proposalId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_AsNonOwnerExpat_ThrowsForbiddenException()
+    {
+        var proposalId = Guid.NewGuid();
+        var authorId = Guid.NewGuid();
+        var organisationId = Guid.NewGuid();
+        var proposal = ProposalEntity.Create(proposalId, "Title", "Short", authorId, organisationId, "Long", null);
+        _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>()).Returns(proposal);
+        SetCurrentUser(CreateUser(Guid.NewGuid(), UserRole.Expat));
+
+        await Assert.ThrowsAsync<ForbiddenException>(
+            () => _handler.Handle(new DeleteProposalCommand(proposalId), CancellationToken.None));
+        await _proposalRepository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/Herit.Application.Tests/Features/Proposal/Commands/SetProposalVisibilityCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Proposal/Commands/SetProposalVisibilityCommandHandlerTests.cs
@@ -5,25 +5,35 @@ using Herit.Domain.Enums;
 using MediatR;
 using NSubstitute;
 using ProposalEntity = Herit.Domain.Entities.Proposal;
+using UserEntity = Herit.Domain.Entities.User;
 
 namespace Herit.Application.Tests.Features.Proposal.Commands;
 
 public class SetProposalVisibilityCommandHandlerTests
 {
     private readonly IProposalRepository _proposalRepository = Substitute.For<IProposalRepository>();
+    private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
     private readonly SetProposalVisibilityCommandHandler _handler;
 
     public SetProposalVisibilityCommandHandlerTests()
     {
-        _handler = new SetProposalVisibilityCommandHandler(_proposalRepository);
+        _handler = new SetProposalVisibilityCommandHandler(_proposalRepository, _currentUserService);
     }
 
+    private static UserEntity CreateUser(Guid id, UserRole role)
+        => UserEntity.Create(id, $"ext-{id}", "user@example.com", "Test User", role);
+
+    private void SetCurrentUser(UserEntity user)
+        => _currentUserService.GetCurrentUserAsync(Arg.Any<CancellationToken>()).Returns(user);
+
     [Fact]
-    public async Task Handle_HappyPath_SetsVisibilityAndCallsUpdateAsync()
+    public async Task Handle_AsOwner_SetsVisibilityAndCallsUpdateAsync()
     {
         var proposalId = Guid.NewGuid();
-        var proposal = ProposalEntity.Create(proposalId, "Title", "Short", Guid.NewGuid(), Guid.NewGuid(), "Long");
+        var authorId = Guid.NewGuid();
+        var proposal = ProposalEntity.Create(proposalId, "Title", "Short", authorId, Guid.NewGuid(), "Long");
         _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>()).Returns(proposal);
+        SetCurrentUser(CreateUser(authorId, UserRole.Expat));
 
         var result = await _handler.Handle(new SetProposalVisibilityCommand(proposalId, ProposalVisibility.Public), CancellationToken.None);
 
@@ -32,6 +42,20 @@ public class SetProposalVisibilityCommandHandlerTests
         await _proposalRepository.Received(1).UpdateAsync(
             Arg.Is<ProposalEntity>(p => p.Visibility == ProposalVisibility.Public),
             Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_AsNonOwner_ThrowsForbiddenException()
+    {
+        var proposalId = Guid.NewGuid();
+        var authorId = Guid.NewGuid();
+        var proposal = ProposalEntity.Create(proposalId, "Title", "Short", authorId, Guid.NewGuid(), "Long");
+        _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>()).Returns(proposal);
+        SetCurrentUser(CreateUser(Guid.NewGuid(), UserRole.Expat));
+
+        await Assert.ThrowsAsync<ForbiddenException>(
+            () => _handler.Handle(new SetProposalVisibilityCommand(proposalId, ProposalVisibility.Public), CancellationToken.None));
+        await _proposalRepository.DidNotReceive().UpdateAsync(Arg.Any<ProposalEntity>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/Herit.Application.Tests/Features/Proposal/Commands/UpdateProposalCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Proposal/Commands/UpdateProposalCommandHandlerTests.cs
@@ -13,21 +13,29 @@ namespace Herit.Application.Tests.Features.Proposal.Commands;
 public class UpdateProposalCommandHandlerTests
 {
     private readonly IProposalRepository _proposalRepository = Substitute.For<IProposalRepository>();
+    private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
     private readonly UpdateProposalCommandHandler _handler;
 
     public UpdateProposalCommandHandlerTests()
     {
-        _handler = new UpdateProposalCommandHandler(_proposalRepository);
+        _handler = new UpdateProposalCommandHandler(_proposalRepository, _currentUserService);
     }
 
+    private static UserEntity CreateUser(Guid id, UserRole role)
+        => UserEntity.Create(id, $"ext-{id}", "user@example.com", "Test User", role);
+
+    private void SetCurrentUser(UserEntity user)
+        => _currentUserService.GetCurrentUserAsync(Arg.Any<CancellationToken>()).Returns(user);
+
     [Fact]
-    public async Task Handle_HappyPath_UpdatesProposalAndCallsUpdateAsync()
+    public async Task Handle_AsOwner_UpdatesProposalAndCallsUpdateAsync()
     {
         var proposalId = Guid.NewGuid();
         var authorId = Guid.NewGuid();
         var organisationId = Guid.NewGuid();
         var proposal = ProposalEntity.Create(proposalId, "Old Title", "Old Short", authorId, organisationId, "Old Long", null);
         _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>()).Returns(proposal);
+        SetCurrentUser(CreateUser(authorId, UserRole.Expat));
 
         var command = new UpdateProposalCommand(proposalId, "New Title", "New Short", "New Long");
 
@@ -37,6 +45,38 @@ public class UpdateProposalCommandHandlerTests
         await _proposalRepository.Received(1).UpdateAsync(
             Arg.Is<ProposalEntity>(p => p.Title == "New Title" && p.ShortDescription == "New Short" && p.LongDescription == "New Long"),
             Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_AsNonOwnerExpat_ThrowsForbiddenException()
+    {
+        var proposalId = Guid.NewGuid();
+        var authorId = Guid.NewGuid();
+        var organisationId = Guid.NewGuid();
+        var proposal = ProposalEntity.Create(proposalId, "Old Title", "Old Short", authorId, organisationId, "Old Long", null);
+        _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>()).Returns(proposal);
+        SetCurrentUser(CreateUser(Guid.NewGuid(), UserRole.Expat));
+
+        var command = new UpdateProposalCommand(proposalId, "New Title", "New Short", "New Long");
+
+        await Assert.ThrowsAsync<ForbiddenException>(() => _handler.Handle(command, CancellationToken.None));
+        await _proposalRepository.DidNotReceive().UpdateAsync(Arg.Any<ProposalEntity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_AsStaffNonOwner_ThrowsForbiddenException()
+    {
+        var proposalId = Guid.NewGuid();
+        var authorId = Guid.NewGuid();
+        var organisationId = Guid.NewGuid();
+        var proposal = ProposalEntity.Create(proposalId, "Old Title", "Old Short", authorId, organisationId, "Old Long", null);
+        _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>()).Returns(proposal);
+        SetCurrentUser(CreateUser(Guid.NewGuid(), UserRole.Staff));
+
+        var command = new UpdateProposalCommand(proposalId, "New Title", "New Short", "New Long");
+
+        await Assert.ThrowsAsync<ForbiddenException>(() => _handler.Handle(command, CancellationToken.None));
+        await _proposalRepository.DidNotReceive().UpdateAsync(Arg.Any<ProposalEntity>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/Herit.Application.Tests/Features/Proposal/Commands/UpdateProposalStatusCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Proposal/Commands/UpdateProposalStatusCommandHandlerTests.cs
@@ -5,34 +5,169 @@ using Herit.Domain.Enums;
 using MediatR;
 using NSubstitute;
 using ProposalEntity = Herit.Domain.Entities.Proposal;
+using UserEntity = Herit.Domain.Entities.User;
 
 namespace Herit.Application.Tests.Features.Proposal.Commands;
 
 public class UpdateProposalStatusCommandHandlerTests
 {
     private readonly IProposalRepository _proposalRepository = Substitute.For<IProposalRepository>();
+    private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
     private readonly UpdateProposalStatusCommandHandler _handler;
+
+    private static readonly Guid AuthorId = Guid.NewGuid();
 
     public UpdateProposalStatusCommandHandlerTests()
     {
-        _handler = new UpdateProposalStatusCommandHandler(_proposalRepository);
+        _handler = new UpdateProposalStatusCommandHandler(_proposalRepository, _currentUserService);
     }
 
     private static ProposalEntity CreateIdeationProposal(Guid id)
-        => ProposalEntity.Create(id, "Title", "Short", Guid.NewGuid(), Guid.NewGuid(), "Long");
+        => ProposalEntity.Create(id, "Title", "Short", AuthorId, Guid.NewGuid(), "Long");
+
+    private static UserEntity CreateUser(Guid id, UserRole role)
+        => UserEntity.Create(id, $"ext-{id}", "user@example.com", "Test User", role);
+
+    private void SetCurrentUser(UserEntity user)
+        => _currentUserService.GetCurrentUserAsync(Arg.Any<CancellationToken>()).Returns(user);
 
     [Fact]
-    public async Task Handle_ValidTransition_IdeationToResourcing_CallsUpdateAsyncOnce()
+    public async Task Handle_IdeationToResourcing_AsOwner_CallsUpdateAsyncOnce()
     {
         var id = Guid.NewGuid();
         var proposal = CreateIdeationProposal(id);
         _proposalRepository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(proposal);
+        SetCurrentUser(CreateUser(AuthorId, UserRole.Expat));
 
         var result = await _handler.Handle(new UpdateProposalStatusCommand(id, ProposalStatus.Resourcing), CancellationToken.None);
 
         Assert.Equal(Unit.Value, result);
         Assert.Equal(ProposalStatus.Resourcing, proposal.Status);
         await _proposalRepository.Received(1).UpdateAsync(proposal, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_IdeationToResourcing_AsNonOwnerExpat_ThrowsForbiddenException()
+    {
+        var id = Guid.NewGuid();
+        var proposal = CreateIdeationProposal(id);
+        _proposalRepository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(proposal);
+        SetCurrentUser(CreateUser(Guid.NewGuid(), UserRole.Expat));
+
+        await Assert.ThrowsAsync<ForbiddenException>(
+            () => _handler.Handle(new UpdateProposalStatusCommand(id, ProposalStatus.Resourcing), CancellationToken.None));
+        await _proposalRepository.DidNotReceive().UpdateAsync(Arg.Any<ProposalEntity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_IdeationToResourcing_AsStaff_ThrowsForbiddenException()
+    {
+        var id = Guid.NewGuid();
+        var proposal = CreateIdeationProposal(id);
+        _proposalRepository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(proposal);
+        SetCurrentUser(CreateUser(Guid.NewGuid(), UserRole.Staff));
+
+        await Assert.ThrowsAsync<ForbiddenException>(
+            () => _handler.Handle(new UpdateProposalStatusCommand(id, ProposalStatus.Resourcing), CancellationToken.None));
+        await _proposalRepository.DidNotReceive().UpdateAsync(Arg.Any<ProposalEntity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_SubmittedToWithdrawn_AsOwner_CallsUpdateAsyncOnce()
+    {
+        var id = Guid.NewGuid();
+        var proposal = CreateIdeationProposal(id);
+        proposal.TransitionStatus(ProposalStatus.Resourcing);
+        proposal.TransitionStatus(ProposalStatus.Submitted);
+        _proposalRepository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(proposal);
+        SetCurrentUser(CreateUser(AuthorId, UserRole.Expat));
+
+        var result = await _handler.Handle(new UpdateProposalStatusCommand(id, ProposalStatus.Withdrawn), CancellationToken.None);
+
+        Assert.Equal(Unit.Value, result);
+        Assert.Equal(ProposalStatus.Withdrawn, proposal.Status);
+        await _proposalRepository.Received(1).UpdateAsync(proposal, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_SubmittedToWithdrawn_AsStaff_ThrowsForbiddenException()
+    {
+        var id = Guid.NewGuid();
+        var proposal = CreateIdeationProposal(id);
+        proposal.TransitionStatus(ProposalStatus.Resourcing);
+        proposal.TransitionStatus(ProposalStatus.Submitted);
+        _proposalRepository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(proposal);
+        SetCurrentUser(CreateUser(Guid.NewGuid(), UserRole.Staff));
+
+        await Assert.ThrowsAsync<ForbiddenException>(
+            () => _handler.Handle(new UpdateProposalStatusCommand(id, ProposalStatus.Withdrawn), CancellationToken.None));
+        await _proposalRepository.DidNotReceive().UpdateAsync(Arg.Any<ProposalEntity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_SubmittedToUnderReview_AsStaff_CallsUpdateAsyncOnce()
+    {
+        var id = Guid.NewGuid();
+        var proposal = CreateIdeationProposal(id);
+        proposal.TransitionStatus(ProposalStatus.Resourcing);
+        proposal.TransitionStatus(ProposalStatus.Submitted);
+        _proposalRepository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(proposal);
+        SetCurrentUser(CreateUser(Guid.NewGuid(), UserRole.Staff));
+
+        var result = await _handler.Handle(new UpdateProposalStatusCommand(id, ProposalStatus.UnderReview), CancellationToken.None);
+
+        Assert.Equal(Unit.Value, result);
+        Assert.Equal(ProposalStatus.UnderReview, proposal.Status);
+        await _proposalRepository.Received(1).UpdateAsync(proposal, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_SubmittedToUnderReview_AsOwner_ThrowsForbiddenException()
+    {
+        var id = Guid.NewGuid();
+        var proposal = CreateIdeationProposal(id);
+        proposal.TransitionStatus(ProposalStatus.Resourcing);
+        proposal.TransitionStatus(ProposalStatus.Submitted);
+        _proposalRepository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(proposal);
+        SetCurrentUser(CreateUser(AuthorId, UserRole.Expat));
+
+        await Assert.ThrowsAsync<ForbiddenException>(
+            () => _handler.Handle(new UpdateProposalStatusCommand(id, ProposalStatus.UnderReview), CancellationToken.None));
+        await _proposalRepository.DidNotReceive().UpdateAsync(Arg.Any<ProposalEntity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_UnderReviewToApproved_AsStaff_CallsUpdateAsyncOnce()
+    {
+        var id = Guid.NewGuid();
+        var proposal = CreateIdeationProposal(id);
+        proposal.TransitionStatus(ProposalStatus.Resourcing);
+        proposal.TransitionStatus(ProposalStatus.Submitted);
+        proposal.TransitionStatus(ProposalStatus.UnderReview);
+        _proposalRepository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(proposal);
+        SetCurrentUser(CreateUser(Guid.NewGuid(), UserRole.Staff));
+
+        var result = await _handler.Handle(new UpdateProposalStatusCommand(id, ProposalStatus.Approved), CancellationToken.None);
+
+        Assert.Equal(Unit.Value, result);
+        Assert.Equal(ProposalStatus.Approved, proposal.Status);
+        await _proposalRepository.Received(1).UpdateAsync(proposal, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_UnderReviewToApproved_AsOwner_ThrowsForbiddenException()
+    {
+        var id = Guid.NewGuid();
+        var proposal = CreateIdeationProposal(id);
+        proposal.TransitionStatus(ProposalStatus.Resourcing);
+        proposal.TransitionStatus(ProposalStatus.Submitted);
+        proposal.TransitionStatus(ProposalStatus.UnderReview);
+        _proposalRepository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(proposal);
+        SetCurrentUser(CreateUser(AuthorId, UserRole.Expat));
+
+        await Assert.ThrowsAsync<ForbiddenException>(
+            () => _handler.Handle(new UpdateProposalStatusCommand(id, ProposalStatus.Approved), CancellationToken.None));
+        await _proposalRepository.DidNotReceive().UpdateAsync(Arg.Any<ProposalEntity>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -50,8 +185,9 @@ public class UpdateProposalStatusCommandHandlerTests
     public async Task Handle_IllegalTransition_ThrowsInvalidOperationException()
     {
         var id = Guid.NewGuid();
-        var proposal = CreateIdeationProposal(id); // status is Ideation
+        var proposal = CreateIdeationProposal(id); // status is Ideation; Approved is staff-authorized but sequence-illegal from here
         _proposalRepository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(proposal);
+        SetCurrentUser(CreateUser(Guid.NewGuid(), UserRole.Staff));
 
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => _handler.Handle(new UpdateProposalStatusCommand(id, ProposalStatus.Approved), CancellationToken.None));


### PR DESCRIPTION
## Description

PR #271 fixed a broken-access-control bug on EOI approve/reject (any staff could act on any EOI; ownership wasn't checked). This PR closes the same gap across the other mutating handlers by adding a `MutationPolicy` (alongside `VisibilityPolicy`) and wiring caller checks via `ICurrentUserService` into every handler that was missing them:

- **Proposal status transitions** (`UpdateProposalStatusCommandHandler`) now enforce per-transition actor rules: the owner drives `Ideation→Resourcing→Submitted` and `Submitted→Withdrawn`; staff drive `Submitted→UnderReview→Approved`. An owner can no longer approve their own proposal, and staff can no longer withdraw a proposal on the owner's behalf.
- **Proposal content/visibility/delete** — owner-only for update/visibility; delete allows owner or staff (PRD §6.1 S7).
- **CFEOI publish/update/close** — owner of the parent proposal, or staff (PRD §6.1 S8).
- **EOI withdraw/visibility** — submitter only. This closes a real broken-access-control bug: previously any authenticated expat could withdraw or change the visibility of any other user's EOI by ID.

All 403s are returned via the existing `ForbiddenException` → `GlobalExceptionHandler` pipeline, matching the convention from #271.

Also includes a small unrelated doc update clarifying that "Sign in with Google" is implemented via Entra ID federation, not direct Google OAuth.

## Linked Issue

Closes #272

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- Added/extended unit tests for every touched handler mirroring the owner/other-expat/staff actor matrix from the EOI fix in #271 (`dotnet test` — 279 tests passing).
- Added a cross-user API-level Playwright assertion (`seams.spec.ts`): expat B attempting to transition expat A's proposal status now gets a 403.
- `dotnet build` and `dotnet format --verify-no-changes` pass.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [x] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)