### PR TITLE
Provision Azure App Service hosting for the staff app

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -20,3 +20,17 @@ services:
       VITE_AZURE_TENANT_NAME: ${VITE_AZURE_TENANT_NAME}
       VITE_AZURE_AUTHORITY: ${VITE_AZURE_AUTHORITY}
       VITE_API_SCOPE: ${VITE_API_SCOPE}
+  staff:
+    project: ./frontend/staff
+    language: js
+    host: appservice
+    dist: dist
+    env:
+      VITE_API_BASE_URL: ${VITE_API_BASE_URL}
+      # Staff app's MSAL redirect URI is its OWN Azure URL, not the portal's.
+      VITE_REDIRECT_URI: ${VITE_STAFF_REDIRECT_URI}
+      VITE_AZURE_CLIENT_ID: ${VITE_AZURE_CLIENT_ID}
+      VITE_AZURE_TENANT_NAME: ${VITE_AZURE_TENANT_NAME}
+      VITE_AZURE_AUTHORITY: ${VITE_AZURE_AUTHORITY}
+      VITE_API_SCOPE: ${VITE_API_SCOPE}
+      VITE_PORTAL_URL: ${VITE_PORTAL_URL}

--- a/docs/ops/entra-external-id-setup.md
+++ b/docs/ops/entra-external-id-setup.md
@@ -21,16 +21,21 @@ One-time provisioning of the Microsoft Entra External ID tenant resources requir
 ./scripts/setup-entra-external-id.sh \
   --tenant-id <entra-tenant-id> \
   --google-client-id <google-oauth-client-id> \
