### PR TITLE
Implement the app shell and dashboard (flow 1, screen 03)

### DIFF
--- a/frontend/staff/src/api/organisations.ts
+++ b/frontend/staff/src/api/organisations.ts
@@ -1,0 +1,5 @@
+import { apiClient } from './client';
+import type { Organisation } from '../types';
+
+export const listOrganisations = (): Promise<Organisation[]> =>
+  apiClient.get('/Organisations').then((r) => r.data);

--- a/frontend/staff/src/api/proposals.ts
+++ b/frontend/staff/src/api/proposals.ts
@@ -1,0 +1,4 @@
+import { apiClient } from './client';
+import type { Proposal } from '../types';
+
+export const listProposals = (): Promise<Proposal[]> => apiClient.get('/Proposals').then((r) => r.data);

--- a/frontend/staff/src/api/rfps.ts
+++ b/frontend/staff/src/api/rfps.ts
@@ -1,0 +1,4 @@
+import { apiClient } from './client';
+import type { Rfp } from '../types';
+
+export const listRfps = (): Promise<Rfp[]> => apiClient.get('/Rfps').then((r) => r.data);

--- a/frontend/staff/src/api/users.ts
+++ b/frontend/staff/src/api/users.ts
@@ -5,3 +5,6 @@ import type { User } from '../types';
 // Returns 404 if no User record exists for this identity (ADR-015: staff/admin
 // accounts are provisioned, never JIT-registered — a 404 here means access-denied).
 export const getCurrentUser = (): Promise<User> => apiClient.get('/Users/me').then((r) => r.data);
+
+// AdminOrSuperAdmin only — used for the admin dashboard's "Staff & admins" count.
+export const listUsers = (): Promise<User[]> => apiClient.get('/Users').then((r) => r.data);

--- a/frontend/staff/src/components/StatCard.tsx
+++ b/frontend/staff/src/components/StatCard.tsx
@@ -1,0 +1,28 @@
+import { Link } from 'react-router-dom';
+
+type StatCardTone = 'neutral' | 'amber' | 'orange';
+
+const toneStyles: Record<StatCardTone, string> = {
+  neutral: 'text-neutral-900',
+  amber: 'text-status-amber-text',
+  orange: 'text-status-orange-text',
+};
+
+interface StatCardProps {
+  readonly value: number;
+  readonly label: string;
+  readonly to: string;
+  readonly tone?: StatCardTone;
+}
+
+export default function StatCard({ value, label, to, tone = 'neutral' }: StatCardProps) {
+  return (
+    <Link
+      to={to}
+      className="min-w-[92px] px-4 py-3 bg-neutral-0 border border-neutral-200 rounded-lg shadow-soft hover:border-brand-300 hover:shadow-card transition-colors"
+    >
+      <div className={`text-2xl font-bold ${toneStyles[tone]}`}>{value}</div>
+      <div className="text-xs text-neutral-500 mt-1 whitespace-nowrap">{label}</div>
+    </Link>
+  );
+}

