### PR TITLE
Remove unauthorized PATCH /Users/{id}/profile endpoint

### DIFF
--- a/frontend/portal/e2e/seams.spec.ts
+++ b/frontend/portal/e2e/seams.spec.ts
@@ -156,3 +156,9 @@ test("expat B mutating expat A's proposal is rejected with 403 at the API", asyn
   const response = await apiB.raw('PATCH', `/Proposals/${hostProposalId}/status`, JSON.stringify('Submitted'));
   expect(response.status()).toBe(403);
 });
+
+test("the by-id profile route is gone; only /me/profile can update a user's own profile", async () => {
+  const other = await apiA.getMe();
+  const response = await apiB.raw('PATCH', `/Users/${other.id}/profile`, { nationality: 'Nowhere' });
+  expect(response.status()).toBe(404);
+});

--- a/src/Herit.Api/Controllers/UsersController.cs
+++ b/src/Herit.Api/Controllers/UsersController.cs
@@ -88,11 +88,4 @@ public class UsersController : ControllerBase
         await _mediator.Send(new DeleteOrganisationAdminCommand(id), ct);
         return NoContent();
     }
-
-    [HttpPatch("{id:guid}/profile")]
-    public async Task<IActionResult> UpdateProfile(Guid id, [FromBody] UpdateUserProfileCommand command, CancellationToken ct)
-    {
-        await _mediator.Send(command with { Id = id }, ct);
-        return NoContent();
-    }
 }


### PR DESCRIPTION
## Description

`PATCH /api/v1/Users/{id}/profile` had no authorization beyond the controller-level `[Authorize]`, and `UpdateUserProfileCommandHandler` performs no caller check — so any authenticated user, including any expat, could update any other user's email, nationality, location, and expertise tags by ID.

No frontend code calls this route (only `/Users/me/profile` is used, which resolves the target from `ICurrentUserService`), and the staff app's planned user-management flows use `PUT /api/v1/Users/staff/{id}` instead. Since the route is redundant and unused, this removes it entirely rather than gating it — the smaller attack surface, per the issue's own recommendation.

## Linked Issue

Closes #277

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- `dotnet test --configuration Release` — all 277 tests pass (no handler-level behavior changed; the vulnerability was in the controller's routing/authorization, not the command handler, which is now only reachable via the always-self-scoped `/me/profile`).
- Added an E2E guard test in `frontend/portal/e2e/seams.spec.ts` asserting `PATCH /Users/{otherUserId}/profile` now returns 404.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)