### PR TITLE
Implement the RFP detail with lifecycle actions and modals (flow 2a, screens 03–04)

### DIFF
--- a/frontend/staff/src/api/errors.ts
+++ b/frontend/staff/src/api/errors.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+interface ProblemDetails {
+  title?: string;
+  detail?: string;
+}
+
+/** Surfaces the backend's ProblemDetails message (403/validation/etc.) instead of a generic failure string. */
+export function getErrorMessage(error: unknown, fallback: string): string {
+  if (axios.isAxiosError<ProblemDetails>(error)) {
+    return error.response?.data?.detail ?? error.response?.data?.title ?? fallback;
+  }
+  return fallback;
+}

--- a/frontend/staff/src/api/rfps.ts
+++ b/frontend/staff/src/api/rfps.ts
@@ -1,5 +1,5 @@
 import { apiClient } from './client';
-import type { Rfp } from '../types';
+import type { Rfp, RfpStatus } from '../types';
 
 export const listRfps = (): Promise<Rfp[]> => apiClient.get('/Rfps').then((r) => r.data);
 
@@ -25,3 +25,9 @@ export interface UpdateRfpPayload {
 
 export const updateRfp = (id: string, payload: UpdateRfpPayload): Promise<void> =>
   apiClient.put(`/Rfps/${id}`, payload).then(() => undefined);
+
+export const updateRfpStatus = (id: string, newStatus: RfpStatus): Promise<void> =>
+  apiClient.patch(`/Rfps/${id}/status`, { newStatus }).then(() => undefined);
+
+export const deleteRfp = (id: string): Promise<void> =>
+  apiClient.delete(`/Rfps/${id}`).then(() => undefined);

--- a/frontend/staff/src/components/Modal.tsx
+++ b/frontend/staff/src/components/Modal.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from 'react';
+
+interface ModalProps {
+  readonly tone: 'neutral' | 'danger';
+  readonly icon: ReactNode;
+  readonly title: string;
+  readonly description?: string;
+  readonly children?: ReactNode;
+  readonly actions: ReactNode;
+  readonly onClose: () => void;
+}
+
+/** Checkbox/summary-friendly confirm dialog shell — reused for the Approve, Publish and Delete RFP flows. */
+export default function Modal({ tone, icon, title, description, children, actions, onClose }: ModalProps) {
+  const iconBg = tone === 'danger' ? 'bg-status-danger-bg' : 'bg-brand-100';
+  const iconColor = tone === 'danger' ? 'text-status-danger-text' : 'text-brand-700';
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-neutral-900/40" onClick={onClose}>
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        onClick={(e) => e.stopPropagation()}
+        className="bg-neutral-0 rounded-xl shadow-floating max-w-[420px] w-full overflow-hidden"
+      >
+        <div className="px-6 pt-6 pb-4 flex flex-col items-center text-center">
+          <div className={`w-14 h-14 rounded-full ${iconBg} flex items-center justify-center mb-4`}>
+            <span className={iconColor}>{icon}</span>
+          </div>
+          <h2 className="text-lg font-bold text-neutral-900 mb-2">{title}</h2>
+          {description && <p className="text-sm text-neutral-500 leading-relaxed">{description}</p>}
+        </div>
+        {children && <div className="px-6 pb-4">{children}</div>}
+        <div className="px-6 py-4 bg-neutral-50 border-t border-neutral-200 flex justify-end gap-3">{actions}</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/staff/src/pages/app/RfpDetailPage.test.tsx
+++ b/frontend/staff/src/pages/app/RfpDetailPage.test.tsx
@@ -1,0 +1,148 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import RfpDetailPage from './RfpDetailPage';
+import { deleteRfp, getRfpById, updateRfpStatus } from '../../api/rfps';
+import { listOrganisations } from '../../api/organisations';
+import type { Organisation, Rfp } from '../../types';
+
+vi.mock('../../api/rfps', () => ({
+  getRfpById: vi.fn(),
+  updateRfpStatus: vi.fn(),
+  deleteRfp: vi.fn(),
+}));
+vi.mock('../../api/organisations', () => ({ listOrganisations: vi.fn() }));
+
+const mockGetRfpById = vi.mocked(getRfpById);
+const mockUpdateRfpStatus = vi.mocked(updateRfpStatus);
+const mockDeleteRfp = vi.mocked(deleteRfp);
+const mockListOrganisations = vi.mocked(listOrganisations);
+
+const organisations: Organisation[] = [{ id: 'o1', name: 'Ministry of Digital Economy' }];
+
+const baseRfp: Rfp = {
+  id: 'rfp-1',
+  title: 'Digital ID Verification',
+  shortDescription: 'A short description.',
+  longDescription: 'A long description.',
+  status: 'Draft',
+  organisationId: 'o1',
+  authorId: 'u1',
+  tags: 'identity',
+};
+
+function renderPage(rfp: Rfp, initialEntries = ['/rfps/rfp-1']) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  mockGetRfpById.mockResolvedValue(rfp);
+  mockListOrganisations.mockResolvedValue(organisations);
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={initialEntries}>
+        <Routes>
+          <Route path="/rfps/:id" element={<RfpDetailPage />} />
+          <Route path="/rfps" element={<div>rfps list</div>} />
+          <Route path="/rfps/:id/edit" element={<div>editor page</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('RfpDetailPage — Draft', () => {
+  it('shows Edit/Approve/Delete actions and opens a bare confirm for Approve', async () => {
+    const user = userEvent.setup();
+    renderPage(baseRfp);
+
+    await screen.findByText('Digital ID Verification');
+    expect(screen.getByRole('link', { name: 'Edit' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Publish' })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Approve' }));
+    expect(screen.getByRole('dialog', { name: 'Approve this RFP?' })).toBeInTheDocument();
+  });
+});
+
+describe('RfpDetailPage — status transitions', () => {
+  it('calls the status endpoint with Approved when confirming approve', async () => {
+    const user = userEvent.setup();
+    mockUpdateRfpStatus.mockResolvedValue(undefined);
+    renderPage(baseRfp);
+
+    await user.click(await screen.findByRole('button', { name: 'Approve' }));
+    const dialog = screen.getByRole('dialog', { name: 'Approve this RFP?' });
+    await user.click(within(dialog).getByRole('button', { name: 'Approve' }));
+
+    await waitFor(() => expect(mockUpdateRfpStatus).toHaveBeenCalledWith('rfp-1', 'Approved'));
+  });
+
+  it('shows the publish confirm-with-summary modal for Approved RFPs and calls the status endpoint', async () => {
+    const user = userEvent.setup();
+    mockUpdateRfpStatus.mockResolvedValue(undefined);
+    renderPage({ ...baseRfp, status: 'Approved' });
+
+    await user.click(await screen.findByRole('button', { name: 'Publish' }));
+    const dialog = screen.getByRole('dialog', { name: 'Publish this RFP?' });
+    expect(within(dialog).getByText('Digital ID Verification')).toBeInTheDocument();
+    expect(within(dialog).getByText('A short description.')).toBeInTheDocument();
+
+    await user.click(within(dialog).getByRole('button', { name: 'Publish' }));
+    await waitFor(() => expect(mockUpdateRfpStatus).toHaveBeenCalledWith('rfp-1', 'Published'));
+  });
+
+  it('surfaces a backend error message instead of a generic failure', async () => {
+    const user = userEvent.setup();
+    mockUpdateRfpStatus.mockRejectedValue({
+      isAxiosError: true,
+      response: { data: { detail: "You don't have permission to approve this RFP." } },
+    });
+    renderPage(baseRfp);
+
+    await user.click(await screen.findByRole('button', { name: 'Approve' }));
+    const dialog = screen.getByRole('dialog', { name: 'Approve this RFP?' });
+    await user.click(within(dialog).getByRole('button', { name: 'Approve' }));
+
+    expect(await screen.findByText("You don't have permission to approve this RFP.")).toBeInTheDocument();
+  });
+});
+
+describe('RfpDetailPage — Published', () => {
+  it('shows the live-on-portal indicator with a link and no Approve/Publish action', async () => {
+    renderPage({ ...baseRfp, status: 'Published' });
+    expect(await screen.findByText(/Live on the portal/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'View public page' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Approve' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Publish' })).not.toBeInTheDocument();
+  });
+});
+
+describe('RfpDetailPage — delete', () => {
+  it('requires the confirmation checkbox before enabling Delete and uses published copy', async () => {
+    const user = userEvent.setup();
+    renderPage({ ...baseRfp, status: 'Published' });
+
+    await user.click(await screen.findByRole('button', { name: 'Delete' }));
+    const dialog = screen.getByRole('dialog', { name: 'Delete this RFP?' });
+    expect(within(dialog).getByText(/removes it from the portal immediately/)).toBeInTheDocument();
+
+    const confirmButton = within(dialog).getByRole('button', { name: 'Delete' });
+    expect(confirmButton).toBeDisabled();
+
+    await user.click(within(dialog).getByRole('checkbox'));
+    expect(confirmButton).toBeEnabled();
+  });
+
+  it('deletes and returns to the list with a confirmation', async () => {
+    const user = userEvent.setup();
+    mockDeleteRfp.mockResolvedValue(undefined);
+    renderPage(baseRfp);
+
+    await user.click(await screen.findByRole('button', { name: 'Delete' }));
+    const dialog = screen.getByRole('dialog', { name: 'Delete this RFP?' });
+    await user.click(within(dialog).getByRole('checkbox'));
+    await user.click(within(dialog).getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(mockDeleteRfp).toHaveBeenCalledWith('rfp-1'));
+    expect(await screen.findByText('rfps list')).toBeInTheDocument();
+  });
+});

--- a/frontend/staff/src/pages/app/RfpDetailPage.tsx
+++ b/frontend/staff/src/pages/app/RfpDetailPage.tsx
@@ -1,14 +1,118 @@
-import { useSearchParams } from 'react-router-dom';
+import { useState } from 'react';
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { deleteRfp, getRfpById, updateRfpStatus } from '../../api/rfps';
+import { getErrorMessage } from '../../api/errors';
+import { listOrganisations } from '../../api/organisations';
+import type { RfpStatus } from '../../types';
+import StatusBadge from '../../components/StatusBadge';
+import Modal from '../../components/Modal';
+import LoadingSpinner from '../../components/LoadingSpinner';
 
-// Placeholder — the full RFP detail with lifecycle actions (flow 2a, screens 03–04) lands in a later issue.
-// The in-app confirmation banner below is wired up for the editor's create/edit redirects.
+const PORTAL_URL = import.meta.env.VITE_PORTAL_URL ?? 'https://herit.app';
+
+type ModalKind = 'approve' | 'publish' | 'delete' | null;
+
+const CheckIcon = () => (
+  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+  </svg>
+);
+
+const GlobeIcon = () => (
+  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M3 12h18M12 3c2.5 2.5 4 5.5 4 9s-1.5 6.5-4 9c-2.5-2.5-4-5.5-4-9s1.5-6.5 4-9z"
+    />
+  </svg>
+);
+
+const TrashIcon = () => (
+  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M9.5 4h5a1 1 0 011 1v2h-7V5a1 1 0 011-1z"
+    />
+  </svg>
+);
+
 export default function RfpDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [searchParams] = useSearchParams();
   const created = searchParams.get('created') === 'true';
   const updated = searchParams.get('updated') === 'true';
 
+  const [modal, setModal] = useState<ModalKind>(null);
+  const [deleteChecked, setDeleteChecked] = useState(false);
+
+  const {
+    data: rfp,
+    isLoading,
+    isError,
+  } = useQuery({ queryKey: ['rfps', id], queryFn: () => getRfpById(id!) });
+
+  const { data: organisations } = useQuery({ queryKey: ['organisations'], queryFn: listOrganisations });
+
+  const statusMutation = useMutation({
+    mutationFn: (status: RfpStatus) => updateRfpStatus(id!, status),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['rfps'] });
+      setModal(null);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteRfp(id!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['rfps'] });
+      navigate('/rfps?deleted=true');
+    },
+  });
+
+  const closeModal = () => {
+    if (statusMutation.isPending || deleteMutation.isPending) return;
+    setModal(null);
+    setDeleteChecked(false);
+    statusMutation.reset();
+    deleteMutation.reset();
+  };
+
+  if (isLoading) return <LoadingSpinner className="py-32" />;
+
+  if (isError || !rfp) {
+    return (
+      <div className="max-w-[760px] mx-auto px-6 py-20 text-center">
+        <h2 className="text-xl font-bold text-neutral-900 mb-2">RFP not found</h2>
+        <p className="text-sm text-neutral-500 mb-6">This RFP may have been removed.</p>
+        <Link to="/rfps" className="text-brand hover:underline font-medium text-sm">
+          ← Back to RFPs
+        </Link>
+      </div>
+    );
+  }
+
+  const org = organisations?.find((o) => o.id === rfp.organisationId);
+  const subtitle = [org?.name, rfp.tags].filter(Boolean).join(' · ');
+  const publicUrl = `${PORTAL_URL}/rfps/${rfp.id}`;
+
+  const deleteDescription =
+    rfp.status === 'Published'
+      ? 'This RFP is currently live on the portal. Deleting it removes it from the portal immediately. Proposals that already reference this RFP keep their reference — deleting the RFP does not delete or alter them.'
+      : 'This permanently deletes the RFP. It cannot be undone.';
+
   return (
-    <div className="max-w-[1080px] mx-auto px-6 py-8">
+    <div className="max-w-[800px] mx-auto px-6 py-8 pb-16">
+      <Link to="/rfps" className="inline-block text-sm text-neutral-500 hover:text-neutral-900 mb-5">
+        ← Back to RFPs
+      </Link>
+
       {created && (
         <div className="mb-5 px-4 py-3 rounded-lg border border-status-success-text/20 bg-status-success-bg text-status-success-text text-sm font-medium">
           RFP created — it starts in Draft.
@@ -19,7 +123,176 @@ export default function RfpDetailPage() {
           RFP changes saved.
         </div>
       )}
-      <p className="text-sm text-neutral-500">RFP detail is coming soon.</p>
+
+      <div className="flex items-start justify-between gap-4 mb-1.5">
+        <h1 className="text-2xl font-bold text-neutral-900">{rfp.title}</h1>
+        <StatusBadge type="rfp" status={rfp.status} />
+      </div>
+      {subtitle && <p className="text-sm text-neutral-500 mb-5">{subtitle}</p>}
+
+      {rfp.status === 'Published' && (
+        <div className="mb-5 px-4 py-3 rounded-lg border border-status-success-text/20 bg-status-success-bg text-status-success-text text-sm">
+          Live on the portal — expats can view and respond to this RFP right now.{' '}
+          <a href={publicUrl} target="_blank" rel="noreferrer" className="font-semibold underline">
+            View public page
+          </a>
+        </div>
+      )}
+
+      <div className="bg-neutral-0 border border-neutral-200 rounded-lg shadow-soft p-6">
+        <h3 className="text-xs font-semibold text-neutral-900 uppercase tracking-wide mb-2">Short description</h3>
+        <p className="text-sm text-neutral-500 leading-relaxed mb-5">{rfp.shortDescription}</p>
+        <h3 className="text-xs font-semibold text-neutral-900 uppercase tracking-wide mb-2">Long description</h3>
+        <p className="text-sm text-neutral-500 leading-relaxed whitespace-pre-line">{rfp.longDescription}</p>
+      </div>
+
+      <div className="mt-6 pt-5 border-t border-neutral-200 flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex gap-3">
+          <Link
+            to={`/rfps/${rfp.id}/edit`}
+            className="inline-flex items-center px-4 h-10 bg-neutral-0 border border-neutral-200 text-sm font-medium text-neutral-900 rounded-lg hover:bg-neutral-50 transition-colors"
+          >
+            Edit
+          </Link>
+          {rfp.status === 'Draft' && (
+            <button
+              onClick={() => setModal('approve')}
+              className="inline-flex items-center px-4 h-10 bg-brand text-white text-sm font-medium rounded-lg hover:bg-brand-dark transition-colors"
+            >
+              Approve
+            </button>
+          )}
+          {rfp.status === 'Approved' && (
+            <button
+              onClick={() => setModal('publish')}
+              className="inline-flex items-center px-4 h-10 bg-brand text-white text-sm font-medium rounded-lg hover:bg-brand-dark transition-colors"
+            >
+              Publish
+            </button>
+          )}
+        </div>
+        <button
+          onClick={() => setModal('delete')}
+          className="inline-flex items-center px-4 h-10 bg-status-danger-bg text-status-danger-text text-sm font-medium rounded-lg hover:bg-status-danger-bg/70 transition-colors"
+        >
+          Delete
+        </button>
+      </div>
+
+      {modal === 'approve' && (
+        <Modal
+          tone="neutral"
+          icon={<CheckIcon />}
+          title="Approve this RFP?"
+          description="Marks it ready to publish. Staff can still edit before publishing — this does not put it on the portal yet."
+          onClose={closeModal}
+          actions={
+            <>
+              <button
+                onClick={closeModal}
+                className="inline-flex items-center px-4 h-9 text-sm font-medium text-neutral-500 hover:text-neutral-900 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => statusMutation.mutate('Approved')}
+                disabled={statusMutation.isPending}
+                className="inline-flex items-center px-4 h-9 bg-brand text-white text-sm font-medium rounded-lg hover:bg-brand-dark transition-colors disabled:opacity-60"
+              >
+                {statusMutation.isPending ? 'Approving...' : 'Approve'}
+              </button>
+            </>
+          }
+        >
+          {statusMutation.isError && (
+            <p className="text-sm text-status-danger-text text-center">
+              {getErrorMessage(statusMutation.error, 'Failed to approve this RFP. Please try again.')}
+            </p>
+          )}
+        </Modal>
+      )}
+
+      {modal === 'publish' && (
+        <Modal
+          tone="neutral"
+          icon={<GlobeIcon />}
+          title="Publish this RFP?"
+          description="This puts the RFP live on the public Herit Portal immediately. Here's what expats will see:"
+          onClose={closeModal}
+          actions={
+            <>
+              <button
+                onClick={closeModal}
+                className="inline-flex items-center px-4 h-9 text-sm font-medium text-neutral-500 hover:text-neutral-900 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => statusMutation.mutate('Published')}
+                disabled={statusMutation.isPending}
+                className="inline-flex items-center px-4 h-9 bg-brand text-white text-sm font-medium rounded-lg hover:bg-brand-dark transition-colors disabled:opacity-60"
+              >
+                {statusMutation.isPending ? 'Publishing...' : 'Publish'}
+              </button>
+            </>
+          }
+        >
+          <div className="bg-neutral-50 border border-neutral-200 rounded-lg p-4 text-left">
+            <p className="text-sm font-semibold text-neutral-900 mb-1">{rfp.title}</p>
+            <p className="text-sm text-neutral-500 mb-1.5">{rfp.shortDescription}</p>
+            {subtitle && <p className="text-xs text-neutral-400">{subtitle}</p>}
+          </div>
+          {statusMutation.isError && (
+            <p className="mt-3 text-sm text-status-danger-text text-center">
+              {getErrorMessage(statusMutation.error, 'Failed to publish this RFP. Please try again.')}
+            </p>
+          )}
+        </Modal>
+      )}
+
+      {modal === 'delete' && (
+        <Modal
+          tone="danger"
+          icon={<TrashIcon />}
+          title="Delete this RFP?"
+          description={deleteDescription}
+          onClose={closeModal}
+          actions={
+            <>
+              <button
+                onClick={closeModal}
+                className="inline-flex items-center px-4 h-9 text-sm font-medium text-neutral-500 hover:text-neutral-900 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => deleteMutation.mutate()}
+                disabled={!deleteChecked || deleteMutation.isPending}
+                className="inline-flex items-center px-4 h-9 bg-status-danger-text text-white text-sm font-medium rounded-lg hover:opacity-90 transition-colors disabled:opacity-60"
+              >
+                {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
+              </button>
+            </>
+          }
+        >
+          <label className="flex items-start gap-3 cursor-pointer pt-2 border-t border-neutral-200">
+            <input
+              type="checkbox"
+              checked={deleteChecked}
+              onChange={(e) => setDeleteChecked(e.target.checked)}
+              className="mt-0.5 w-4 h-4 accent-brand"
+            />
+            <span className="text-sm text-neutral-700 text-left">
+              I understand this action is permanent and cannot be undone.
+            </span>
+          </label>
+          {deleteMutation.isError && (
+            <p className="mt-3 text-sm text-status-danger-text text-center">
+              {getErrorMessage(deleteMutation.error, 'Failed to delete this RFP. Please try again.')}
+            </p>
+          )}
+        </Modal>
+      )}
     </div>
   );
 }

--- a/frontend/staff/src/pages/app/RfpEditorPage.tsx
+++ b/frontend/staff/src/pages/app/RfpEditorPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import type { FormEvent } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createRfp, getRfpById, updateRfp } from '../../api/rfps';
 import { listOrganisations } from '../../api/organisations';
 import LoadingSpinner from '../../components/LoadingSpinner';
