### PR TITLE
Upgrade web App Service runtime to Node 22 LTS

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -86,7 +86,7 @@ module web './app/web-appservice-avm.bicep' = {
     tags: tags
     appServicePlanId: appServicePlan.outputs.resourceId
     appInsightResourceId: monitoring.outputs.applicationInsightsResourceId
-    linuxFxVersion: 'node|20-lts'
+    linuxFxVersion: 'node|22-lts'
   }
 }
 


### PR DESCRIPTION
## Description

Azure notified that Node 20 LTS extended support on App Service ends 30 April 2026. The GitHub Actions workflow already builds with Node 22, but the App Service runtime in `infra/main.bicep` was still pinned to `node|20-lts`. This updates it to `node|22-lts` so the deployed runtime matches what's built and tested in CI.

## Linked Issue

Closes #214

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Chore / refactor

## Testing Notes

Validated the Bicep template compiles cleanly with `az bicep build --file infra/main.bicep` (only pre-existing, unrelated warnings). No other files reference Node 20.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)