### PR TITLE
Implement the RFP editor (flow 2a, screen 02)

### DIFF
--- a/frontend/staff/src/api/rfps.ts
+++ b/frontend/staff/src/api/rfps.ts
@@ -2,3 +2,26 @@ import { apiClient } from './client';
 import type { Rfp } from '../types';
 
 export const listRfps = (): Promise<Rfp[]> => apiClient.get('/Rfps').then((r) => r.data);
+
+export const getRfpById = (id: string): Promise<Rfp> => apiClient.get(`/Rfps/${id}`).then((r) => r.data);
+
+export interface CreateRfpPayload {
+  title: string;
+  shortDescription: string;
+  organisationId: string;
+  longDescription: string;
+  tags?: string;
+}
+
+export const createRfp = (payload: CreateRfpPayload): Promise<string> =>
+  apiClient.post('/Rfps', payload).then((r) => r.data);
+
+export interface UpdateRfpPayload {
+  title: string;
+  shortDescription: string;
+  longDescription: string;
+  tags?: string;
+}
+
+export const updateRfp = (id: string, payload: UpdateRfpPayload): Promise<void> =>
+  apiClient.put(`/Rfps/${id}`, payload).then(() => undefined);

--- a/frontend/staff/src/pages/app/RfpDetailPage.tsx
+++ b/frontend/staff/src/pages/app/RfpDetailPage.tsx
@@ -1,7 +1,24 @@
-// Placeholder — the RFP detail with lifecycle actions (flow 2a, screens 03–04) lands in a later issue.
+import { useSearchParams } from 'react-router-dom';
+
+// Placeholder — the full RFP detail with lifecycle actions (flow 2a, screens 03–04) lands in a later issue.
+// The in-app confirmation banner below is wired up for the editor's create/edit redirects.
 export default function RfpDetailPage() {
+  const [searchParams] = useSearchParams();
+  const created = searchParams.get('created') === 'true';
+  const updated = searchParams.get('updated') === 'true';
+
   return (
     <div className="max-w-[1080px] mx-auto px-6 py-8">
+      {created && (
+        <div className="mb-5 px-4 py-3 rounded-lg border border-status-success-text/20 bg-status-success-bg text-status-success-text text-sm font-medium">
+          RFP created — it starts in Draft.
+        </div>
+      )}
+      {updated && (
+        <div className="mb-5 px-4 py-3 rounded-lg border border-status-success-text/20 bg-status-success-bg text-status-success-text text-sm font-medium">
+          RFP changes saved.
+        </div>
+      )}
       <p className="text-sm text-neutral-500">RFP detail is coming soon.</p>
     </div>
   );

--- a/frontend/staff/src/pages/app/RfpEditorPage.test.tsx
+++ b/frontend/staff/src/pages/app/RfpEditorPage.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import RfpEditorPage from './RfpEditorPage';
+import { createRfp, getRfpById, updateRfp } from '../../api/rfps';
+import { listOrganisations } from '../../api/organisations';
+import type { Organisation, Rfp } from '../../types';
+
+vi.mock('../../api/rfps', () => ({
+  createRfp: vi.fn(),
+  updateRfp: vi.fn(),
+  getRfpById: vi.fn(),
+}));
+vi.mock('../../api/organisations', () => ({ listOrganisations: vi.fn() }));
+
+const mockCreateRfp = vi.mocked(createRfp);
+const mockUpdateRfp = vi.mocked(updateRfp);
+const mockGetRfpById = vi.mocked(getRfpById);
+const mockListOrganisations = vi.mocked(listOrganisations);
+
+const organisations: Organisation[] = [
+  { id: 'o1', name: 'Ministry of Digital Economy' },
+  { id: 'o2', name: 'Diaspora Engagement Bureau' },
+];
+
+const draftRfp: Rfp = {
+  id: 'rfp-1',
+  title: 'Digital ID Verification',
+  shortDescription: 'A short description.',
+  longDescription: 'A long description.',
+  status: 'Draft',
+  organisationId: 'o1',
+  authorId: 'u1',
+  tags: 'identity',
+};
+
+function renderPage(initialEntries: string[], path: string) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={initialEntries}>
+        <Routes>
+          <Route path={path} element={<RfpEditorPage />} />
+          <Route path="/rfps/:id" element={<div>detail page</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockListOrganisations.mockResolvedValue(organisations);
+  mockGetRfpById.mockResolvedValue(draftRfp);
+});
+
+describe('RfpEditorPage — create mode', () => {
+  it('shows validation errors and does not submit when required fields are empty', async () => {
+    const user = userEvent.setup();
+    renderPage(['/rfps/new'], '/rfps/new');
+
+    await screen.findByText('Ministry of Digital Economy');
+    await user.click(screen.getByRole('button', { name: 'Create RFP' }));
+
+    expect(await screen.findByText('Title is required.')).toBeInTheDocument();
+    expect(screen.getByText('Short description is required.')).toBeInTheDocument();
+    expect(screen.getByText('Long description is required.')).toBeInTheDocument();
+    expect(screen.getByText('Organisation is required.')).toBeInTheDocument();
+    expect(mockCreateRfp).not.toHaveBeenCalled();
+  });
+
+  it('submits the form and redirects to the detail page with a created confirmation', async () => {
+    const user = userEvent.setup();
+    mockCreateRfp.mockResolvedValue('new-rfp-id');
+    renderPage(['/rfps/new'], '/rfps/new');
+
+    await user.type(screen.getByLabelText('Title'), 'New RFP Title');
+    await user.type(screen.getByLabelText('Short description'), 'Short desc');
+    await user.type(screen.getByLabelText('Long description'), 'Long desc');
+    await user.selectOptions(await screen.findByLabelText('Organisation'), 'o1');
+    await user.click(screen.getByRole('button', { name: 'Create RFP' }));
+
+    await waitFor(() =>
+      expect(mockCreateRfp).toHaveBeenCalledWith({
+        title: 'New RFP Title',
+        shortDescription: 'Short desc',
+        longDescription: 'Long desc',
+        tags: undefined,
+        organisationId: 'o1',
+      }),
+    );
+    expect(await screen.findByText('detail page')).toBeInTheDocument();
+  });
+});
+
+describe('RfpEditorPage — edit mode', () => {
+  it('prefills the form from the existing RFP and disables the organisation field', async () => {
+    renderPage(['/rfps/rfp-1/edit'], '/rfps/:id/edit');
+
+    expect(await screen.findByDisplayValue('Digital ID Verification')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('A short description.')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('A long description.')).toBeInTheDocument();
+    expect(screen.getByLabelText('Organisation')).toBeDisabled();
+  });
+
+  it('shows the published warning when editing a published RFP', async () => {
+    mockGetRfpById.mockResolvedValue({ ...draftRfp, status: 'Published' });
+    renderPage(['/rfps/rfp-1/edit'], '/rfps/:id/edit');
+
+    expect(await screen.findByText('This RFP is live on the portal')).toBeInTheDocument();
+  });
+
+  it('submits changes via PUT and redirects with an updated confirmation', async () => {
+    const user = userEvent.setup();
+    mockUpdateRfp.mockResolvedValue(undefined);
+    renderPage(['/rfps/rfp-1/edit'], '/rfps/:id/edit');
+
+    await screen.findByDisplayValue('Digital ID Verification');
+    await user.clear(screen.getByLabelText('Title'));
+    await user.type(screen.getByLabelText('Title'), 'Updated Title');
+    await user.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() =>
+      expect(mockUpdateRfp).toHaveBeenCalledWith('rfp-1', {
+        title: 'Updated Title',
+        shortDescription: 'A short description.',
+        longDescription: 'A long description.',
+        tags: 'identity',
+      }),
+    );
+    expect(await screen.findByText('detail page')).toBeInTheDocument();
+  });
+});

