### PR TITLE
Return submitter identity in EOI list/detail responses

### DIFF
--- a/frontend/portal/e2e/full-loop.spec.ts
+++ b/frontend/portal/e2e/full-loop.spec.ts
@@ -142,11 +142,17 @@ test('full loop: JIT sign-in through proposal withdrawal', async ({ browser }) =
     await apiB.dispose();
   });
 
-  await test.step("A1 sees B's EOI in the inbox and approves it", async () => {
+  await test.step("A1 sees B's real name (not a GUID fragment) in the inbox and approves it", async () => {
+    const apiB = await Api.forToken(state.identities.userB.token);
+    const submitterName = (await apiB.listMyEois()).find((e) => e.cfeoiId === cfeoiId)!.submitterName;
+    await apiB.dispose();
+
     await a1.page.goto(`/cfeois/${cfeoiId}/eois`);
     await expect(a1.page.getByRole('heading', { name: 'Expressions of Interest' })).toBeVisible();
     const eoiCard = a1.page.locator('div.divide-y > div').filter({ hasText: eoiMessage });
     await expect(eoiCard).toBeVisible();
+    await expect(eoiCard.getByText(submitterName, { exact: true })).toBeVisible();
+    await expect(eoiCard.getByText(/^Submitter #/)).toHaveCount(0);
     await eoiCard.getByRole('button', { name: 'Approve' }).click();
     await expect(eoiCard.getByText('Approved')).toBeVisible();
   });

--- a/frontend/portal/e2e/support/api.ts
+++ b/frontend/portal/e2e/support/api.ts
@@ -26,6 +26,8 @@ export interface CfeoiDto {
 export interface EoiDto {
   id: string;
   submittedById: string;
+  submitterName: string;
+  submitterEmail: string | null;
   message: string;
   cfeoiId: string;
   status: string;

--- a/frontend/portal/src/pages/app/CfeoiEoiInboxPage.tsx
+++ b/frontend/portal/src/pages/app/CfeoiEoiInboxPage.tsx
@@ -22,7 +22,7 @@ function EoiCard({ eoi, onApprove, onReject, isMutating }: {
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-3 mb-2">
           <span className="text-sm font-medium text-gray-900">
-            Submitter #{eoi.submittedById.slice(0, 8)}
+            {eoi.submitterName}
           </span>
           <StatusBadge type="eoi" status={eoi.status} />
         </div>

--- a/frontend/portal/src/types/index.ts
+++ b/frontend/portal/src/types/index.ts
@@ -79,6 +79,8 @@ export interface Eoi {
   status: EoiStatus;
   visibility: EoiVisibility;
   submittedById: string;
+  submitterName: string;
+  submitterEmail?: string;
   cfeoiId: string;
 }
 

--- a/src/Herit.Application/Features/Eoi/Dtos/EoiResponseDto.cs
+++ b/src/Herit.Application/Features/Eoi/Dtos/EoiResponseDto.cs
@@ -1,0 +1,33 @@
+using Herit.Domain.Enums;
+using EoiEntity = Herit.Domain.Entities.Eoi;
+using UserEntity = Herit.Domain.Entities.User;
+
+namespace Herit.Application.Features.Eoi.Dtos;
+
+/// <summary>
+/// EOI list/detail response shape. Submitter name is always included so the inbox can
+/// display who applied instead of an invented reference like a GUID fragment; the
+/// submitter's email is included only for staff callers, since the proposal owner has no
+/// channel-of-contact need until an EOI is approved (see issue #285).
+/// </summary>
+public record EoiResponseDto(
+    Guid Id,
+    string Message,
+    Guid CfeoiId,
+    EoiStatus Status,
+    EoiVisibility Visibility,
+    Guid SubmittedById,
+    string SubmitterName,
+    string? SubmitterEmail)
+{
+    public static EoiResponseDto From(EoiEntity eoi, UserEntity? submitter, bool includeSubmitterEmail)
+        => new(
+            eoi.Id,
+            eoi.Message,
+            eoi.CfeoiId,
+            eoi.Status,
+            eoi.Visibility,
+            eoi.SubmittedById,
+            submitter?.FullName ?? "Unknown submitter",
+            includeSubmitterEmail ? submitter?.Email : null);
+}

--- a/src/Herit.Application/Features/Eoi/Queries/GetEoiById/GetEoiByIdQuery.cs
+++ b/src/Herit.Application/Features/Eoi/Queries/GetEoiById/GetEoiByIdQuery.cs
@@ -1,25 +1,39 @@
+using Herit.Application.Authorization;
 using Herit.Application.Exceptions;
+using Herit.Application.Features.Eoi.Dtos;
 using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.Eoi.Queries.GetEoiById;
 
-public record GetEoiByIdQuery(Guid Id) : IRequest<Herit.Domain.Entities.Eoi>;
+public record GetEoiByIdQuery(Guid Id) : IRequest<EoiResponseDto>;
 
-public class GetEoiByIdQueryHandler : IRequestHandler<GetEoiByIdQuery, Herit.Domain.Entities.Eoi>
+public class GetEoiByIdQueryHandler : IRequestHandler<GetEoiByIdQuery, EoiResponseDto>
 {
     private readonly IEoiRepository _eoiRepository;
+    private readonly IUserRepository _userRepository;
+    private readonly ICurrentUserService _currentUserService;
 
-    public GetEoiByIdQueryHandler(IEoiRepository eoiRepository)
+    public GetEoiByIdQueryHandler(
+        IEoiRepository eoiRepository,
+        IUserRepository userRepository,
+        ICurrentUserService currentUserService)
     {
         _eoiRepository = eoiRepository;
+        _userRepository = userRepository;
+        _currentUserService = currentUserService;
     }
 
-    public async Task<Herit.Domain.Entities.Eoi> Handle(GetEoiByIdQuery request, CancellationToken cancellationToken)
+    public async Task<EoiResponseDto> Handle(GetEoiByIdQuery request, CancellationToken cancellationToken)
     {
         var eoi = await _eoiRepository.GetByIdAsync(request.Id, cancellationToken);
         if (eoi is null)
             throw new NotFoundException($"Eoi '{request.Id}' was not found.");
-        return eoi;
+
+        var submitter = await _userRepository.GetByIdAsync(eoi.SubmittedById, cancellationToken);
+        var currentUser = await _currentUserService.GetCurrentUserOrNullAsync(cancellationToken);
+        var includeEmail = VisibilityPolicy.IsStaff(currentUser);
+
+        return EoiResponseDto.From(eoi, submitter, includeEmail);
     }
 }

--- a/src/Herit.Application/Features/Eoi/Queries/ListEoisByCfeoi/ListEoisByCfeoiQuery.cs
+++ b/src/Herit.Application/Features/Eoi/Queries/ListEoisByCfeoi/ListEoisByCfeoiQuery.cs
@@ -1,31 +1,35 @@
 using Herit.Application.Authorization;
+using Herit.Application.Features.Eoi.Dtos;
 using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.Eoi.Queries.ListEoisByCfeoi;
 
-public record ListEoisByCfeoiQuery(Guid CfeoiId) : IRequest<IEnumerable<Herit.Domain.Entities.Eoi>>;
+public record ListEoisByCfeoiQuery(Guid CfeoiId) : IRequest<IEnumerable<EoiResponseDto>>;
 
-public class ListEoisByCfeoiQueryHandler : IRequestHandler<ListEoisByCfeoiQuery, IEnumerable<Herit.Domain.Entities.Eoi>>
+public class ListEoisByCfeoiQueryHandler : IRequestHandler<ListEoisByCfeoiQuery, IEnumerable<EoiResponseDto>>
 {
     private readonly IEoiRepository _eoiRepository;
     private readonly ICfeoiRepository _cfeoiRepository;
     private readonly IProposalRepository _proposalRepository;
+    private readonly IUserRepository _userRepository;
     private readonly ICurrentUserService _currentUserService;
 
     public ListEoisByCfeoiQueryHandler(
         IEoiRepository eoiRepository,
         ICfeoiRepository cfeoiRepository,
         IProposalRepository proposalRepository,
+        IUserRepository userRepository,
         ICurrentUserService currentUserService)
     {
         _eoiRepository = eoiRepository;
         _cfeoiRepository = cfeoiRepository;
         _proposalRepository = proposalRepository;
+        _userRepository = userRepository;
         _currentUserService = currentUserService;
     }
 
-    public async Task<IEnumerable<Herit.Domain.Entities.Eoi>> Handle(ListEoisByCfeoiQuery request, CancellationToken cancellationToken)
+    public async Task<IEnumerable<EoiResponseDto>> Handle(ListEoisByCfeoiQuery request, CancellationToken cancellationToken)
     {
         var user = await _currentUserService.GetCurrentUserOrNullAsync(cancellationToken);
         var eois = await _eoiRepository.ListByCfeoiAsync(request.CfeoiId, cancellationToken);
@@ -39,6 +43,15 @@ public class ListEoisByCfeoiQueryHandler : IRequestHandler<ListEoisByCfeoiQuery,
             proposalOwnerId = proposal?.AuthorId ?? Guid.Empty;
         }
 
-        return eois.Where(e => VisibilityPolicy.CanViewEoi(e, user, proposalOwnerId)).ToList();
+        var visibleEois = eois.Where(e => VisibilityPolicy.CanViewEoi(e, user, proposalOwnerId)).ToList();
+
+        var submitterIds = visibleEois.Select(e => e.SubmittedById).Distinct();
+        var submitters = (await _userRepository.ListByIdsAsync(submitterIds, cancellationToken))
+            .ToDictionary(u => u.Id);
+
+        var includeEmail = VisibilityPolicy.IsStaff(user);
+        return visibleEois
+            .Select(e => EoiResponseDto.From(e, submitters.GetValueOrDefault(e.SubmittedById), includeEmail))
+            .ToList();
     }
 }

--- a/src/Herit.Application/Features/Eoi/Queries/ListEoisByUser/ListEoisByUserQuery.cs
+++ b/src/Herit.Application/Features/Eoi/Queries/ListEoisByUser/ListEoisByUserQuery.cs
@@ -1,19 +1,35 @@
+using Herit.Application.Authorization;
+using Herit.Application.Features.Eoi.Dtos;
 using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.Eoi.Queries.ListEoisByUser;
 
-public record ListEoisByUserQuery(Guid UserId) : IRequest<IEnumerable<Herit.Domain.Entities.Eoi>>;
+public record ListEoisByUserQuery(Guid UserId) : IRequest<IEnumerable<EoiResponseDto>>;
 
-public class ListEoisByUserQueryHandler : IRequestHandler<ListEoisByUserQuery, IEnumerable<Herit.Domain.Entities.Eoi>>
+public class ListEoisByUserQueryHandler : IRequestHandler<ListEoisByUserQuery, IEnumerable<EoiResponseDto>>
 {
     private readonly IEoiRepository _eoiRepository;
+    private readonly IUserRepository _userRepository;
+    private readonly ICurrentUserService _currentUserService;
 
-    public ListEoisByUserQueryHandler(IEoiRepository eoiRepository)
+    public ListEoisByUserQueryHandler(
+        IEoiRepository eoiRepository,
+        IUserRepository userRepository,
+        ICurrentUserService currentUserService)
     {
         _eoiRepository = eoiRepository;
+        _userRepository = userRepository;
+        _currentUserService = currentUserService;
     }
 
-    public Task<IEnumerable<Herit.Domain.Entities.Eoi>> Handle(ListEoisByUserQuery request, CancellationToken cancellationToken)
-        => _eoiRepository.ListByUserAsync(request.UserId, cancellationToken);
+    public async Task<IEnumerable<EoiResponseDto>> Handle(ListEoisByUserQuery request, CancellationToken cancellationToken)
+    {
+        var eois = (await _eoiRepository.ListByUserAsync(request.UserId, cancellationToken)).ToList();
+        var submitter = await _userRepository.GetByIdAsync(request.UserId, cancellationToken);
+        var currentUser = await _currentUserService.GetCurrentUserOrNullAsync(cancellationToken);
+        var includeEmail = VisibilityPolicy.IsStaff(currentUser);
+
+        return eois.Select(e => EoiResponseDto.From(e, submitter, includeEmail)).ToList();
+    }
 }

--- a/src/Herit.Application/Interfaces/IUserRepository.cs
+++ b/src/Herit.Application/Interfaces/IUserRepository.cs
@@ -7,6 +7,7 @@ public interface IUserRepository
     Task<User?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
     Task<User?> GetByExternalIdAsync(string externalId, CancellationToken cancellationToken = default);
     Task<IEnumerable<User>> ListAsync(CancellationToken cancellationToken = default);
+    Task<IEnumerable<User>> ListByIdsAsync(IEnumerable<Guid> ids, CancellationToken cancellationToken = default);
     Task AddAsync(User user, CancellationToken cancellationToken = default);
     Task UpdateAsync(User user, CancellationToken cancellationToken = default);
     Task DeleteAsync(Guid id, CancellationToken cancellationToken = default);

--- a/src/Herit.Infrastructure/Repositories/UserRepository.cs
+++ b/src/Herit.Infrastructure/Repositories/UserRepository.cs
@@ -24,6 +24,9 @@ public class UserRepository : IUserRepository
     public async Task<IEnumerable<User>> ListAsync(CancellationToken cancellationToken = default)
         => await _context.Users.ToListAsync(cancellationToken);
 
+    public async Task<IEnumerable<User>> ListByIdsAsync(IEnumerable<Guid> ids, CancellationToken cancellationToken = default)
+        => await _context.Users.Where(u => ids.Contains(u.Id)).ToListAsync(cancellationToken);
+
     public async Task AddAsync(User user, CancellationToken cancellationToken = default)
     {
         await _context.Users.AddAsync(user, cancellationToken);

--- a/tests/Herit.Api.Tests/Controllers/EoiControllerTests.cs
+++ b/tests/Herit.Api.Tests/Controllers/EoiControllerTests.cs
@@ -1,4 +1,5 @@
 using Herit.Api.Controllers;
+using Herit.Application.Features.Eoi.Dtos;
 using Herit.Application.Features.Eoi.Queries.ListEoisByUser;
 using Herit.Application.Interfaces;
 using Herit.Domain.Entities;
@@ -6,7 +7,6 @@ using Herit.Domain.Enums;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using NSubstitute;
-using EoiEntity = Herit.Domain.Entities.Eoi;
 
 namespace Herit.Api.Tests.Controllers;
 
@@ -21,6 +21,9 @@ public class EoiControllerTests
         _controller = new EoiController(_mediator, _currentUserService);
     }
 
+    private static EoiResponseDto MakeEoiResponse(Guid submittedById, string message)
+        => new(Guid.NewGuid(), message, Guid.NewGuid(), EoiStatus.Pending, EoiVisibility.Private, submittedById, "Test User", null);
+
     [Fact]
     public async Task ListMyEois_ReturnsOkWithEois()
     {
@@ -28,17 +31,17 @@ public class EoiControllerTests
         var user = User.Create(userId, "ext-123", "test@example.com", "Test User", UserRole.Expat);
         var eois = new[]
         {
-            EoiEntity.Create(Guid.NewGuid(), userId, "Message 1", Guid.NewGuid()),
-            EoiEntity.Create(Guid.NewGuid(), userId, "Message 2", Guid.NewGuid())
+            MakeEoiResponse(userId, "Message 1"),
+            MakeEoiResponse(userId, "Message 2")
         };
         _currentUserService.GetCurrentUserAsync(Arg.Any<CancellationToken>()).Returns(user);
         _mediator.Send(Arg.Any<ListEoisByUserQuery>(), Arg.Any<CancellationToken>())
-            .Returns((IEnumerable<EoiEntity>)eois);
+            .Returns((IEnumerable<EoiResponseDto>)eois);
 
         var result = await _controller.ListMyEois(CancellationToken.None);
 
         var ok = Assert.IsType<OkObjectResult>(result);
-        var returned = Assert.IsAssignableFrom<IEnumerable<EoiEntity>>(ok.Value);
+        var returned = Assert.IsAssignableFrom<IEnumerable<EoiResponseDto>>(ok.Value);
         Assert.Equal(2, returned.Count());
     }
 
@@ -49,7 +52,7 @@ public class EoiControllerTests
         var user = User.Create(userId, "ext-123", "test@example.com", "Test User", UserRole.Expat);
         _currentUserService.GetCurrentUserAsync(Arg.Any<CancellationToken>()).Returns(user);
         _mediator.Send(Arg.Any<ListEoisByUserQuery>(), Arg.Any<CancellationToken>())
-            .Returns(Enumerable.Empty<EoiEntity>());
+            .Returns(Enumerable.Empty<EoiResponseDto>());
 
         await _controller.ListMyEois(CancellationToken.None);
 

--- a/tests/Herit.Application.Tests/Features/Eoi/Queries/GetEoiByIdQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Eoi/Queries/GetEoiByIdQueryHandlerTests.cs
@@ -1,27 +1,37 @@
 using Herit.Application.Exceptions;
 using Herit.Application.Features.Eoi.Queries.GetEoiById;
 using Herit.Application.Interfaces;
+using Herit.Domain.Enums;
 using NSubstitute;
 using EoiEntity = Herit.Domain.Entities.Eoi;
+using UserEntity = Herit.Domain.Entities.User;
 
 namespace Herit.Application.Tests.Features.Eoi.Queries;
 
 public class GetEoiByIdQueryHandlerTests
 {
     private readonly IEoiRepository _eoiRepository = Substitute.For<IEoiRepository>();
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
     private readonly GetEoiByIdQueryHandler _handler;
 
     public GetEoiByIdQueryHandlerTests()
     {
-        _handler = new GetEoiByIdQueryHandler(_eoiRepository);
+        _handler = new GetEoiByIdQueryHandler(_eoiRepository, _userRepository, _currentUserService);
     }
+
+    private static UserEntity MakeUser(Guid id, UserRole role, string fullName = "Submitter", string email = "submitter@example.com")
+        => UserEntity.Create(id, $"ext-{id}", email, fullName, role);
 
     [Fact]
     public async Task Handle_EoiFound_ReturnsEoi()
     {
         var eoiId = Guid.NewGuid();
-        var eoi = EoiEntity.Create(eoiId, Guid.NewGuid(), "Message", Guid.NewGuid());
+        var submitterId = Guid.NewGuid();
+        var eoi = EoiEntity.Create(eoiId, submitterId, "Message", Guid.NewGuid());
         _eoiRepository.GetByIdAsync(eoiId, Arg.Any<CancellationToken>()).Returns(eoi);
+        _userRepository.GetByIdAsync(submitterId, Arg.Any<CancellationToken>()).Returns(MakeUser(submitterId, UserRole.Expat));
+        _currentUserService.GetCurrentUserOrNullAsync(Arg.Any<CancellationToken>()).Returns(MakeUser(submitterId, UserRole.Expat));
 
         var result = await _handler.Handle(new GetEoiByIdQuery(eoiId), CancellationToken.None);
 
@@ -36,5 +46,41 @@ public class GetEoiByIdQueryHandlerTests
         _eoiRepository.GetByIdAsync(eoiId, Arg.Any<CancellationToken>()).Returns((EoiEntity?)null);
 
         await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(new GetEoiByIdQuery(eoiId), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_StaffCaller_IncludesSubmitterEmail()
+    {
+        var eoiId = Guid.NewGuid();
+        var submitterId = Guid.NewGuid();
+        var eoi = EoiEntity.Create(eoiId, submitterId, "Message", Guid.NewGuid());
+        _eoiRepository.GetByIdAsync(eoiId, Arg.Any<CancellationToken>()).Returns(eoi);
+        _userRepository.GetByIdAsync(submitterId, Arg.Any<CancellationToken>())
+            .Returns(MakeUser(submitterId, UserRole.Expat, "Jamie Submitter", "jamie@example.com"));
+        _currentUserService.GetCurrentUserOrNullAsync(Arg.Any<CancellationToken>())
+            .Returns(MakeUser(Guid.NewGuid(), UserRole.Staff));
+
+        var result = await _handler.Handle(new GetEoiByIdQuery(eoiId), CancellationToken.None);
+
+        Assert.Equal("Jamie Submitter", result.SubmitterName);
+        Assert.Equal("jamie@example.com", result.SubmitterEmail);
+    }
+
+    [Fact]
+    public async Task Handle_NonStaffCaller_DoesNotIncludeSubmitterEmail()
+    {
+        var eoiId = Guid.NewGuid();
+        var submitterId = Guid.NewGuid();
+        var eoi = EoiEntity.Create(eoiId, submitterId, "Message", Guid.NewGuid());
+        _eoiRepository.GetByIdAsync(eoiId, Arg.Any<CancellationToken>()).Returns(eoi);
+        _userRepository.GetByIdAsync(submitterId, Arg.Any<CancellationToken>())
+            .Returns(MakeUser(submitterId, UserRole.Expat, "Jamie Submitter", "jamie@example.com"));
+        _currentUserService.GetCurrentUserOrNullAsync(Arg.Any<CancellationToken>())
+            .Returns(MakeUser(submitterId, UserRole.Expat));
+
+        var result = await _handler.Handle(new GetEoiByIdQuery(eoiId), CancellationToken.None);
+
+        Assert.Equal("Jamie Submitter", result.SubmitterName);
+        Assert.Null(result.SubmitterEmail);
     }
 }

--- a/tests/Herit.Application.Tests/Features/Eoi/Queries/ListEoisByCfeoiQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Eoi/Queries/ListEoisByCfeoiQueryHandlerTests.cs
@@ -15,6 +15,7 @@ public class ListEoisByCfeoiQueryHandlerTests
     private readonly IEoiRepository _eoiRepository = Substitute.For<IEoiRepository>();
     private readonly ICfeoiRepository _cfeoiRepository = Substitute.For<ICfeoiRepository>();
     private readonly IProposalRepository _proposalRepository = Substitute.For<IProposalRepository>();
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
     private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
     private readonly ListEoisByCfeoiQueryHandler _handler;
 
@@ -30,7 +31,7 @@ public class ListEoisByCfeoiQueryHandlerTests
     public ListEoisByCfeoiQueryHandlerTests()
     {
         _handler = new ListEoisByCfeoiQueryHandler(
-            _eoiRepository, _cfeoiRepository, _proposalRepository, _currentUserService);
+            _eoiRepository, _cfeoiRepository, _proposalRepository, _userRepository, _currentUserService);
 
         var proposal = ProposalEntity.Create(Guid.NewGuid(), "Title", "Short", _proposalOwnerId, Guid.NewGuid(), "Long");
         var cfeoi = CfeoiEntity.Create(_cfeoiId, "CFEOI", "Description", CfeoiResourceType.Human, proposal.Id);
@@ -43,6 +44,18 @@ public class ListEoisByCfeoiQueryHandlerTests
         _proposalRepository.GetByIdAsync(proposal.Id, Arg.Any<CancellationToken>()).Returns(proposal);
         _eoiRepository.ListByCfeoiAsync(_cfeoiId, Arg.Any<CancellationToken>())
             .Returns(new[] { _privateByA, _sharedByB, _privateByB });
+
+        _userRepository.ListByIdsAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var ids = ((IEnumerable<Guid>)callInfo[0]).ToHashSet();
+                var users = new[]
+                {
+                    MakeUser(_submitterAId, UserRole.Expat, "Submitter A", "a@example.com"),
+                    MakeUser(_submitterBId, UserRole.Expat, "Submitter B", "b@example.com")
+                };
+                return users.Where(u => ids.Contains(u.Id));
+            });
     }
 
     private EoiEntity MakeEoi(Guid submittedById, EoiVisibility visibility)
@@ -53,8 +66,8 @@ public class ListEoisByCfeoiQueryHandlerTests
         return eoi;
     }
 
-    private static UserEntity MakeUser(Guid id, UserRole role)
-        => UserEntity.Create(id, $"ext-{id}", "user@example.com", "User", role);
+    private static UserEntity MakeUser(Guid id, UserRole role, string fullName = "User", string email = "user@example.com")
+        => UserEntity.Create(id, $"ext-{id}", email, fullName, role);
 
     private void CurrentUser(UserEntity? user)
         => _currentUserService.GetCurrentUserOrNullAsync(Arg.Any<CancellationToken>()).Returns(user);
@@ -110,5 +123,34 @@ public class ListEoisByCfeoiQueryHandlerTests
         var result = await _handler.Handle(new ListEoisByCfeoiQuery(_cfeoiId), CancellationToken.None);
 
         Assert.Equal(3, result.Count());
+    }
+
+    [Fact]
+    public async Task Handle_ProposalOwner_IncludesSubmitterNameButNotEmail()
+    {
+        CurrentUser(MakeUser(_proposalOwnerId, UserRole.Expat));
+
+        var result = await _handler.Handle(new ListEoisByCfeoiQuery(_cfeoiId), CancellationToken.None);
+        var dto = Assert.Single(result);
+
+        Assert.Equal("Submitter B", dto.SubmitterName);
+        Assert.Null(dto.SubmitterEmail);
+    }
+
+    [Theory]
+    [InlineData(UserRole.Staff)]
+    [InlineData(UserRole.OrganisationAdmin)]
+    [InlineData(UserRole.SuperAdmin)]
+    public async Task Handle_Staff_IncludesSubmitterNameAndEmail(UserRole role)
+    {
+        CurrentUser(MakeUser(Guid.NewGuid(), role));
+
+        var result = await _handler.Handle(new ListEoisByCfeoiQuery(_cfeoiId), CancellationToken.None);
+
+        Assert.All(result, dto =>
+        {
+            Assert.False(string.IsNullOrEmpty(dto.SubmitterName));
+            Assert.False(string.IsNullOrEmpty(dto.SubmitterEmail));
+        });
     }
 }

--- a/tests/Herit.Application.Tests/Features/Eoi/Queries/ListEoisByUserQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Eoi/Queries/ListEoisByUserQueryHandlerTests.cs
@@ -1,19 +1,26 @@
 using Herit.Application.Features.Eoi.Queries.ListEoisByUser;
 using Herit.Application.Interfaces;
+using Herit.Domain.Enums;
 using NSubstitute;
 using EoiEntity = Herit.Domain.Entities.Eoi;
+using UserEntity = Herit.Domain.Entities.User;
 
 namespace Herit.Application.Tests.Features.Eoi.Queries;
 
 public class ListEoisByUserQueryHandlerTests
 {
     private readonly IEoiRepository _eoiRepository = Substitute.For<IEoiRepository>();
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
     private readonly ListEoisByUserQueryHandler _handler;
 
     public ListEoisByUserQueryHandlerTests()
     {
-        _handler = new ListEoisByUserQueryHandler(_eoiRepository);
+        _handler = new ListEoisByUserQueryHandler(_eoiRepository, _userRepository, _currentUserService);
     }
+
+    private static UserEntity MakeUser(Guid id, UserRole role, string fullName = "Submitter", string email = "submitter@example.com")
+        => UserEntity.Create(id, $"ext-{id}", email, fullName, role);
 
     [Fact]
     public async Task Handle_NonEmptyList_ReturnsAllEoisForUser()
@@ -25,6 +32,8 @@ public class ListEoisByUserQueryHandlerTests
             EoiEntity.Create(Guid.NewGuid(), userId, "Message 2", Guid.NewGuid())
         };
         _eoiRepository.ListByUserAsync(userId, Arg.Any<CancellationToken>()).Returns(eois);
+        _userRepository.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(MakeUser(userId, UserRole.Expat));
+        _currentUserService.GetCurrentUserOrNullAsync(Arg.Any<CancellationToken>()).Returns(MakeUser(userId, UserRole.Expat));
 
         var result = await _handler.Handle(new ListEoisByUserQuery(userId), CancellationToken.None);
 
@@ -36,9 +45,43 @@ public class ListEoisByUserQueryHandlerTests
     {
         var userId = Guid.NewGuid();
         _eoiRepository.ListByUserAsync(userId, Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<EoiEntity>());
+        _userRepository.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(MakeUser(userId, UserRole.Expat));
+        _currentUserService.GetCurrentUserOrNullAsync(Arg.Any<CancellationToken>()).Returns(MakeUser(userId, UserRole.Expat));
 
         var result = await _handler.Handle(new ListEoisByUserQuery(userId), CancellationToken.None);
 
         Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task Handle_IncludesSubmitterName()
+    {
+        var userId = Guid.NewGuid();
+        var eois = new[] { EoiEntity.Create(Guid.NewGuid(), userId, "Message", Guid.NewGuid()) };
+        _eoiRepository.ListByUserAsync(userId, Arg.Any<CancellationToken>()).Returns(eois);
+        _userRepository.GetByIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(MakeUser(userId, UserRole.Expat, "Jamie Submitter"));
+        _currentUserService.GetCurrentUserOrNullAsync(Arg.Any<CancellationToken>())
+            .Returns(MakeUser(userId, UserRole.Expat));
+
+        var result = await _handler.Handle(new ListEoisByUserQuery(userId), CancellationToken.None);
+
+        Assert.Equal("Jamie Submitter", Assert.Single(result).SubmitterName);
+    }
+
+    [Fact]
+    public async Task Handle_NonStaffCaller_DoesNotIncludeSubmitterEmail()
+    {
+        var userId = Guid.NewGuid();
+        var eois = new[] { EoiEntity.Create(Guid.NewGuid(), userId, "Message", Guid.NewGuid()) };
+        _eoiRepository.ListByUserAsync(userId, Arg.Any<CancellationToken>()).Returns(eois);
+        _userRepository.GetByIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(MakeUser(userId, UserRole.Expat));
+        _currentUserService.GetCurrentUserOrNullAsync(Arg.Any<CancellationToken>())
+            .Returns(MakeUser(userId, UserRole.Expat));
+
+        var result = await _handler.Handle(new ListEoisByUserQuery(userId), CancellationToken.None);
+
+        Assert.Null(Assert.Single(result).SubmitterEmail);
     }
 }

--- a/tests/Herit.Infrastructure.Tests/Repositories/UserRepositoryTests.cs
+++ b/tests/Herit.Infrastructure.Tests/Repositories/UserRepositoryTests.cs
@@ -136,4 +136,27 @@ public class UserRepositoryTests : IDisposable
 
         Assert.Null(result);
     }
+
+    [Fact]
+    public async Task ListByIdsAsync_ReturnsOnlyMatchingUsers()
+    {
+        var idA = Guid.NewGuid();
+        var idB = Guid.NewGuid();
+        await _repository.AddAsync(User.Create(idA, "ext-a", "a@example.com", "User A", UserRole.Staff));
+        await _repository.AddAsync(User.Create(idB, "ext-b", "b@example.com", "User B", UserRole.Expat));
+        await _repository.AddAsync(User.Create(Guid.NewGuid(), "ext-c", "c@example.com", "User C", UserRole.Expat));
+
+        var result = await _repository.ListByIdsAsync(new[] { idA, idB });
+
+        Assert.Equal(2, result.Count());
+        Assert.Equal(new[] { idA, idB }.OrderBy(x => x), result.Select(u => u.Id).OrderBy(x => x));
+    }
+
+    [Fact]
+    public async Task ListByIdsAsync_WhenNoIds_ReturnsEmptyCollection()
+    {
+        var result = await _repository.ListByIdsAsync(Array.Empty<Guid>());
+
+        Assert.Empty(result);
+    }
 }


### PR DESCRIPTION
## Description

Spec section 3d requires the EOI inbox to show the submitter's name (and the staff-app flow 2c design additionally shows email), but `ListEoisByCfeoiQuery`, `ListMyEois`, and `GetEoiById` previously returned raw `Eoi` entities whose only submitter field is `submittedById`. `GET /Users/{id}` is `AdminOrSuperAdmin`-gated, so neither proposal owners nor staff could resolve the ID — the portal inbox worked around this with `Submitter #{first-8-of-GUID}`, an invented-reference-ID pattern the design reviews prohibit.

This PR introduces `EoiResponseDto`, resolved server-side via a join on `User`, and returned from all three EOI list/detail queries in place of the raw entity.

**Field-exposure decision:** submitter **full name** is always included for anyone authorized to see the EOI (owner, staff, the submitter). Submitter **email** is included **staff-only** (gated on `VisibilityPolicy.IsStaff(currentUser)`), per the issue's recommendation — the proposal owner has no channel-of-contact need until an EOI is approved. This also matches the staff flow 2c design's flat `name`/`email` shape on each EOI list item, so the same DTO can be consumed as-is once the staff app is built.

The portal inbox (`CfeoiEoiInboxPage.tsx`) now renders `eoi.submitterName` instead of the GUID fragment.

## Linked Issue

Closes #285

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- Added/updated unit tests for `ListEoisByCfeoiQueryHandler`, `ListEoisByUserQueryHandler`, and `GetEoiByIdQueryHandler` covering the DTO mapping and the staff-only email exposure rule, plus a new `UserRepository.ListByIdsAsync` in-memory-DB test.
- Updated `EoiControllerTests` to assert against `EoiResponseDto`.
- Added an E2E assertion in `full-loop.spec.ts` verifying the proposal owner sees the real submitter name (not a `Submitter #` fragment) in the inbox.
- `dotnet build --configuration Release` and `dotnet test --configuration Release --no-build`: all 287 backend tests pass.
- Frontend: `tsc --noEmit` and `vitest run` pass.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [x] Relevant documentation updated (N/A — no docs changes required; DTO shape matches existing flow 2c design doc)
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)