@@ -20,6 +20,7 @@ export default function RfpEditorPage() {
   const { id } = useParams<{ id: string }>();
   const isEdit = !!id;
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const [title, setTitle] = useState('');
   const [shortDescription, setShortDescription] = useState('');
@@ -68,6 +69,7 @@ export default function RfpEditorPage() {
       return createRfp({ ...payload, organisationId });
     },
     onSuccess: (rfpId) => {
+      queryClient.invalidateQueries({ queryKey: ['rfps'] });
       navigate(`/rfps/${rfpId}?${isEdit ? 'updated' : 'created'}=true`);
     },
   });

--- a/frontend/staff/src/pages/app/RfpsPage.test.tsx
+++ b/frontend/staff/src/pages/app/RfpsPage.test.tsx
@@ -82,6 +82,11 @@ describe('RfpsPage', () => {
     expect(screen.getByText('New RFPs start in Draft. Create one to get started.')).toBeInTheDocument();
   });
 
+  it('shows a deletion confirmation banner when redirected with ?deleted=true', async () => {
+    renderPage(['/rfps?deleted=true']);
+    expect(await screen.findByText('RFP deleted.')).toBeInTheDocument();
+  });
+
   it('links rows to the detail page and the New RFP action to the editor', async () => {
     renderPage();
 

--- a/frontend/staff/src/pages/app/RfpsPage.tsx
+++ b/frontend/staff/src/pages/app/RfpsPage.tsx
@@ -30,6 +30,8 @@ export default function RfpsPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [search, setSearch] = useState('');
 
+  const deleted = searchParams.get('deleted') === 'true';
+
   const statusParam = searchParams.get('status');
   const activeTab: RfpStatus = isRfpStatus(statusParam) ? statusParam : 'Draft';
 
@@ -71,6 +73,11 @@ export default function RfpsPage() {
 
   return (
     <div className="max-w-[1080px] mx-auto px-6 py-8 pb-16">
+      {deleted && (
+        <div className="mb-5 px-4 py-3 rounded-lg border border-status-success-text/20 bg-status-success-bg text-status-success-text text-sm font-medium">
+          RFP deleted.
+        </div>
+      )}
       <div className="flex items-start justify-between gap-4 mb-5">
         <div>
           <h1 className="text-2xl font-bold text-neutral-900 mb-1">RFPs</h1>


### PR DESCRIPTION
## Description

Implements the staff RFP detail view in its three status states (Draft/Approved/Published) plus the transition and delete modals, per `designs/flow2a/` screens 03–04 and spec section 2a.

- **Draft**: Edit / Approve / Delete. **Approved**: Edit / Publish / Delete. **Published**: Edit / Delete + a "live on the portal" banner linking to the public RFP page.
- Approve is a lightweight bare confirm; Publish is a confirm-with-summary modal showing the title/short description/org·tags that expats will see. Both call `PATCH /api/v1/Rfps/{id}/status`.
- Delete is a checkbox-gated destructive confirmation with mockup copy that varies for Published RFPs ("removes it from the portal immediately; proposals that already reference this RFP keep their reference"), calling `DELETE /api/v1/Rfps/{id}` and returning to the list with a confirmation banner.
- Backend 403/validation errors are surfaced via a new `getErrorMessage` helper that reads the ProblemDetails `detail`/`title` fields, instead of a generic failure message.
- Added a reusable `Modal` component (tone/icon/title/description/children/actions) shared by all three confirmations.
- Fixed a latent bug surfaced by this change: the editor's save mutation didn't invalidate the `['rfps']` query cache, so saving an edit and landing on the detail page could show stale pre-edit data for up to the query's stale time.

## Linked Issue

Closes #283

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- `npx tsc --noEmit`, `npx vitest run` (39 tests passing), and `npm run build` all pass in `frontend/staff`.
- New `RfpDetailPage.test.tsx` covers all three status states, both status-transition modals, the delete checkbox gating and published-vs-other copy, backend error surfacing, and the redirect-with-confirmation flow.
- Not manually verified in a browser against a running backend — no staff E2E harness exists yet for this flow, so verification here is build/typecheck/unit-test only.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)