### PR TITLE
Backend hardening: 409 for restricted org deletes, guard self/last-admin deletion

### DIFF
--- a/frontend/portal/e2e/organisations.spec.ts
+++ b/frontend/portal/e2e/organisations.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test';
+import { Api } from './support/api';
+import { readRunState, type RunState } from './support/run-state';
+
+/**
+ * Backend hardening (issue #284): deleting an organisation with attached
+ * records must surface a 409 Conflict rather than an unhandled DB error.
+ */
+
+let state: RunState;
+let admin: Api;
+
+test.beforeAll(async () => {
+  state = readRunState();
+  admin = await Api.forToken(state.identities.superAdmin.token);
+});
+
+test.afterAll(async () => {
+  await admin.dispose();
+});
+
+test('deleting an organisation with attached records returns 409, empty organisation deletes cleanly', async ({}, testInfo) => {
+  const scope = `${state.runId}-w${testInfo.workerIndex}`;
+  const orgId = await admin.createOrganisation(`Org delete conflict fixture (E2E ${scope})`);
+
+  const staffUserId = await admin.createStaffUser(
+    `org-delete-conflict-${scope}@e2e.herit.local`,
+    'Org Delete Conflict Fixture Staff',
+    orgId,
+  );
+
+  const conflictResponse = await admin.raw('DELETE', `/Organisations/${orgId}`);
+  expect(conflictResponse.status()).toBe(409);
+
+  await admin.deleteStaffUser(staffUserId);
+
+  const emptyResponse = await admin.raw('DELETE', `/Organisations/${orgId}`);
+  expect(emptyResponse.status()).toBe(204);
+});

--- a/src/Herit.Api/Middleware/GlobalExceptionHandler.cs
+++ b/src/Herit.Api/Middleware/GlobalExceptionHandler.cs
@@ -26,6 +26,12 @@ public class GlobalExceptionHandler(ILogger<GlobalExceptionHandler> logger) : IE
                 Title = "Forbidden",
                 Detail = exception.Message
             },
+            ConflictException => new ProblemDetails
+            {
+                Status = StatusCodes.Status409Conflict,
+                Title = "Conflict",
+                Detail = exception.Message
+            },
             InvalidOperationException => new ProblemDetails
             {
                 Status = StatusCodes.Status400BadRequest,

--- a/src/Herit.Application/Exceptions/ConflictException.cs
+++ b/src/Herit.Application/Exceptions/ConflictException.cs
@@ -1,0 +1,6 @@
+namespace Herit.Application.Exceptions;
+
+public class ConflictException : Exception
+{
+    public ConflictException(string message) : base(message) { }
+}

--- a/src/Herit.Application/Features/Organisation/Commands/DeleteOrganisation/DeleteOrganisationCommand.cs
+++ b/src/Herit.Application/Features/Organisation/Commands/DeleteOrganisation/DeleteOrganisationCommand.cs
@@ -9,10 +9,20 @@ public record DeleteOrganisationCommand(Guid Id) : IRequest<Unit>;
 public class DeleteOrganisationCommandHandler : IRequestHandler<DeleteOrganisationCommand, Unit>
 {
     private readonly IOrganisationRepository _repository;
+    private readonly IUserRepository _userRepository;
+    private readonly IRfpRepository _rfpRepository;
+    private readonly IProposalRepository _proposalRepository;
 
-    public DeleteOrganisationCommandHandler(IOrganisationRepository repository)
+    public DeleteOrganisationCommandHandler(
+        IOrganisationRepository repository,
+        IUserRepository userRepository,
+        IRfpRepository rfpRepository,
+        IProposalRepository proposalRepository)
     {
         _repository = repository;
+        _userRepository = userRepository;
+        _rfpRepository = rfpRepository;
+        _proposalRepository = proposalRepository;
     }
 
     public async Task<Unit> Handle(DeleteOrganisationCommand request, CancellationToken cancellationToken)
@@ -21,7 +31,28 @@ public class DeleteOrganisationCommandHandler : IRequestHandler<DeleteOrganisati
         if (organisation is null)
             throw new NotFoundException($"Organisation '{request.Id}' does not exist.");
 
+        await EnsureNoAttachedRecordsAsync(request.Id, cancellationToken);
+
         await _repository.DeleteAsync(request.Id, cancellationToken);
         return Unit.Value;
+    }
+
+    private async Task EnsureNoAttachedRecordsAsync(Guid organisationId, CancellationToken cancellationToken)
+    {
+        var users = await _userRepository.ListAsync(cancellationToken);
+        if (users.Any(u => u.OrganisationId == organisationId))
+            throw new ConflictException($"Organisation '{organisationId}' still has attached users and cannot be deleted.");
+
+        var organisations = await _repository.ListAsync(cancellationToken);
+        if (organisations.Any(o => o.ParentId == organisationId))
+            throw new ConflictException($"Organisation '{organisationId}' still has child organisations and cannot be deleted.");
+
+        var rfps = await _rfpRepository.ListAsync(cancellationToken);
+        if (rfps.Any(r => r.OrganisationId == organisationId))
+            throw new ConflictException($"Organisation '{organisationId}' still has attached RFPs and cannot be deleted.");
+
+        var proposals = await _proposalRepository.ListAsync(cancellationToken);
+        if (proposals.Any(p => p.OrganisationId == organisationId))
+            throw new ConflictException($"Organisation '{organisationId}' still has attached proposals and cannot be deleted.");
     }
 }