--- a/frontend/staff/src/components/layout/AppLayout.tsx
+++ b/frontend/staff/src/components/layout/AppLayout.tsx
@@ -1,0 +1,13 @@
+import { Outlet } from 'react-router-dom';
+import AppNav from '../nav/AppNav';
+
+export default function AppLayout() {
+  return (
+    <div className="min-h-screen flex flex-col bg-neutral-50 font-sans antialiased">
+      <AppNav />
+      <main className="flex-1">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/frontend/staff/src/components/nav/AppNav.test.tsx
+++ b/frontend/staff/src/components/nav/AppNav.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import AppNav from './AppNav';
+import { useCurrentUser } from '../../hooks/useCurrentUser';
+import type { User } from '../../types';
+
+vi.mock('@azure/msal-react', () => ({
+  useMsal: vi.fn(() => ({ instance: {}, accounts: [] })),
+}));
+vi.mock('../../hooks/useCurrentUser', () => ({
+  useCurrentUser: vi.fn(),
+}));
+vi.mock('../../api/client', () => ({
+  msalInstance: { logoutRedirect: vi.fn() },
+}));
+
+const mockUseCurrentUser = vi.mocked(useCurrentUser);
+
+function renderNav() {
+  return render(
+    <MemoryRouter>
+      <AppNav />
+    </MemoryRouter>,
+  );
+}
+
+describe('AppNav', () => {
+  it('hides Organisations and Users links for a Staff user', () => {
+    const user: User = { id: '1', email: 'a@b.com', fullName: 'Jonas Weber', role: 'Staff' };
+    mockUseCurrentUser.mockReturnValue({ user, isLoading: false, error: null, isNotFound: false });
+
+    renderNav();
+
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    expect(screen.getByText('RFPs')).toBeInTheDocument();
+    expect(screen.getByText('Proposals')).toBeInTheDocument();
+    expect(screen.queryByText('Organisations')).not.toBeInTheDocument();
+    expect(screen.queryByText('Users')).not.toBeInTheDocument();
+    expect(screen.getByText('Jonas Weber')).toBeInTheDocument();
+  });
+
+  it.each(['OrganisationAdmin', 'SuperAdmin'] as const)(
+    'shows Organisations and Users links for %s',
+    (role) => {
+      const user: User = { id: '1', email: 'a@b.com', fullName: 'Amara Chen', role };
+      mockUseCurrentUser.mockReturnValue({ user, isLoading: false, error: null, isNotFound: false });
+
+      renderNav();
+
+      expect(screen.getByText('Organisations')).toBeInTheDocument();
+      expect(screen.getByText('Users')).toBeInTheDocument();
+    },
+  );
+});

--- a/frontend/staff/src/components/nav/AppNav.tsx
+++ b/frontend/staff/src/components/nav/AppNav.tsx
@@ -1,0 +1,88 @@
+import { NavLink } from 'react-router-dom';
+import { useMsal } from '@azure/msal-react';
+import { msalInstance } from '../../api/client';
+import { useCurrentUser } from '../../hooks/useCurrentUser';
+import { isAdminRole, roleLabel } from '../../types';
+
+const navLinkClass = ({ isActive }: { isActive: boolean }) =>
+  `text-sm font-medium transition-colors ${isActive ? 'text-white' : 'text-neutral-400 hover:text-white'}`;
+
+export default function AppNav() {
+  useMsal();
+  const { user } = useCurrentUser();
+  const isAdmin = !!user && isAdminRole(user.role);
+
+  const displayName = user?.fullName ?? 'Account';
+  const initials = displayName
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2);
+
+  const handleSignOut = () => {
+    msalInstance.logoutRedirect({ postLogoutRedirectUri: '/' });
+  };
+
+  return (
+    <header className="bg-neutral-900 h-16 flex items-center justify-between px-6 shadow-nav">
+      <div className="flex items-center gap-8">
+        <div className="flex items-center gap-2">
+          <span className="w-8 h-8 rounded-md bg-brand text-white flex items-center justify-center font-bold text-lg">
+            H
+          </span>
+          <span className="font-bold text-lg text-white">Herit</span>
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-brand-300 bg-brand-500/25 border border-brand-500 rounded px-1.5 py-0.5">
+            Staff
+          </span>
+        </div>
+        <nav className="flex items-center gap-6">
+          <NavLink to="/" end className={navLinkClass}>
+            Dashboard
+          </NavLink>
+          <NavLink to="/rfps" className={navLinkClass}>
+            RFPs
+          </NavLink>
+          <NavLink to="/proposals" className={navLinkClass}>
+            Proposals
+          </NavLink>
+          {isAdmin && (
+            <>
+              <NavLink to="/organisations" className={navLinkClass}>
+                Organisations
+              </NavLink>
+              <NavLink to="/users" className={navLinkClass}>
+                Users
+              </NavLink>
+            </>
+          )}
+        </nav>
+      </div>
+
+      <div className="flex items-center gap-3.5">
+        <span className="w-[34px] h-[34px] rounded-full bg-brand-100 text-brand-600 flex items-center justify-center font-semibold text-sm">
+          {initials}
+        </span>
+        <div className="flex flex-col leading-tight">
+          <span className="text-sm font-medium text-white">{displayName}</span>
+          {user && <span className="text-[11px] text-neutral-400">{roleLabel(user.role)}</span>}
+        </div>
+        <button
+          onClick={handleSignOut}
+          className="ml-1.5 text-neutral-400 hover:text-white transition-colors"
+          title="Sign out"
+          aria-label="Sign out"
+        >
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
+            />
+          </svg>
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/frontend/staff/src/pages/app/DashboardPage.test.tsx
+++ b/frontend/staff/src/pages/app/DashboardPage.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import DashboardPage from './DashboardPage';
+import { useCurrentUser } from '../../hooks/useCurrentUser';
+import { listRfps } from '../../api/rfps';
+import { listProposals } from '../../api/proposals';
+import { listOrganisations } from '../../api/organisations';
+import { listUsers } from '../../api/users';
+import type { Organisation, Proposal, Rfp, User } from '../../types';
+
+vi.mock('../../hooks/useCurrentUser', () => ({ useCurrentUser: vi.fn() }));
+vi.mock('../../api/rfps', () => ({ listRfps: vi.fn() }));
+vi.mock('../../api/proposals', () => ({ listProposals: vi.fn() }));
+vi.mock('../../api/organisations', () => ({ listOrganisations: vi.fn() }));
+vi.mock('../../api/users', () => ({ listUsers: vi.fn(), getCurrentUser: vi.fn() }));
+
+const mockUseCurrentUser = vi.mocked(useCurrentUser);
+const mockListRfps = vi.mocked(listRfps);
+const mockListProposals = vi.mocked(listProposals);
+const mockListOrganisations = vi.mocked(listOrganisations);
+const mockListUsers = vi.mocked(listUsers);
+
+const rfps: Rfp[] = [
+  { id: '1', title: 'a', shortDescription: '', longDescription: '', status: 'Draft', organisationId: 'o1', authorId: 'u1' },
+  { id: '2', title: 'b', shortDescription: '', longDescription: '', status: 'Draft', organisationId: 'o1', authorId: 'u1' },
+  { id: '3', title: 'c', shortDescription: '', longDescription: '', status: 'Approved', organisationId: 'o1', authorId: 'u1' },
+  { id: '4', title: 'd', shortDescription: '', longDescription: '', status: 'Published', organisationId: 'o1', authorId: 'u1' },
+];
+
+const proposals: Proposal[] = [
+  { id: '1', title: 'a', shortDescription: '', longDescription: '', status: 'Submitted', authorId: 'u1', organisationId: 'o1' },
+  { id: '2', title: 'b', shortDescription: '', longDescription: '', status: 'UnderReview', authorId: 'u1', organisationId: 'o1' },
+  { id: '3', title: 'c', shortDescription: '', longDescription: '', status: 'UnderReview', authorId: 'u1', organisationId: 'o1' },
+  { id: '4', title: 'd', shortDescription: '', longDescription: '', status: 'Approved', authorId: 'u1', organisationId: 'o1' },
+];
+
+const organisations: Organisation[] = [{ id: 'o1', name: 'Org One' }, { id: 'o2', name: 'Org Two' }];
+
+const users: User[] = [
+  { id: 'u1', email: 'staff@a.com', fullName: 'Staff One', role: 'Staff' },
+  { id: 'u2', email: 'admin@a.com', fullName: 'Admin One', role: 'SuperAdmin' },
+  { id: 'u3', email: 'expat@a.com', fullName: 'Expat One', role: 'Expat' },
+];
+
+function renderDashboard() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockListRfps.mockResolvedValue(rfps);
+  mockListProposals.mockResolvedValue(proposals);
+  mockListOrganisations.mockResolvedValue(organisations);
+  mockListUsers.mockResolvedValue(users);
+});
+
+describe('DashboardPage', () => {
+  it('computes RFP and proposal counts for a Staff user and hides the admin section', async () => {
+    const user: User = { id: 'u1', email: 'staff@a.com', fullName: 'Staff One', role: 'Staff' };
+    mockUseCurrentUser.mockReturnValue({ user, isLoading: false, error: null, isNotFound: false });
+
+    renderDashboard();
+
+    expect(await screen.findByText('Welcome back, Staff One')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('Draft').previousSibling?.textContent).toBe('2'));
+    expect(screen.getByText('Approved').previousSibling?.textContent).toBe('1');
+    expect(screen.getByText('Published').previousSibling?.textContent).toBe('1');
+    expect(screen.getByText('Submitted').previousSibling?.textContent).toBe('1');
+    expect(screen.getByText('Under Review').previousSibling?.textContent).toBe('2');
+
+    expect(screen.queryByText('Organisations & users')).not.toBeInTheDocument();
+    expect(mockListOrganisations).not.toHaveBeenCalled();
+    expect(mockListUsers).not.toHaveBeenCalled();
+  });
+
+  it('shows the admin section with organisation and staff/admin counts for an admin role', async () => {
+    const user: User = { id: 'u2', email: 'admin@a.com', fullName: 'Admin One', role: 'SuperAdmin' };
+    mockUseCurrentUser.mockReturnValue({ user, isLoading: false, error: null, isNotFound: false });
+
+    renderDashboard();
+
+    await waitFor(() => expect(screen.getByText('Organisations').previousSibling?.textContent).toBe('2'));
+    // Staff & admins excludes the Expat user in the fixture.
+    expect(screen.getByText('Staff & admins').previousSibling?.textContent).toBe('2');
+  });
+});