-  --google-client-secret <google-oauth-client-secret>
+  --google-client-secret <google-oauth-client-secret> \
+  --spa-redirect-uri https://<portal-app-service-hostname> \
+  --spa-redirect-uri https://<staff-app-service-hostname>
 ```
 
 The script will:
 1. Create the **Herit API** app registration in the Entra External ID tenant (idempotent — safe to re-run).
 2. Generate a client secret and print it to the console.
-3. Register Google as a social identity provider via the Microsoft Graph API.
-4. Print all Key Vault values (see Step 3).
+3. Register any supplied `--spa-redirect-uri` values under the app's **SPA** platform (idempotent — unions with existing URIs).
+4. Register Google as a social identity provider via the Microsoft Graph API.
+5. Print all Key Vault values (see Step 3).
 
 > **Note:** If Google identity provider configuration fails with a 404 or unsupported operation error, configure it manually via the Azure Portal: **Entra External ID → External Identities → All identity providers → Add → Google**.
+
+> **Redirect URIs:** The portal and staff single-page apps share this app registration, so both deployed URLs must be registered as SPA redirect URIs. Their hostnames are only known after `azd provision` provisions the App Services — read them from `azd env get-values` (`SERVICE_WEB_URI` / `SERVICE_STAFF_URI`) or the Azure Portal, then re-run the script with the `--spa-redirect-uri` flags above. Patching the app registration requires `Application.ReadWrite.All`, so a tenant admin must run this step.
 
 ---
 

--- a/frontend/staff/.env.example
+++ b/frontend/staff/.env.example
@@ -10,3 +10,7 @@ VITE_REDIRECT_URI=http://localhost:5174
 
 # API scope registered in Entra External ID
 VITE_API_SCOPE=api://your-api-client-id/access_as_user
+
+# Portal URL — used by the sign-in / access-denied pages to link back to the
+# public portal. Defaults to https://herit.app when unset.
+VITE_PORTAL_URL=http://localhost:5173

--- a/infra/app/staff-appservice-avm.bicep
+++ b/infra/app/staff-appservice-avm.bicep
@@ -1,0 +1,37 @@
+param name string
+param location string = resourceGroup().location
+param tags object = {}
+param serviceName string = 'staff'
+param appCommandLine string = 'pm2 serve /home/site/wwwroot --no-daemon --spa'
+param appInsightResourceId string
+param appServicePlanId string
+param linuxFxVersion string
+param kind string = 'app,linux'
+
+module staff 'br/public:avm/res/web/site:0.6.0' = {
+  name: '${name}-deployment'
+  params: {
+    kind: kind
+    name: name
+    serverFarmResourceId: appServicePlanId
+    tags: union(tags, { 'azd-service-name': serviceName })
+    location: location
+    appInsightResourceId: appInsightResourceId
+    siteConfig: {
+      appCommandLine: appCommandLine
+      linuxFxVersion: linuxFxVersion
+      alwaysOn: true
+    }
+    logsConfiguration: {
+      applicationLogs: { fileSystem: { level: 'Verbose' } }
+      detailedErrorMessages: { enabled: true }
+      failedRequestsTracing: { enabled: true }
+      httpLogs: { fileSystem: { enabled: true, retentionInDays: 1, retentionInMb: 35 } }
+    }
+    appSettingsKeyValuePairs: { ApplicationInsightsAgent_EXTENSION_VERSION: contains(kind, 'linux') ? '~3' : '~2' }
+  }
+}
+
+output SERVICE_STAFF_IDENTITY_PRINCIPAL_ID string = staff.outputs.systemAssignedMIPrincipalId
+output SERVICE_STAFF_NAME string = staff.outputs.name
+output SERVICE_STAFF_URI string = 'https://${staff.outputs.defaultHostname}'

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -22,6 +22,7 @@ param logAnalyticsName string = ''
 param resourceGroupName string = ''
 param sqlServerName string = ''
 param webServiceName string = ''
+param staffServiceName string = ''
 param apimServiceName string = ''
 param connectionStringKey string = 'AZURE-SQL-CONNECTION-STRING'
 
@@ -90,6 +91,20 @@ module web './app/web-appservice-avm.bicep' = {
   }
 }
 
+// The staff-facing frontend (reuses the shared App Service Plan)
+module staff './app/staff-appservice-avm.bicep' = {
+  name: 'staff'
+  scope: rg
+  params: {
+    name: !empty(staffServiceName) ? staffServiceName : '${abbrs.webSitesAppService}staff-${resourceToken}'
+    location: location
+    tags: tags
+    appServicePlanId: appServicePlan.outputs.resourceId
+    appInsightResourceId: monitoring.outputs.applicationInsightsResourceId
+    linuxFxVersion: 'node|22-lts'
+  }
+}
+
 // The application backend
 module api './app/api-appservice-avm.bicep' = {
   name: 'api'
@@ -113,9 +128,10 @@ module api './app/api-appservice-avm.bicep' = {
       AzureAd__TenantId: '@Microsoft.KeyVault(VaultName=${keyVault.outputs.name};SecretName=entra-tenant-id)'
       AzureAd__ClientId: '@Microsoft.KeyVault(VaultName=${keyVault.outputs.name};SecretName=entra-client-id)'
       AllowedOrigins__0: web.outputs.SERVICE_WEB_URI
+      AllowedOrigins__1: staff.outputs.SERVICE_STAFF_URI
     }
     appInsightResourceId: monitoring.outputs.applicationInsightsResourceId
-    allowedOrigins: [web.outputs.SERVICE_WEB_URI]
+    allowedOrigins: [web.outputs.SERVICE_WEB_URI, staff.outputs.SERVICE_STAFF_URI]
   }
 }
 
@@ -299,6 +315,7 @@ output AZURE_LOCATION string = location
 output AZURE_TENANT_ID string = tenant().tenantId
 output API_BASE_URL string = useAPIM ? apimApi.outputs.serviceApiUri : api.outputs.SERVICE_API_URI
 output REACT_APP_WEB_BASE_URL string = web.outputs.SERVICE_WEB_URI
+output SERVICE_STAFF_URI string = staff.outputs.SERVICE_STAFF_URI
 output USE_APIM bool = useAPIM
 output SERVICE_API_ENDPOINTS array = useAPIM ? [apimApi.outputs.serviceApiUri, api.outputs.SERVICE_API_URI] : []
 
@@ -309,3 +326,10 @@ output VITE_AZURE_CLIENT_ID string = entraClientId
 output VITE_AZURE_TENANT_NAME string = ciamSubdomain
 output VITE_AZURE_AUTHORITY string = '${entraAuthority}/${ciamSubdomain}.onmicrosoft.com/'
 output VITE_API_SCOPE string = 'api://${entraClientId}/access_as_user'
+
+// Staff-app build-time env vars. The staff app reuses the portal's Entra app
+// registration (shared VITE_AZURE_* / VITE_API_* outputs above), but its MSAL
+// redirect URI must be its OWN Azure URL — not the portal's VITE_REDIRECT_URI.
+// VITE_PORTAL_URL points sign-in/access-denied links back at the portal.
+output VITE_STAFF_REDIRECT_URI string = staff.outputs.SERVICE_STAFF_URI
+output VITE_PORTAL_URL string = web.outputs.SERVICE_WEB_URI

--- a/scripts/setup-entra-external-id.sh
+++ b/scripts/setup-entra-external-id.sh
@@ -29,6 +29,9 @@ set -euo pipefail
 TENANT_ID=""
 GOOGLE_CLIENT_ID=""
 GOOGLE_CLIENT_SECRET=""
+SPA_REDIRECT_URIS=()
+
+USAGE="Usage: $0 --tenant-id <id> --google-client-id <id> --google-client-secret <secret> [--spa-redirect-uri <url> ...]"
 
 # ---------------------------------------------------------------------------
 # Argument parsing
@@ -41,9 +44,11 @@ while [[ $# -gt 0 ]]; do
       GOOGLE_CLIENT_ID="$2"; shift 2 ;;
     --google-client-secret)
       GOOGLE_CLIENT_SECRET="$2"; shift 2 ;;
+    --spa-redirect-uri)
+      SPA_REDIRECT_URIS+=("$2"); shift 2 ;;
     *)
       echo "Unknown argument: $1" >&2
-      echo "Usage: $0 --tenant-id <id> --google-client-id <id> --google-client-secret <secret>" >&2
+      echo "$USAGE" >&2
       exit 1 ;;
   esac
 done
@@ -58,7 +63,7 @@ MISSING=()
 
 if [[ ${#MISSING[@]} -gt 0 ]]; then
   echo "Error: missing required parameter(s): ${MISSING[*]}" >&2
-  echo "Usage: $0 --tenant-id <id> --google-client-id <id> --google-client-secret <secret>" >&2
+  echo "$USAGE" >&2
   exit 1
 fi
 
@@ -127,6 +132,57 @@ SECRET_RESPONSE=$(az rest \
 
 CLIENT_SECRET=$(echo "$SECRET_RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['secretText'])")
 echo "    Client secret generated."
+
+# ---------------------------------------------------------------------------
+# Step 2b: Register SPA redirect URIs
+#
+# The portal and staff single-page apps reuse this same app registration, so
+# each deployed SPA URL must be listed as a redirect URI under the app's `spa`
+# platform. The URLs are only known after `azd provision` generates the App
+# Service hostnames, so they are passed in with --spa-redirect-uri (repeatable):
+#
+#   ./scripts/setup-entra-external-id.sh ... \
+#     --spa-redirect-uri https://app-web-xxxx.azurewebsites.net \
+#     --spa-redirect-uri https://app-staff-xxxx.azurewebsites.net
+#
+# This step is idempotent — it unions the supplied URIs with any already
+# registered, so re-running never drops existing redirect URIs.
+#
+# NOTE: patching the app registration requires Application.ReadWrite.All on the
+# signed-in principal (a tenant-admin-granted permission). Claude Code cannot
+# execute this against a real tenant; a tenant admin must run the script.
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Step 2b: Registering SPA redirect URIs..."
+
+if [[ ${#SPA_REDIRECT_URIS[@]} -eq 0 ]]; then
+  echo "    No --spa-redirect-uri values supplied. Skipping."
+else
+  EXISTING_URIS=$(az rest \
+    --method GET \
+    --uri "https://graph.microsoft.com/v1.0/applications/${OBJECT_ID}" \
+    --query "spa.redirectUris" \
+    --output json \
+    --only-show-errors)
+
+  MERGED_URIS=$(python3 -c "
+import json, sys
+# spa.redirectUris is null when the app has no SPA platform yet.
+existing = json.loads(sys.argv[1]) or []
+supplied = sys.argv[2:]
+merged = list(dict.fromkeys(existing + supplied))
+print(json.dumps(merged))
+" "$EXISTING_URIS" "${SPA_REDIRECT_URIS[@]}")
+
+  az rest \
+    --method PATCH \
+    --uri "https://graph.microsoft.com/v1.0/applications/${OBJECT_ID}" \
+    --headers "Content-Type=application/json" \
+    --body "{\"spa\": {\"redirectUris\": ${MERGED_URIS}}}" \
+    --only-show-errors
+
+  echo "    SPA redirect URIs now: ${MERGED_URIS}"
+fi
 
 # ---------------------------------------------------------------------------
 # Step 3: Configure Google as an identity provider


### PR DESCRIPTION
## Description

The staff app (`frontend/staff`) had no Azure deployment target — the `cd` job provisioned only the portal and API. This wires the staff app into the `azd` provisioning path:

- **New Bicep module** `infra/app/staff-appservice-avm.bicep`, mirroring `web-appservice-avm.bicep`, wired into `infra/main.bicep`. It **reuses the shared App Service Plan** (`appServicePlan.outputs.resourceId`) — no second plan is provisioned (cost guardrail).
- **New `staff` service in `azure.yaml`** (host: appservice, dist: dist) with its `VITE_*` env vars. Its `VITE_REDIRECT_URI` is the staff app's **own** Azure URL via a new `VITE_STAFF_REDIRECT_URI` output — not a reuse of the portal's `VITE_REDIRECT_URI` output. Adds `VITE_PORTAL_URL` so the sign-in / access-denied pages link back to the portal.
- **API CORS** — added the staff origin to both `AllowedOrigins__1` (app config) and the platform `allowedOrigins` array, so authenticated calls from the deployed staff app pass CORS preflight.
- **Entra** — the staff app reuses the portal's app registration (MVP; a separate registration would buy audit separation / per-app conditional access but nothing requires it now). Extended `scripts/setup-entra-external-id.sh` with a repeatable `--spa-redirect-uri` flag that unions supplied URIs into the app registration's SPA `redirectUris` via Microsoft Graph (idempotent), replacing the manual portal step. Docs updated.

### Tenant-admin step Claude Code can't execute

Patching the app registration's redirect URIs requires `Application.ReadWrite.All` on the signed-in principal. A tenant admin must run `setup-entra-external-id.sh` with `--spa-redirect-uri https://<portal-hostname> --spa-redirect-uri https://<staff-hostname>` after `azd provision` (hostnames come from the `SERVICE_WEB_URI` / `SERVICE_STAFF_URI` azd outputs).

## Linked Issue

Closes #298

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- `az bicep build --file infra/main.bicep` compiles cleanly.
- `bash -n scripts/setup-entra-external-id.sh` passes; the redirect-URI merge logic was unit-tested for the null-SPA, dedup, and empty-input cases.
- `dotnet build Herit.slnx --configuration Release` succeeds; staff frontend `npm run build` and `npm test` (21 tests) pass.
- **End-to-end acceptance** (staff reachable at its Azure URL, full Entra sign-in round-trip, authenticated `GET /Users/me` from the deployed app) requires a live `azd provision`/`azd deploy` against the tenant plus the tenant-admin redirect-URI step above — to be verified in the `cd` run / deployed environment.

Out of scope (per issue): network-level access restriction (IP allowlist / private endpoint) for the staff app — worth a separate future issue.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test` / frontend tests)
- [x] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)