--- a/src/Herit.Application/Features/User/Commands/DeleteOrganisationAdmin/DeleteOrganisationAdminCommand.cs
+++ b/src/Herit.Application/Features/User/Commands/DeleteOrganisationAdmin/DeleteOrganisationAdminCommand.cs
@@ -11,11 +11,16 @@ public class DeleteOrganisationAdminCommandHandler : IRequestHandler<DeleteOrgan
 {
     private readonly IUserRepository _userRepository;
     private readonly IIdentityProviderService _identityProviderService;
+    private readonly ICurrentUserService _currentUserService;
 
-    public DeleteOrganisationAdminCommandHandler(IUserRepository userRepository, IIdentityProviderService identityProviderService)
+    public DeleteOrganisationAdminCommandHandler(
+        IUserRepository userRepository,
+        IIdentityProviderService identityProviderService,
+        ICurrentUserService currentUserService)
     {
         _userRepository = userRepository;
         _identityProviderService = identityProviderService;
+        _currentUserService = currentUserService;
     }
 
     public async Task<Unit> Handle(DeleteOrganisationAdminCommand request, CancellationToken cancellationToken)
@@ -26,6 +31,15 @@ public class DeleteOrganisationAdminCommandHandler : IRequestHandler<DeleteOrgan
 
         if (user.Role != UserRole.OrganisationAdmin)
             throw new InvalidOperationException($"User with ID '{request.Id}' is not an OrganisationAdmin.");
+
+        var currentUser = await _currentUserService.GetCurrentUserAsync(cancellationToken);
+        if (currentUser.Id == request.Id)
+            throw new ForbiddenException("You cannot delete your own account.");
+
+        var allUsers = await _userRepository.ListAsync(cancellationToken);
+        var remainingAdminCount = allUsers.Count(u => u.Role == UserRole.OrganisationAdmin);
+        if (remainingAdminCount <= 1)
+            throw new ConflictException("The last remaining OrganisationAdmin cannot be deleted.");
 
         await _identityProviderService.DeleteUserAsync(user.ExternalId, cancellationToken);
         await _userRepository.DeleteAsync(request.Id, cancellationToken);

--- a/src/Herit.Application/Features/User/Commands/DeleteStaffUser/DeleteStaffUserCommand.cs
+++ b/src/Herit.Application/Features/User/Commands/DeleteStaffUser/DeleteStaffUserCommand.cs
@@ -11,11 +11,16 @@ public class DeleteStaffUserCommandHandler : IRequestHandler<DeleteStaffUserComm
 {
     private readonly IUserRepository _userRepository;
     private readonly IIdentityProviderService _identityProviderService;
+    private readonly ICurrentUserService _currentUserService;
 
-    public DeleteStaffUserCommandHandler(IUserRepository userRepository, IIdentityProviderService identityProviderService)
+    public DeleteStaffUserCommandHandler(
+        IUserRepository userRepository,
+        IIdentityProviderService identityProviderService,
+        ICurrentUserService currentUserService)
     {
         _userRepository = userRepository;
         _identityProviderService = identityProviderService;
+        _currentUserService = currentUserService;
     }
 
     public async Task<Unit> Handle(DeleteStaffUserCommand request, CancellationToken cancellationToken)
@@ -26,6 +31,10 @@ public class DeleteStaffUserCommandHandler : IRequestHandler<DeleteStaffUserComm
 
         if (user.Role != UserRole.Staff)
             throw new InvalidOperationException($"User with ID '{request.Id}' is not a Staff user.");
+
+        var currentUser = await _currentUserService.GetCurrentUserAsync(cancellationToken);
+        if (currentUser.Id == request.Id)
+            throw new ForbiddenException("You cannot delete your own account.");
 
         await _identityProviderService.DeleteUserAsync(user.ExternalId, cancellationToken);
         await _userRepository.DeleteAsync(request.Id, cancellationToken);

--- a/tests/Herit.Api.Tests/Middleware/GlobalExceptionHandlerTests.cs
+++ b/tests/Herit.Api.Tests/Middleware/GlobalExceptionHandlerTests.cs
@@ -34,6 +34,18 @@ public class GlobalExceptionHandlerTests
     }
 
     [Fact]
+    public async Task TryHandleAsync_ConflictException_Returns409()
+    {
+        var context = CreateHttpContext();
+        var exception = new ConflictException("Organisation still has attached records");
+
+        var handled = await _handler.TryHandleAsync(context, exception, CancellationToken.None);
+
+        Assert.True(handled);
+        Assert.Equal((int)HttpStatusCode.Conflict, context.Response.StatusCode);
+    }
+
+    [Fact]
     public async Task TryHandleAsync_InvalidOperationException_Returns400()
     {
         var context = CreateHttpContext();

--- a/tests/Herit.Application.Tests/Features/Organisation/Commands/DeleteOrganisationCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Organisation/Commands/DeleteOrganisationCommandHandlerTests.cs
@@ -1,23 +1,35 @@
 using Herit.Application.Exceptions;
 using Herit.Application.Features.Organisation.Commands.DeleteOrganisation;
 using Herit.Application.Interfaces;
+using Herit.Domain.Enums;
 using NSubstitute;
 using OrganisationEntity = Herit.Domain.Entities.Organisation;
+using ProposalEntity = Herit.Domain.Entities.Proposal;
+using RfpEntity = Herit.Domain.Entities.Rfp;
+using UserEntity = Herit.Domain.Entities.User;
 
 namespace Herit.Application.Tests.Features.Organisation.Commands;
 
 public class DeleteOrganisationCommandHandlerTests
 {
     private readonly IOrganisationRepository _repository = Substitute.For<IOrganisationRepository>();
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly IRfpRepository _rfpRepository = Substitute.For<IRfpRepository>();
+    private readonly IProposalRepository _proposalRepository = Substitute.For<IProposalRepository>();
     private readonly DeleteOrganisationCommandHandler _handler;
 
     public DeleteOrganisationCommandHandlerTests()
     {
-        _handler = new DeleteOrganisationCommandHandler(_repository);
+        _handler = new DeleteOrganisationCommandHandler(_repository, _userRepository, _rfpRepository, _proposalRepository);
+
+        _userRepository.ListAsync(Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<UserEntity>());
+        _repository.ListAsync(Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<OrganisationEntity>());
+        _rfpRepository.ListAsync(Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<RfpEntity>());
+        _proposalRepository.ListAsync(Arg.Any<CancellationToken>()).Returns(Enumerable.Empty<ProposalEntity>());
     }
 
     [Fact]
-    public async Task Handle_WithExistingOrganisation_DeletesAndReturnsUnit()
+    public async Task Handle_WithExistingEmptyOrganisation_DeletesAndReturnsUnit()
     {
         var id = Guid.NewGuid();
         var organisation = OrganisationEntity.Create(id, "Ministry of Finance");
@@ -52,5 +64,57 @@ public class DeleteOrganisationCommandHandlerTests
         await _handler.Handle(new DeleteOrganisationCommand(id), CancellationToken.None);
 
         await _repository.Received(1).DeleteAsync(id, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WithAttachedUser_ThrowsConflictException()
+    {
+        var id = Guid.NewGuid();
+        var organisation = OrganisationEntity.Create(id, "Ministry of Finance");
+        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(organisation);
+        var attachedUser = UserEntity.Create(Guid.NewGuid(), "ext-1", "user@example.com", "Test User", UserRole.Staff, id);
+        _userRepository.ListAsync(Arg.Any<CancellationToken>()).Returns([attachedUser]);
+
+        await Assert.ThrowsAsync<ConflictException>(() => _handler.Handle(new DeleteOrganisationCommand(id), CancellationToken.None));
+        await _repository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WithChildOrganisation_ThrowsConflictException()
+    {
+        var id = Guid.NewGuid();
+        var organisation = OrganisationEntity.Create(id, "Ministry of Finance");
+        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(organisation);
+        var child = OrganisationEntity.Create(Guid.NewGuid(), "Child Org", id);
+        _repository.ListAsync(Arg.Any<CancellationToken>()).Returns([child]);
+
+        await Assert.ThrowsAsync<ConflictException>(() => _handler.Handle(new DeleteOrganisationCommand(id), CancellationToken.None));
+        await _repository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WithAttachedRfp_ThrowsConflictException()
+    {
+        var id = Guid.NewGuid();
+        var organisation = OrganisationEntity.Create(id, "Ministry of Finance");
+        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(organisation);
+        var rfp = RfpEntity.Create(Guid.NewGuid(), "Title", "Short", Guid.NewGuid(), id, "Long");
+        _rfpRepository.ListAsync(Arg.Any<CancellationToken>()).Returns([rfp]);
+
+        await Assert.ThrowsAsync<ConflictException>(() => _handler.Handle(new DeleteOrganisationCommand(id), CancellationToken.None));
+        await _repository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WithAttachedProposal_ThrowsConflictException()
+    {
+        var id = Guid.NewGuid();
+        var organisation = OrganisationEntity.Create(id, "Ministry of Finance");
+        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(organisation);
+        var proposal = ProposalEntity.Create(Guid.NewGuid(), "Title", "Short", Guid.NewGuid(), id, "Long");
+        _proposalRepository.ListAsync(Arg.Any<CancellationToken>()).Returns([proposal]);
+
+        await Assert.ThrowsAsync<ConflictException>(() => _handler.Handle(new DeleteOrganisationCommand(id), CancellationToken.None));
+        await _repository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Herit.Application.Tests/Features/User/Commands/DeleteOrganisationAdminCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/User/Commands/DeleteOrganisationAdminCommandHandlerTests.cs
@@ -12,11 +12,15 @@ public class DeleteOrganisationAdminCommandHandlerTests
 {
     private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
     private readonly IIdentityProviderService _identityProviderService = Substitute.For<IIdentityProviderService>();
+    private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
     private readonly DeleteOrganisationAdminCommandHandler _handler;
 
     public DeleteOrganisationAdminCommandHandlerTests()
     {
-        _handler = new DeleteOrganisationAdminCommandHandler(_userRepository, _identityProviderService);
+        _handler = new DeleteOrganisationAdminCommandHandler(_userRepository, _identityProviderService, _currentUserService);
+
+        var actingUser = UserEntity.Create(Guid.NewGuid(), "ext-actor", "actor@gov.eg", "Acting Admin", UserRole.SuperAdmin);
+        _currentUserService.GetCurrentUserAsync(Arg.Any<CancellationToken>()).Returns(actingUser);
     }
 
     [Fact]
@@ -24,7 +28,9 @@ public class DeleteOrganisationAdminCommandHandlerTests
     {
         var userId = Guid.NewGuid();
         var user = UserEntity.Create(userId, "ext-admin", "admin@gov.eg", "Org Admin", UserRole.OrganisationAdmin, Guid.NewGuid());
+        var otherAdmin = UserEntity.Create(Guid.NewGuid(), "ext-admin-2", "admin2@gov.eg", "Other Admin", UserRole.OrganisationAdmin, Guid.NewGuid());
         _userRepository.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+        _userRepository.ListAsync(Arg.Any<CancellationToken>()).Returns([user, otherAdmin]);
 
         var command = new DeleteOrganisationAdminCommand(userId);
         await _handler.Handle(command, CancellationToken.None);
@@ -61,11 +67,45 @@ public class DeleteOrganisationAdminCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WhenIdentityProviderDeletionThrows_DoesNotDeleteFromDatabase()
+    public async Task Handle_WhenDeletingSelf_ThrowsForbiddenException()
+    {
+        var userId = Guid.NewGuid();
+        var user = UserEntity.Create(userId, "ext-admin", "admin@gov.eg", "Org Admin", UserRole.OrganisationAdmin, Guid.NewGuid());
+        var otherAdmin = UserEntity.Create(Guid.NewGuid(), "ext-admin-2", "admin2@gov.eg", "Other Admin", UserRole.OrganisationAdmin, Guid.NewGuid());
+        _userRepository.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+        _userRepository.ListAsync(Arg.Any<CancellationToken>()).Returns([user, otherAdmin]);
+        _currentUserService.GetCurrentUserAsync(Arg.Any<CancellationToken>()).Returns(user);
+
+        var command = new DeleteOrganisationAdminCommand(userId);
+
+        await Assert.ThrowsAsync<ForbiddenException>(() => _handler.Handle(command, CancellationToken.None));
+        await _userRepository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        await _identityProviderService.DidNotReceive().DeleteUserAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenDeletingLastOrganisationAdmin_ThrowsConflictException()
     {
         var userId = Guid.NewGuid();
         var user = UserEntity.Create(userId, "ext-admin", "admin@gov.eg", "Org Admin", UserRole.OrganisationAdmin, Guid.NewGuid());
         _userRepository.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+        _userRepository.ListAsync(Arg.Any<CancellationToken>()).Returns([user]);
+
+        var command = new DeleteOrganisationAdminCommand(userId);
+
+        await Assert.ThrowsAsync<ConflictException>(() => _handler.Handle(command, CancellationToken.None));
+        await _userRepository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        await _identityProviderService.DidNotReceive().DeleteUserAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenIdentityProviderDeletionThrows_DoesNotDeleteFromDatabase()
+    {
+        var userId = Guid.NewGuid();
+        var user = UserEntity.Create(userId, "ext-admin", "admin@gov.eg", "Org Admin", UserRole.OrganisationAdmin, Guid.NewGuid());
+        var otherAdmin = UserEntity.Create(Guid.NewGuid(), "ext-admin-2", "admin2@gov.eg", "Other Admin", UserRole.OrganisationAdmin, Guid.NewGuid());
+        _userRepository.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+        _userRepository.ListAsync(Arg.Any<CancellationToken>()).Returns([user, otherAdmin]);
         _identityProviderService.DeleteUserAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Identity provider deletion failed"));
 

--- a/tests/Herit.Application.Tests/Features/User/Commands/DeleteStaffUserCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/User/Commands/DeleteStaffUserCommandHandlerTests.cs
@@ -12,11 +12,15 @@ public class DeleteStaffUserCommandHandlerTests
 {
     private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
     private readonly IIdentityProviderService _identityProviderService = Substitute.For<IIdentityProviderService>();
+    private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
     private readonly DeleteStaffUserCommandHandler _handler;
 
     public DeleteStaffUserCommandHandlerTests()
     {
-        _handler = new DeleteStaffUserCommandHandler(_userRepository, _identityProviderService);
+        _handler = new DeleteStaffUserCommandHandler(_userRepository, _identityProviderService, _currentUserService);
+
+        var actingUser = UserEntity.Create(Guid.NewGuid(), "ext-actor", "actor@gov.eg", "Acting Admin", UserRole.SuperAdmin);
+        _currentUserService.GetCurrentUserAsync(Arg.Any<CancellationToken>()).Returns(actingUser);
     }
 
     [Fact]
@@ -56,6 +60,21 @@ public class DeleteStaffUserCommandHandlerTests
         var command = new DeleteStaffUserCommand(userId);
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(command, CancellationToken.None));
+        await _userRepository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        await _identityProviderService.DidNotReceive().DeleteUserAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenDeletingSelf_ThrowsForbiddenException()
+    {
+        var userId = Guid.NewGuid();
+        var user = UserEntity.Create(userId, "ext-staff", "staff@gov.eg", "Staff User", UserRole.Staff, Guid.NewGuid());
+        _userRepository.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+        _currentUserService.GetCurrentUserAsync(Arg.Any<CancellationToken>()).Returns(user);
+
+        var command = new DeleteStaffUserCommand(userId);
+
+        await Assert.ThrowsAsync<ForbiddenException>(() => _handler.Handle(command, CancellationToken.None));
         await _userRepository.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
         await _identityProviderService.DidNotReceive().DeleteUserAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }


### PR DESCRIPTION
## Description

Closes two backend gaps flagged during the staff-app design reviews (flow 3, Administration):

1. **Organisation delete surfaces a raw DB error instead of a 409.** `DeleteOrganisationCommandHandler` now pre-checks for attached users, child organisations, RFPs, and proposals before deleting, and throws a new `ConflictException` (mapped to 409 in `GlobalExceptionHandler`, mirroring the existing `ForbiddenException` → 403 pattern) if any are found. Note: only the `Users.OrganisationId` and `Organisation.ParentId` foreign keys are actually `DeleteBehavior.Restrict` in the DB (verified in `HeritDbContextModelSnapshot.cs`) — RFPs and Proposals reference `OrganisationId` as a plain `Guid` with no FK constraint, so they would silently orphan rather than throw. The pre-check covers all four record types explicitly rather than relying on the DB exception, so RFPs/Proposals are protected too.

2. **Nothing prevents deleting your own account or the last admin.** `DeleteStaffUserCommandHandler` and `DeleteOrganisationAdminCommandHandler` now inject `ICurrentUserService` and reject self-deletion with a `ForbiddenException` (403). `DeleteOrganisationAdminCommandHandler` additionally rejects deleting the last remaining `OrganisationAdmin` with a `ConflictException` (409).

   **Scoping decision on "last admin":** there is no delete endpoint for `SuperAdmin` accounts anywhere in the codebase today (only creatable via the CLI seeder) — `DeleteOrganisationAdminCommand` explicitly rejects non-`OrganisationAdmin` roles, so a `SuperAdmin` can't reach this path. The only administrative role actually deletable today is `OrganisationAdmin`, so the last-admin guard targets that role, counted globally (not per-organisation). If a `SuperAdmin`-delete path is added in the future, the same last-admin check should be applied there.

## Linked Issue

Closes #284

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- Unit tests added/extended for all three handlers (`DeleteOrganisationCommandHandlerTests`, `DeleteStaffUserCommandHandlerTests`, `DeleteOrganisationAdminCommandHandlerTests`) covering: empty org delete succeeds, org with attached users/child-orgs/RFPs/proposals → `ConflictException`, self-delete → `ForbiddenException`, delete of the last `OrganisationAdmin` → `ConflictException`, delete of a non-last admin → succeeds.
- Added a `GlobalExceptionHandlerTests` case asserting `ConflictException` → 409.
- Extended the Playwright E2E suite with `organisations.spec.ts`: creates an org with an attached staff user, asserts `DELETE` returns 409, deletes the staff user, then asserts the now-empty org deletes with 204.
- `dotnet build` and `dotnet test` pass locally (295 tests, 0 failures).

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)