--- a/frontend/staff/src/pages/app/RfpEditorPage.tsx
+++ b/frontend/staff/src/pages/app/RfpEditorPage.tsx
@@ -1,8 +1,273 @@
-// Placeholder — the RFP editor (flow 2a, screen 02) lands in a later issue.
+import { useEffect, useState } from 'react';
+import type { FormEvent } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { createRfp, getRfpById, updateRfp } from '../../api/rfps';
+import { listOrganisations } from '../../api/organisations';
+import LoadingSpinner from '../../components/LoadingSpinner';
+
+const TITLE_MAX_LENGTH = 256;
+const SHORT_DESCRIPTION_MAX_LENGTH = 512;
+
+interface FormErrors {
+  title?: string;
+  shortDescription?: string;
+  longDescription?: string;
+  organisationId?: string;
+}
+
 export default function RfpEditorPage() {
+  const { id } = useParams<{ id: string }>();
+  const isEdit = !!id;
+  const navigate = useNavigate();
+
+  const [title, setTitle] = useState('');
+  const [shortDescription, setShortDescription] = useState('');
+  const [longDescription, setLongDescription] = useState('');
+  const [organisationId, setOrganisationId] = useState('');
+  const [tags, setTags] = useState('');
+  const [errors, setErrors] = useState<FormErrors>({});
+
+  const {
+    data: rfp,
+    isLoading: isRfpLoading,
+    isError: isRfpError,
+  } = useQuery({
+    queryKey: ['rfps', id],
+    queryFn: () => getRfpById(id!),
+    enabled: isEdit,
+  });
+
+  const { data: organisations, isLoading: isOrgsLoading } = useQuery({
+    queryKey: ['organisations'],
+    queryFn: listOrganisations,
+  });
+
+  useEffect(() => {
+    if (rfp) {
+      setTitle(rfp.title);
+      setShortDescription(rfp.shortDescription);
+      setLongDescription(rfp.longDescription);
+      setOrganisationId(rfp.organisationId);
+      setTags(rfp.tags ?? '');
+    }
+  }, [rfp]);
+
+  const mutation = useMutation({
+    mutationFn: async (): Promise<string> => {
+      const payload = {
+        title: title.trim(),
+        shortDescription: shortDescription.trim(),
+        longDescription: longDescription.trim(),
+        tags: tags.trim() || undefined,
+      };
+      if (isEdit) {
+        await updateRfp(id!, payload);
+        return id!;
+      }
+      return createRfp({ ...payload, organisationId });
+    },
+    onSuccess: (rfpId) => {
+      navigate(`/rfps/${rfpId}?${isEdit ? 'updated' : 'created'}=true`);
+    },
+  });
+
+  const validate = (): boolean => {
+    const nextErrors: FormErrors = {};
+    if (!title.trim()) nextErrors.title = 'Title is required.';
+    else if (title.length > TITLE_MAX_LENGTH) nextErrors.title = `Title must be ${TITLE_MAX_LENGTH} characters or fewer.`;
+
+    if (!shortDescription.trim()) nextErrors.shortDescription = 'Short description is required.';
+    else if (shortDescription.length > SHORT_DESCRIPTION_MAX_LENGTH)
+      nextErrors.shortDescription = `Short description must be ${SHORT_DESCRIPTION_MAX_LENGTH} characters or fewer.`;
+
+    if (!longDescription.trim()) nextErrors.longDescription = 'Long description is required.';
+
+    if (!isEdit && !organisationId) nextErrors.organisationId = 'Organisation is required.';
+
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  };
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (!validate()) return;
+    mutation.mutate();
+  };
+
+  if (isEdit && isRfpLoading) return <LoadingSpinner className="py-32" />;
+
+  if (isEdit && (isRfpError || !rfp)) {
+    return (
+      <div className="max-w-[760px] mx-auto px-6 py-20 text-center">
+        <h2 className="text-xl font-bold text-neutral-900 mb-2">RFP not found</h2>
+        <p className="text-sm text-neutral-500 mb-6">This RFP may have been removed.</p>
+        <Link to="/rfps" className="text-brand hover:underline font-medium text-sm">
+          ← Back to RFPs
+        </Link>
+      </div>
+    );
+  }
+
+  const isPublished = isEdit && rfp?.status === 'Published';
+  const cancelTo = isEdit ? `/rfps/${id}` : '/rfps';
+  const saveLabel = isEdit ? 'Save changes' : 'Create RFP';
+  const submitLabel = mutation.isPending ? 'Saving...' : saveLabel;
+
   return (
-    <div className="max-w-[1080px] mx-auto px-6 py-8">
-      <p className="text-sm text-neutral-500">The RFP editor is coming soon.</p>
+    <div className="max-w-[760px] mx-auto px-6 py-8 pb-16">
+      <h1 className="text-2xl font-bold text-neutral-900 mb-1.5">{isEdit ? 'Edit RFP' : 'Create new RFP'}</h1>
+      <p className="text-sm text-neutral-500 mb-5">
+        {isEdit
+          ? 'Update the details for this RFP.'
+          : 'New RFPs start in Draft. You can approve and publish it once it is ready.'}
+      </p>
+
+      {isPublished && (
+        <div className="mb-5 px-4 py-3 rounded-lg border border-status-info-text/20 bg-status-info-bg text-status-info-text text-sm">
+          <p className="font-semibold mb-0.5">This RFP is live on the portal</p>
+          <p>
+            Saving here updates the published RFP immediately — there is no re-approval step. Expats browsing the
+            portal see your changes as soon as you save.
+          </p>
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="bg-neutral-0 border border-neutral-200 rounded-lg shadow-soft p-6">
+        <div className="flex flex-col gap-5">
+          <div>
+            <label htmlFor="title" className="block text-sm font-medium text-neutral-900 mb-1.5">
+              Title
+            </label>
+            <input
+              id="title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="e.g. Digital ID Verification for Remote Diaspora Voting"
+              className="w-full px-3.5 h-[42px] bg-white border border-neutral-200 rounded-lg text-sm focus:outline-none focus:border-brand focus:ring-1 focus:ring-brand transition-shadow"
+            />
+            {errors.title && <p className="mt-1 text-xs text-status-danger-text">{errors.title}</p>}
+          </div>
+
+          <div>
+            <label htmlFor="shortDescription" className="block text-sm font-medium text-neutral-900 mb-1.5">
+              Short description
+            </label>
+            <textarea
+              id="shortDescription"
+              rows={2}
+              value={shortDescription}
+              onChange={(e) => setShortDescription(e.target.value)}
+              placeholder="One or two sentences shown in list and card views."
+              className="w-full px-3.5 py-2.5 bg-white border border-neutral-200 rounded-lg text-sm focus:outline-none focus:border-brand focus:ring-1 focus:ring-brand transition-shadow resize-y"
+            />
+            {errors.shortDescription && (
+              <p className="mt-1 text-xs text-status-danger-text">{errors.shortDescription}</p>
+            )}
+          </div>
+
+          <div>
+            <label htmlFor="longDescription" className="block text-sm font-medium text-neutral-900 mb-1.5">
+              Long description
+            </label>
+            <div className="border border-neutral-200 rounded-lg overflow-hidden">
+              <div className="flex gap-1 px-2.5 py-2 bg-neutral-50 border-b border-neutral-200">
+                {['bold', 'italic', 'list-ul', 'list-ol', 'link'].map((icon) => (
+                  <button
+                    key={icon}
+                    type="button"
+                    disabled
+                    aria-hidden="true"
+                    tabIndex={-1}
+                    className="w-7 h-7 rounded flex items-center justify-center text-neutral-400 cursor-default"
+                  >
+                    <i className={`fa-solid fa-${icon} text-xs`} />
+                  </button>
+                ))}
+              </div>
+              <textarea
+                id="longDescription"
+                rows={7}
+                value={longDescription}
+                onChange={(e) => setLongDescription(e.target.value)}
+                placeholder="Full RFP scope, deliverables, timeline and eligibility."
+                className="w-full px-3.5 py-2.5 bg-white text-sm focus:outline-none resize-y border-0"
+              />
+            </div>
+            <p className="mt-1.5 text-xs text-neutral-400">
+              Toolbar matches the portal's rich-text editor convention; formatting controls are illustrative here.
+            </p>
+            {errors.longDescription && (
+              <p className="mt-1 text-xs text-status-danger-text">{errors.longDescription}</p>
+            )}
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="organisationId" className="block text-sm font-medium text-neutral-900 mb-1.5">
+                Organisation
+              </label>
+              <select
+                id="organisationId"
+                value={organisationId}
+                onChange={(e) => setOrganisationId(e.target.value)}
+                disabled={isEdit || isOrgsLoading}
+                className="w-full px-3.5 h-[42px] bg-white border border-neutral-200 rounded-lg text-sm focus:outline-none focus:border-brand focus:ring-1 focus:ring-brand transition-shadow disabled:bg-neutral-50 disabled:text-neutral-500"
+              >
+                <option value="" disabled>
+                  Select an organisation
+                </option>
+                {(organisations ?? []).map((org) => (
+                  <option key={org.id} value={org.id}>
+                    {org.name}
+                  </option>
+                ))}
+              </select>
+              {isEdit ? (
+                <p className="mt-1.5 text-xs text-neutral-400">Organisation cannot be changed after creation.</p>
+              ) : (
+                errors.organisationId && <p className="mt-1 text-xs text-status-danger-text">{errors.organisationId}</p>
+              )}
+            </div>
+            <div>
+              <label htmlFor="tags" className="block text-sm font-medium text-neutral-900 mb-1.5">
+                Tags <span className="text-neutral-400 font-normal">(optional)</span>
+              </label>
+              <input
+                id="tags"
+                type="text"
+                value={tags}
+                onChange={(e) => setTags(e.target.value)}
+                placeholder="e.g. identity, voting, remote"
+                className="w-full px-3.5 h-[42px] bg-white border border-neutral-200 rounded-lg text-sm focus:outline-none focus:border-brand focus:ring-1 focus:ring-brand transition-shadow"
+              />
+            </div>
+          </div>
+
+          {mutation.isError && (
+            <p className="text-sm text-status-danger-text">
+              {isEdit ? 'Failed to save changes.' : 'Failed to create RFP.'} Please check the form and try again.
+            </p>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-3 mt-7 pt-5 border-t border-neutral-200">
+          <Link
+            to={cancelTo}
+            className="inline-flex items-center px-4 h-10 text-sm font-medium text-neutral-500 hover:text-neutral-900 transition-colors"
+          >
+            Cancel
+          </Link>
+          <button
+            type="submit"
+            disabled={mutation.isPending}
+            className="inline-flex items-center gap-2 px-4 h-10 bg-brand text-white text-sm font-medium rounded-lg hover:bg-brand-dark transition-colors disabled:opacity-60"
+          >
+            {submitLabel}
+          </button>
+        </div>
+      </form>
     </div>
   );
 }

--- a/frontend/staff/src/routes/router.tsx
+++ b/frontend/staff/src/routes/router.tsx
@@ -29,6 +29,7 @@ export const router = createBrowserRouter([
       { path: '/rfps', element: <RfpsPage /> },
       { path: '/rfps/new', element: <RfpEditorPage /> },
       { path: '/rfps/:id', element: <RfpDetailPage /> },
+      { path: '/rfps/:id/edit', element: <RfpEditorPage /> },
       { path: '/proposals', element: <ProposalsPage /> },
       { path: '/organisations', element: <OrganisationsPage /> },
       { path: '/users', element: <UsersPage /> },


### PR DESCRIPTION
## Description

Implements the RFP editor's create and edit states per `designs/flow2a/` screen 02 and spec section 2a.

- Fields: title, short description, long description (textarea with an illustrative rich-text toolbar, consistent with the portal's plain-textarea editor convention), organisation selector fed by `GET /api/v1/Organisations`, optional tags.
- Create → `POST /api/v1/Rfps` (lands in `Draft`) → redirects to `/rfps/{id}?created=true` for an in-app confirmation.
- Edit → `PUT /api/v1/Rfps/{id}`, available from any status. The organisation selector is disabled in edit mode since the backend's `UpdateRfpCommand` doesn't accept an organisation change.
- Editing a `Published` RFP shows the mockup's banner noting changes go live immediately with no re-approval.
- Client-side validation mirrors the backend FluentValidation rules (required title/short/long description, 256/512 char limits, required organisation on create).
- Added a new `/rfps/:id/edit` route. The RFP detail page (flow 2a, screens 03–04) is still a placeholder pending a later issue, so it now also reads `created`/`updated` query params to render the in-app confirmation banner.

## Linked Issue

Closes #282

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- Added `RfpEditorPage.test.tsx` covering create validation, successful create/redirect, edit prefill (with disabled organisation field), the Published-edit warning banner, and successful edit/redirect.
- `npm run build` and `npm test -- --run` pass in `frontend/staff`.
- `dotnet build --configuration Release` passes (no backend changes needed).

## Checklist

- [x] Code builds cleanly (`dotnet build`, `npm run build`)
- [x] Tests pass (`dotnet test`, `npm test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)