### PR TITLE
Implement the RFP list (flow 2a, screen 01)

### DIFF
--- a/frontend/staff/src/components/EmptyState.tsx
+++ b/frontend/staff/src/components/EmptyState.tsx
@@ -1,0 +1,25 @@
+interface EmptyStateProps {
+  readonly title: string;
+  readonly description?: string;
+  readonly action?: React.ReactNode;
+}
+
+export default function EmptyState({ title, description, action }: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center py-20 text-center">
+      <div className="w-16 h-16 bg-neutral-100 rounded-full flex items-center justify-center mb-4">
+        <svg className="w-8 h-8 text-neutral-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+          />
+        </svg>
+      </div>
+      <h3 className="text-lg font-semibold text-neutral-900 mb-2">{title}</h3>
+      {description && <p className="text-sm text-neutral-500 max-w-sm">{description}</p>}
+      {action && <div className="mt-6">{action}</div>}
+    </div>
+  );
+}

--- a/frontend/staff/src/components/LoadingSpinner.tsx
+++ b/frontend/staff/src/components/LoadingSpinner.tsx
@@ -1,0 +1,11 @@
+interface LoadingSpinnerProps {
+  readonly className?: string;
+}
+
+export default function LoadingSpinner({ className = '' }: LoadingSpinnerProps) {
+  return (
+    <div className={`flex items-center justify-center py-16 ${className}`}>
+      <div className="w-8 h-8 border-4 border-neutral-200 border-t-brand rounded-full animate-spin" />
+    </div>
+  );
+}

--- a/frontend/staff/src/components/StatusBadge.tsx
+++ b/frontend/staff/src/components/StatusBadge.tsx
@@ -1,0 +1,22 @@
+import type { RfpStatus } from '../types';
+
+const rfpStatusStyles: Record<RfpStatus, string> = {
+  Draft: 'bg-status-neutral-bg text-status-neutral-text',
+  Approved: 'bg-status-info-bg text-status-info-text',
+  Published: 'bg-status-success-bg text-status-success-text',
+};
+
+interface StatusBadgeProps {
+  readonly type: 'rfp';
+  readonly status: RfpStatus;
+}
+
+export default function StatusBadge({ status }: StatusBadgeProps) {
+  return (
+    <span
+      className={`inline-block px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider rounded border border-transparent ${rfpStatusStyles[status]}`}
+    >
+      {status}
+    </span>
+  );
+}

--- a/frontend/staff/src/pages/app/RfpDetailPage.tsx
+++ b/frontend/staff/src/pages/app/RfpDetailPage.tsx
@@ -1,0 +1,8 @@
+// Placeholder — the RFP detail with lifecycle actions (flow 2a, screens 03–04) lands in a later issue.
+export default function RfpDetailPage() {
+  return (
+    <div className="max-w-[1080px] mx-auto px-6 py-8">
+      <p className="text-sm text-neutral-500">RFP detail is coming soon.</p>
+    </div>
+  );
+}

--- a/frontend/staff/src/pages/app/RfpEditorPage.tsx
+++ b/frontend/staff/src/pages/app/RfpEditorPage.tsx
@@ -1,0 +1,8 @@
+// Placeholder — the RFP editor (flow 2a, screen 02) lands in a later issue.
+export default function RfpEditorPage() {
+  return (
+    <div className="max-w-[1080px] mx-auto px-6 py-8">
+      <p className="text-sm text-neutral-500">The RFP editor is coming soon.</p>
+    </div>
+  );
+}