--- a/frontend/staff/src/pages/app/DashboardPage.tsx
+++ b/frontend/staff/src/pages/app/DashboardPage.tsx
@@ -1,8 +1,85 @@
-// Placeholder — the app shell and dashboard (flow 1, screen 03) land in a later issue.
+import { useQuery } from '@tanstack/react-query';
+import { listRfps } from '../../api/rfps';
+import { listProposals } from '../../api/proposals';
+import { listOrganisations } from '../../api/organisations';
+import { listUsers } from '../../api/users';
+import { useCurrentUser } from '../../hooks/useCurrentUser';
+import { isAdminRole, isStaffRole, roleLabel, type RfpStatus, type ProposalStatus } from '../../types';
+import StatCard from '../../components/StatCard';
+
+function countByStatus<T extends string>(items: { status: T }[] | undefined, status: T): number {
+  return items?.filter((item) => item.status === status).length ?? 0;
+}
+
+const RFP_STATUSES: RfpStatus[] = ['Draft', 'Approved', 'Published'];
+
 export default function DashboardPage() {
+  const { user } = useCurrentUser();
+  const isAdmin = !!user && isAdminRole(user.role);
+
+  const { data: rfps } = useQuery({ queryKey: ['rfps'], queryFn: listRfps });
+  const { data: proposals } = useQuery({ queryKey: ['proposals'], queryFn: listProposals });
+  const { data: organisations } = useQuery({
+    queryKey: ['organisations'],
+    queryFn: listOrganisations,
+    enabled: isAdmin,
+  });
+  const { data: users } = useQuery({ queryKey: ['users'], queryFn: listUsers, enabled: isAdmin });
+
+  const submittedCount = countByStatus<ProposalStatus>(proposals, 'Submitted');
+  const underReviewCount = countByStatus<ProposalStatus>(proposals, 'UnderReview');
+
   return (
-    <main className="min-h-screen bg-neutral-50 flex items-center justify-center font-sans antialiased">
-      <p className="text-sm text-neutral-500">Signed in to Herit Staff.</p>
-    </main>
+    <div className="max-w-[1080px] mx-auto px-6 py-8 pb-16">
+      <div className="mb-7">
+        <h1 className="text-2xl font-bold text-neutral-900 mb-1">
+          Welcome back{user ? `, ${user.fullName}` : ''}
+        </h1>
+        <p className="text-sm text-neutral-500">
+          {user ? roleLabel(user.role) : ''} · counts below are computed from the current list endpoints, not a
+          stats API — nothing here is a trend or a "this week" figure.
+        </p>
+      </div>
+
+      <section className="mb-7">
+        <h2 className="text-lg font-semibold text-neutral-900 mb-3">RFPs by status</h2>
+        <div className="flex gap-3 flex-wrap">
+          {RFP_STATUSES.map((status) => (
+            <StatCard
+              key={status}
+              value={countByStatus<RfpStatus>(rfps, status)}
+              label={status}
+              to={`/rfps?status=${status}`}
+            />
+          ))}
+        </div>
+      </section>
+
+      <section className="mb-7">
+        <h2 className="text-lg font-semibold text-neutral-900 mb-3">Proposals awaiting review</h2>
+        <div className="flex gap-3 flex-wrap">
+          <StatCard value={submittedCount} label="Submitted" to="/proposals?status=Submitted" tone="amber" />
+          <StatCard value={underReviewCount} label="Under Review" to="/proposals?status=UnderReview" tone="orange" />
+        </div>
+      </section>
+
+      {isAdmin && (
+        <section className="mb-7">
+          <h2 className="text-lg font-semibold text-neutral-900 mb-3">Organisations &amp; users</h2>
+          <div className="flex gap-3 flex-wrap mb-2.5">
+            <StatCard value={organisations?.length ?? 0} label="Organisations" to="/organisations" />
+            <StatCard
+              value={users?.filter((u) => isStaffRole(u.role)).length ?? 0}
+              label="Staff & admins"
+              to="/users"
+            />
+          </div>
+          <p className="text-xs text-neutral-500 leading-relaxed">
+            These counts span every organisation on the platform. Organisation-scoped permissions don't exist yet —
+            any admin sees and manages all organisations, not just their own.
+          </p>
+        </section>
+      )}
+    </div>
   );
 }