--- a/frontend/staff/src/pages/app/RfpsPage.test.tsx
+++ b/frontend/staff/src/pages/app/RfpsPage.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import RfpsPage from './RfpsPage';
+import { listRfps } from '../../api/rfps';
+import { listOrganisations } from '../../api/organisations';
+import type { Organisation, Rfp } from '../../types';
+
+vi.mock('../../api/rfps', () => ({ listRfps: vi.fn() }));
+vi.mock('../../api/organisations', () => ({ listOrganisations: vi.fn() }));
+
+const mockListRfps = vi.mocked(listRfps);
+const mockListOrganisations = vi.mocked(listOrganisations);
+
+const rfps: Rfp[] = [
+  { id: '1', title: 'Digital ID Verification', shortDescription: '', longDescription: '', status: 'Draft', organisationId: 'o1', authorId: 'u1', tags: 'identity' },
+  { id: '2', title: 'Remote Voting Portal', shortDescription: '', longDescription: '', status: 'Draft', organisationId: 'o2', authorId: 'u1' },
+  { id: '3', title: 'Consular Records', shortDescription: '', longDescription: '', status: 'Approved', organisationId: 'o1', authorId: 'u1' },
+  { id: '4', title: 'Diaspora Outreach', shortDescription: '', longDescription: '', status: 'Published', organisationId: 'o1', authorId: 'u1' },
+];
+
+const organisations: Organisation[] = [
+  { id: 'o1', name: 'Ministry of Digital Economy' },
+  { id: 'o2', name: 'Diaspora Engagement Bureau' },
+];
+
+function renderPage(initialEntries = ['/rfps']) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={initialEntries}>
+        <RfpsPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockListRfps.mockResolvedValue(rfps);
+  mockListOrganisations.mockResolvedValue(organisations);
+});
+
+describe('RfpsPage', () => {
+  it('defaults to the Draft tab and lists matching RFPs with org names', async () => {
+    renderPage();
+
+    expect(await screen.findByText('Digital ID Verification')).toBeInTheDocument();
+    expect(screen.getByText('Remote Voting Portal')).toBeInTheDocument();
+    expect(screen.queryByText('Consular Records')).not.toBeInTheDocument();
+    expect(screen.getByText('Ministry of Digital Economy')).toBeInTheDocument();
+    expect(screen.getByText('Diaspora Engagement Bureau')).toBeInTheDocument();
+  });
+
+  it('respects a status query param and switches tabs on click', async () => {
+    const user = userEvent.setup();
+    renderPage(['/rfps?status=Published']);
+
+    expect(await screen.findByText('Diaspora Outreach')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /Approved/ }));
+    expect(await screen.findByText('Consular Records')).toBeInTheDocument();
+    expect(screen.queryByText('Diaspora Outreach')).not.toBeInTheDocument();
+  });
+
+  it('filters by search text within the active tab', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await screen.findByText('Digital ID Verification');
+    await user.type(screen.getByPlaceholderText('Search RFPs'), 'identity');
+
+    expect(screen.getByText('Digital ID Verification')).toBeInTheDocument();
+    expect(screen.queryByText('Remote Voting Portal')).not.toBeInTheDocument();
+  });
+
+  it('shows an empty state when a status tab has no RFPs', async () => {
+    mockListRfps.mockResolvedValue([]);
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('No draft RFPs')).toBeInTheDocument());
+    expect(screen.getByText('New RFPs start in Draft. Create one to get started.')).toBeInTheDocument();
+  });
+
+  it('links rows to the detail page and the New RFP action to the editor', async () => {
+    renderPage();
+
+    const row = await screen.findByText('Digital ID Verification');
+    expect(row.closest('a')).toHaveAttribute('href', '/rfps/1');
+    expect(screen.getByRole('link', { name: 'New RFP' })).toHaveAttribute('href', '/rfps/new');
+  });
+});