--- a/frontend/staff/src/pages/app/OrganisationsPage.tsx
+++ b/frontend/staff/src/pages/app/OrganisationsPage.tsx
@@ -1,0 +1,8 @@
+// Placeholder — organisation hierarchy management (flow 3a) lands in a later issue.
+export default function OrganisationsPage() {
+  return (
+    <div className="max-w-[1080px] mx-auto px-6 py-8">
+      <p className="text-sm text-neutral-500">Organisation management is coming soon.</p>
+    </div>
+  );
+}

--- a/frontend/staff/src/pages/app/ProposalsPage.tsx
+++ b/frontend/staff/src/pages/app/ProposalsPage.tsx
@@ -1,0 +1,8 @@
+// Placeholder — the proposal review queue (flow 2b) lands in a later issue.
+export default function ProposalsPage() {
+  return (
+    <div className="max-w-[1080px] mx-auto px-6 py-8">
+      <p className="text-sm text-neutral-500">Proposal review is coming soon.</p>
+    </div>
+  );
+}

--- a/frontend/staff/src/pages/app/RfpsPage.tsx
+++ b/frontend/staff/src/pages/app/RfpsPage.tsx
@@ -1,0 +1,8 @@
+// Placeholder — the RFP list (flow 2a, screen 01) lands in a later issue.
+export default function RfpsPage() {
+  return (
+    <div className="max-w-[1080px] mx-auto px-6 py-8">
+      <p className="text-sm text-neutral-500">RFP management is coming soon.</p>
+    </div>
+  );
+}