--- a/frontend/staff/src/pages/app/RfpsPage.tsx
+++ b/frontend/staff/src/pages/app/RfpsPage.tsx
@@ -1,8 +1,160 @@
-// Placeholder — the RFP list (flow 2a, screen 01) lands in a later issue.
+import { useMemo, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { listRfps } from '../../api/rfps';
+import { listOrganisations } from '../../api/organisations';
+import type { RfpStatus } from '../../types';
+import StatusBadge from '../../components/StatusBadge';
+import EmptyState from '../../components/EmptyState';
+import LoadingSpinner from '../../components/LoadingSpinner';
+
+const TABS: RfpStatus[] = ['Draft', 'Approved', 'Published'];
+
+const EMPTY_STATE_COPY: Record<RfpStatus, { title: string; description: string }> = {
+  Draft: { title: 'No draft RFPs', description: 'New RFPs start in Draft. Create one to get started.' },
+  Approved: {
+    title: 'No approved RFPs',
+    description: 'RFPs move here once a staff member approves them from Draft.',
+  },
+  Published: {
+    title: 'No published RFPs',
+    description: 'Approved RFPs become visible here once published to the portal.',
+  },
+};
+
+function isRfpStatus(value: string | null): value is RfpStatus {
+  return TABS.includes(value as RfpStatus);
+}
+
 export default function RfpsPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [search, setSearch] = useState('');
+
+  const statusParam = searchParams.get('status');
+  const activeTab: RfpStatus = isRfpStatus(statusParam) ? statusParam : 'Draft';
+
+  const setActiveTab = (status: RfpStatus) => {
+    setSearchParams({ status });
+  };
+
+  const {
+    data: rfps,
+    isLoading,
+    isError,
+  } = useQuery({ queryKey: ['rfps'], queryFn: listRfps });
+
+  const { data: orgs } = useQuery({ queryKey: ['organisations'], queryFn: listOrganisations });
+
+  const orgMap = useMemo(
+    () => Object.fromEntries((orgs ?? []).map((o) => [o.id, o.name])),
+    [orgs],
+  );
+
+  const counts = useMemo(() => {
+    const result: Record<RfpStatus, number> = { Draft: 0, Approved: 0, Published: 0 };
+    for (const rfp of rfps ?? []) result[rfp.status]++;
+    return result;
+  }, [rfps]);
+
+  const filtered = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return (rfps ?? []).filter((rfp) => {
+      if (rfp.status !== activeTab) return false;
+      if (!query) return true;
+      return (
+        rfp.title.toLowerCase().includes(query) ||
+        (orgMap[rfp.organisationId] ?? '').toLowerCase().includes(query) ||
+        (rfp.tags ?? '').toLowerCase().includes(query)
+      );
+    });
+  }, [rfps, activeTab, search, orgMap]);
+
   return (
-    <div className="max-w-[1080px] mx-auto px-6 py-8">
-      <p className="text-sm text-neutral-500">RFP management is coming soon.</p>
+    <div className="max-w-[1080px] mx-auto px-6 py-8 pb-16">
+      <div className="flex items-start justify-between gap-4 mb-5">
+        <div>
+          <h1 className="text-2xl font-bold text-neutral-900 mb-1">RFPs</h1>
+          <p className="text-sm text-neutral-500">
+            Per ADR-017, any staff user can perform every status transition, including on RFPs they authored —
+            there is no separate-approver role.
+          </p>
+        </div>
+        <Link
+          to="/rfps/new"
+          className="shrink-0 inline-flex items-center gap-2 px-4 h-10 bg-brand text-white text-sm font-medium rounded-lg hover:bg-brand-dark transition-colors"
+        >
+          New RFP
+        </Link>
+      </div>
+
+      <div className="flex items-center justify-between gap-4 flex-wrap mb-4">
+        <div className="flex gap-2">
+          {TABS.map((status) => (
+            <button
+              key={status}
+              onClick={() => setActiveTab(status)}
+              className={`inline-flex items-center gap-2 px-3.5 h-9 rounded-lg text-sm font-medium transition-colors ${
+                activeTab === status
+                  ? 'bg-brand-100 text-brand-700'
+                  : 'text-neutral-500 hover:text-neutral-900 hover:bg-neutral-100'
+              }`}
+            >
+              {status}
+              <span
+                className={`px-1.5 py-0.5 rounded text-xs font-semibold ${
+                  activeTab === status ? 'bg-white text-brand-700' : 'bg-neutral-200 text-neutral-600'
+                }`}
+              >
+                {counts[status]}
+              </span>
+            </button>
+          ))}
+        </div>
+        <div className="w-full sm:w-60">
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search RFPs"
+            className="w-full px-3.5 h-[38px] bg-white border border-neutral-200 rounded-lg text-sm focus:outline-none focus:border-brand focus:ring-1 focus:ring-brand transition-shadow"
+          />
+        </div>
+      </div>
+
+      {isLoading && <LoadingSpinner />}
+      {isError && (
+        <div className="py-10 text-center text-sm text-status-danger-text">Failed to load RFPs. Please try again.</div>
+      )}
+
+      {!isLoading && !isError && (
+        <>
+          {filtered.length === 0 ? (
+            <EmptyState title={EMPTY_STATE_COPY[activeTab].title} description={EMPTY_STATE_COPY[activeTab].description} />
+          ) : (
+            <div className="bg-neutral-0 border border-neutral-200 rounded-lg shadow-soft overflow-hidden">
+              <div className="grid grid-cols-[1fr_200px_130px] gap-3 px-5 py-3 border-b border-neutral-200 text-xs font-semibold text-neutral-500 uppercase tracking-wide">
+                <span>Title</span>
+                <span>Organisation</span>
+                <span>Status</span>
+              </div>
+              {filtered.map((rfp) => (
+                <Link
+                  key={rfp.id}
+                  to={`/rfps/${rfp.id}`}
+                  className="grid grid-cols-[1fr_200px_130px] gap-3 px-5 py-4 border-b border-neutral-200 last:border-b-0 items-center hover:bg-neutral-50 transition-colors"
+                >
+                  <div>
+                    <div className="text-sm font-medium text-neutral-900 mb-0.5">{rfp.title}</div>
+                    {rfp.tags && <div className="text-xs text-neutral-400">{rfp.tags}</div>}
+                  </div>
+                  <span className="text-sm text-neutral-500">{orgMap[rfp.organisationId] ?? '—'}</span>
+                  <StatusBadge type="rfp" status={rfp.status} />
+                </Link>
+              ))}
+            </div>
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/staff/src/routes/router.tsx
+++ b/frontend/staff/src/routes/router.tsx
@@ -5,6 +5,8 @@ import AccessDeniedPage from '../pages/auth/AccessDeniedPage';
 import AuthErrorPage from '../pages/auth/AuthErrorPage';
 import DashboardPage from '../pages/app/DashboardPage';
 import RfpsPage from '../pages/app/RfpsPage';
+import RfpEditorPage from '../pages/app/RfpEditorPage';
+import RfpDetailPage from '../pages/app/RfpDetailPage';
 import ProposalsPage from '../pages/app/ProposalsPage';
 import OrganisationsPage from '../pages/app/OrganisationsPage';
 import UsersPage from '../pages/app/UsersPage';
@@ -25,6 +27,8 @@ export const router = createBrowserRouter([
     children: [
       { path: '/', element: <DashboardPage /> },
       { path: '/rfps', element: <RfpsPage /> },
+      { path: '/rfps/new', element: <RfpEditorPage /> },
+      { path: '/rfps/:id', element: <RfpDetailPage /> },
       { path: '/proposals', element: <ProposalsPage /> },
       { path: '/organisations', element: <OrganisationsPage /> },
       { path: '/users', element: <UsersPage /> },


### PR DESCRIPTION
## Description

Implements the staff RFP list at the shell's `/rfps` route per `designs/flow2a/` screen 01 and spec section 2a: all RFPs from `GET /api/v1/Rfps` with client-side status tabs (Draft/Approved/Published, synced to a `status` query param so the dashboard's stat card links work), search over title/organisation/tags, a new `StatusBadge` for RFP statuses following the portal's badge class conventions, rows linking to the detail route, and a "New RFP" action into the editor route. No reference IDs or author info are shown.

The detail (`/rfps/:id`) and editor (`/rfps/new`) routes are added as placeholder pages — their full implementation is scoped to separate issues (flow 2a screens 02–04).

## Linked Issue

Closes #281

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- `npm run build` and `npx vitest run` pass in `frontend/staff`.
- Added `RfpsPage.test.tsx` covering: default Draft tab, `status` query param handling and tab switching, search filtering within the active tab, empty state per status, and row/action link targets.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)