--- a/frontend/staff/src/pages/app/UsersPage.tsx
+++ b/frontend/staff/src/pages/app/UsersPage.tsx
@@ -1,0 +1,8 @@
+// Placeholder — staff/admin user management (flow 3b/3c) lands in a later issue.
+export default function UsersPage() {
+  return (
+    <div className="max-w-[1080px] mx-auto px-6 py-8">
+      <p className="text-sm text-neutral-500">User management is coming soon.</p>
+    </div>
+  );
+}

--- a/frontend/staff/src/routes/router.tsx
+++ b/frontend/staff/src/routes/router.tsx
@@ -4,6 +4,11 @@ import SignInPage from '../pages/auth/SignInPage';
 import AccessDeniedPage from '../pages/auth/AccessDeniedPage';
 import AuthErrorPage from '../pages/auth/AuthErrorPage';
 import DashboardPage from '../pages/app/DashboardPage';
+import RfpsPage from '../pages/app/RfpsPage';
+import ProposalsPage from '../pages/app/ProposalsPage';
+import OrganisationsPage from '../pages/app/OrganisationsPage';
+import UsersPage from '../pages/app/UsersPage';
+import AppLayout from '../components/layout/AppLayout';
 import ProtectedRoute from './ProtectedRoute';
 
 export const router = createBrowserRouter([
@@ -14,9 +19,15 @@ export const router = createBrowserRouter([
   {
     element: (
       <ProtectedRoute>
-        <DashboardPage />
+        <AppLayout />
       </ProtectedRoute>
     ),
-    path: '/',
+    children: [
+      { path: '/', element: <DashboardPage /> },
+      { path: '/rfps', element: <RfpsPage /> },
+      { path: '/proposals', element: <ProposalsPage /> },
+      { path: '/organisations', element: <OrganisationsPage /> },
+      { path: '/users', element: <UsersPage /> },
+    ],
   },
 ]);

--- a/frontend/staff/src/types/index.test.ts
+++ b/frontend/staff/src/types/index.test.ts
@@ -1,4 +1,4 @@
-import { isStaffRole } from './index';
+import { isAdminRole, isStaffRole, roleLabel } from './index';
 
 describe('isStaffRole', () => {
   it.each(['Staff', 'OrganisationAdmin', 'SuperAdmin'] as const)('treats %s as a staff role', (role) => {
@@ -7,5 +7,23 @@ describe('isStaffRole', () => {
 
   it('does not treat Expat as a staff role', () => {
     expect(isStaffRole('Expat')).toBe(false);
+  });
+});
+
+describe('isAdminRole', () => {
+  it.each(['OrganisationAdmin', 'SuperAdmin'] as const)('treats %s as an admin role', (role) => {
+    expect(isAdminRole(role)).toBe(true);
+  });
+
+  it.each(['Staff', 'Expat'] as const)('does not treat %s as an admin role', (role) => {
+    expect(isAdminRole(role)).toBe(false);
+  });
+});
+
+describe('roleLabel', () => {
+  it('renders a human-readable label for each role', () => {
+    expect(roleLabel('Staff')).toBe('Staff');
+    expect(roleLabel('OrganisationAdmin')).toBe('Organisation Admin');
+    expect(roleLabel('SuperAdmin')).toBe('Super Admin');
   });
 });

--- a/frontend/staff/src/types/index.ts
+++ b/frontend/staff/src/types/index.ts
@@ -8,7 +8,61 @@ export interface User {
 }
 
 export const STAFF_ROLES: readonly UserRole[] = ['Staff', 'OrganisationAdmin', 'SuperAdmin'];
+export const ADMIN_ROLES: readonly UserRole[] = ['OrganisationAdmin', 'SuperAdmin'];
 
 export function isStaffRole(role: UserRole): boolean {
   return STAFF_ROLES.includes(role);
+}
+
+export function isAdminRole(role: UserRole): boolean {
+  return ADMIN_ROLES.includes(role);
+}
+
+const ROLE_LABELS: Record<UserRole, string> = {
+  Expat: 'Expat',
+  Staff: 'Staff',
+  OrganisationAdmin: 'Organisation Admin',
+  SuperAdmin: 'Super Admin',
+};
+
+export function roleLabel(role: UserRole): string {
+  return ROLE_LABELS[role];
+}
+
+export type RfpStatus = 'Draft' | 'Approved' | 'Published';
+
+export interface Rfp {
+  id: string;
+  title: string;
+  shortDescription: string;
+  longDescription: string;
+  status: RfpStatus;
+  organisationId: string;
+  authorId: string;
+  tags?: string;
+}
+
+export type ProposalStatus =
+  | 'Ideation'
+  | 'Resourcing'
+  | 'Submitted'
+  | 'UnderReview'
+  | 'Approved'
+  | 'Withdrawn';
+
+export interface Proposal {
+  id: string;
+  title: string;
+  shortDescription: string;
+  longDescription: string;
+  status: ProposalStatus;
+  authorId: string;
+  organisationId: string;
+  rfpId?: string;
+}
+
+export interface Organisation {
+  id: string;
+  name: string;
+  parentId?: string;
 }


### PR DESCRIPTION
## Description

Implements the Herit Staff app's persistent shell and dashboard per `designs/flow1/` screen 03 and spec section 1:

- Dark header shell with logo + "Staff" tag, nav (Dashboard, RFPs, Proposals, plus Organisations/Users rendered only for admin roles — absent, not disabled), user identity + role label + sign-out.
- Dashboard as a thin launcher: RFP counts by status (Draft/Approved/Published) and proposals-awaiting-review counts (Submitted/Under Review), computed client-side from the plain list endpoints, each stat card linking into its queue route.
- Admin roles (`OrganisationAdmin`/`SuperAdmin`) additionally see an organisations/staff-and-admins count section with the platform-wide footnote from the mockup.
- No trends, charts, or time-windowed figures.
- Added stub pages for `/rfps`, `/proposals`, `/organisations`, `/users` so nav links and stat-card links resolve (real implementations land in later issues per flows 2a/2b/3a/3b).

## Linked Issue

Closes #280

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- `npm test -- --run` in `frontend/staff` (21 tests passing), covering role-based nav visibility and dashboard count computation (including that the admin-only queries are not fired for non-admin roles).
- `npm run build` succeeds (`tsc -b && vite build`).

## Checklist

- [x] Code builds cleanly (`npm run build`)
- [x] Tests pass (`npm test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)