### PR TITLE
Implement the proposal review queue (flow 2b, screen 01)

### DIFF
--- a/frontend/staff/src/components/StatusBadge.tsx
+++ b/frontend/staff/src/components/StatusBadge.tsx
@@ -1,4 +1,4 @@
-import type { RfpStatus } from '../types';
+import type { ProposalStatus, ProposalVisibility, RfpStatus } from '../types';
 
 const rfpStatusStyles: Record<RfpStatus, string> = {
   Draft: 'bg-status-neutral-bg text-status-neutral-text',
@@ -6,17 +6,43 @@ const rfpStatusStyles: Record<RfpStatus, string> = {
   Published: 'bg-status-success-bg text-status-success-text',
 };
 
-interface StatusBadgeProps {
-  readonly type: 'rfp';
-  readonly status: RfpStatus;
+const proposalStatusStyles: Record<ProposalStatus, string> = {
+  Ideation: 'bg-status-neutral-bg text-status-neutral-text',
+  Resourcing: 'bg-status-info-bg text-status-info-text',
+  Submitted: 'bg-status-amber-bg text-status-amber-text',
+  UnderReview: 'bg-status-orange-bg text-status-orange-text',
+  Approved: 'bg-status-success-bg text-status-success-text',
+  Withdrawn: 'bg-status-danger-bg text-status-danger-text',
+};
+
+const visibilityStyles: Record<ProposalVisibility, string> = {
+  Public: 'bg-status-neutral-bg text-status-neutral-text',
+  Private: 'bg-status-neutral-bg text-status-neutral-text',
+  Shared: 'bg-status-info-bg text-status-info-text',
+};
+
+type StatusBadgeProps =
+  | { readonly type: 'rfp'; readonly status: RfpStatus }
+  | { readonly type: 'proposal'; readonly status: ProposalStatus }
+  | { readonly type: 'visibility'; readonly status: ProposalVisibility };
+
+function styleFor(props: StatusBadgeProps): string {
+  switch (props.type) {
+    case 'rfp':
+      return rfpStatusStyles[props.status];
+    case 'proposal':
+      return proposalStatusStyles[props.status];
+    case 'visibility':
+      return visibilityStyles[props.status];
+  }
 }
 
-export default function StatusBadge({ status }: StatusBadgeProps) {
+export default function StatusBadge(props: StatusBadgeProps) {
   return (
     <span
-      className={`inline-block px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider rounded border border-transparent ${rfpStatusStyles[status]}`}
+      className={`inline-block px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider rounded border border-transparent ${styleFor(props)}`}
     >
-      {status}
+      {props.status}
     </span>
   );
 }

--- a/frontend/staff/src/pages/app/ProposalDetailPage.tsx
+++ b/frontend/staff/src/pages/app/ProposalDetailPage.tsx
@@ -1,0 +1,8 @@
+// Placeholder — the proposal review detail (flow 2b, screens 02-03) lands in a later issue.
+export default function ProposalDetailPage() {
+  return (
+    <div className="max-w-[1080px] mx-auto px-6 py-8">
+      <p className="text-sm text-neutral-500">Proposal review detail is coming soon.</p>
+    </div>
+  );
+}

--- a/frontend/staff/src/pages/app/ProposalsPage.test.tsx
+++ b/frontend/staff/src/pages/app/ProposalsPage.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import ProposalsPage from './ProposalsPage';
+import { listProposals } from '../../api/proposals';
+import { listOrganisations } from '../../api/organisations';
+import { listUsers } from '../../api/users';
+import { useCurrentUser } from '../../hooks/useCurrentUser';
+import type { Organisation, Proposal, User } from '../../types';
+
+vi.mock('../../api/proposals', () => ({ listProposals: vi.fn() }));
+vi.mock('../../api/organisations', () => ({ listOrganisations: vi.fn() }));
+vi.mock('../../api/users', () => ({ listUsers: vi.fn() }));
+vi.mock('../../hooks/useCurrentUser', () => ({ useCurrentUser: vi.fn() }));
+
+const mockListProposals = vi.mocked(listProposals);
+const mockListOrganisations = vi.mocked(listOrganisations);
+const mockListUsers = vi.mocked(listUsers);
+const mockUseCurrentUser = vi.mocked(useCurrentUser);
+
+const proposals: Proposal[] = [
+  { id: '1', title: 'Community Health Outreach Expansion', shortDescription: '', longDescription: '', status: 'Submitted', visibility: 'Public', authorId: 'u1', organisationId: 'o1' },
+  { id: '2', title: 'Youth Coding Bootcamp', shortDescription: '', longDescription: '', status: 'Submitted', visibility: 'Private', authorId: 'u2', organisationId: 'o2' },
+  { id: '3', title: 'Diaspora Mentorship Network', shortDescription: '', longDescription: '', status: 'UnderReview', visibility: 'Shared', authorId: 'u1', organisationId: 'o2' },
+  { id: '4', title: 'Digital Literacy for Elders', shortDescription: '', longDescription: '', status: 'Approved', visibility: 'Public', authorId: 'u1', organisationId: 'o1' },
+];
+
+const organisations: Organisation[] = [
+  { id: 'o1', name: 'Ministry of Health' },
+  { id: 'o2', name: 'Ministry of Education' },
+];
+
+const users: User[] = [
+  { id: 'u1', email: 'amara@example.com', fullName: 'Amara Chen', role: 'Staff' },
+  { id: 'u2', email: 'sara@example.com', fullName: 'Sara Osei', role: 'Staff' },
+];
+
+function renderPage(initialEntries = ['/proposals']) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={initialEntries}>
+        <ProposalsPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockListProposals.mockResolvedValue(proposals);
+  mockListOrganisations.mockResolvedValue(organisations);
+  mockListUsers.mockResolvedValue(users);
+  mockUseCurrentUser.mockReturnValue({
+    user: { id: 'staff-1', email: 'jonas@example.com', fullName: 'Jonas Weber', role: 'SuperAdmin' },
+    isLoading: false,
+    error: null,
+    isNotFound: false,
+  });
+});
+
+describe('ProposalsPage', () => {
+  it('defaults to the Submitted tab and lists matching proposals with author and org names', async () => {
+    renderPage();
+
+    expect(await screen.findByText('Community Health Outreach Expansion')).toBeInTheDocument();
+    expect(screen.getByText('Youth Coding Bootcamp')).toBeInTheDocument();
+    expect(screen.queryByText('Diaspora Mentorship Network')).not.toBeInTheDocument();
+    expect(screen.getByText('Amara Chen')).toBeInTheDocument();
+    expect(screen.getByText('Ministry of Health')).toBeInTheDocument();
+  });
+
+  it('respects a status query param and switches tabs on click', async () => {
+    const user = userEvent.setup();
+    renderPage(['/proposals?status=UnderReview']);
+
+    expect(await screen.findByText('Diaspora Mentorship Network')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'All proposals' }));
+    expect(await screen.findByText('Digital Literacy for Elders')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Staff read-access spans every proposal regardless of visibility/),
+    ).toBeInTheDocument();
+  });
+
+  it('falls back to a dash for the author when the user list is unavailable', async () => {
+    mockUseCurrentUser.mockReturnValue({
+      user: { id: 'staff-1', email: 'jonas@example.com', fullName: 'Jonas Weber', role: 'Staff' },
+      isLoading: false,
+      error: null,
+      isNotFound: false,
+    });
+    renderPage();
+
+    await screen.findByText('Community Health Outreach Expansion');
+    expect(mockListUsers).not.toHaveBeenCalled();
+    const dashes = screen.getAllByText('—');
+    expect(dashes.length).toBeGreaterThan(0);
+  });
+
+  it('shows an empty state when a status tab has no proposals', async () => {
+    mockListProposals.mockResolvedValue([]);
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Nothing submitted for review')).toBeInTheDocument());
+  });
+
+  it('links rows to the review detail page', async () => {
+    renderPage();
+
+    const row = await screen.findByText('Community Health Outreach Expansion');
+    expect(row.closest('a')).toHaveAttribute('href', '/proposals/1');
+  });
+});

--- a/frontend/staff/src/pages/app/ProposalsPage.tsx
+++ b/frontend/staff/src/pages/app/ProposalsPage.tsx
@@ -1,8 +1,162 @@
-// Placeholder — the proposal review queue (flow 2b) lands in a later issue.
+import { useMemo } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { listProposals } from '../../api/proposals';
+import { listOrganisations } from '../../api/organisations';
+import { listUsers } from '../../api/users';
+import { useCurrentUser } from '../../hooks/useCurrentUser';
+import { isAdminRole, type ProposalStatus } from '../../types';
+import StatusBadge from '../../components/StatusBadge';
+import EmptyState from '../../components/EmptyState';
+import LoadingSpinner from '../../components/LoadingSpinner';
+
+type QueueTab = 'Submitted' | 'UnderReview' | 'All';
+
+const PRIMARY_TABS: { value: QueueTab; label: string }[] = [
+  { value: 'Submitted', label: 'Submitted' },
+  { value: 'UnderReview', label: 'Under Review' },
+];
+
+const EMPTY_STATE_COPY: Record<QueueTab, { title: string; description: string }> = {
+  Submitted: {
+    title: 'Nothing submitted for review',
+    description: 'No proposals are waiting for review right now. New submissions will appear here.',
+  },
+  UnderReview: {
+    title: 'Nothing under review',
+    description: 'No proposals are currently under review. Proposals move here once staff start reviewing a submission.',
+  },
+  All: {
+    title: 'No proposals yet',
+    description: 'No proposals have been created on the platform yet.',
+  },
+};
+
+function isQueueTab(value: string | null): value is QueueTab {
+  return value === 'Submitted' || value === 'UnderReview' || value === 'All';
+}
+
 export default function ProposalsPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { user } = useCurrentUser();
+  const isAdmin = !!user && isAdminRole(user.role);
+
+  const statusParam = searchParams.get('status');
+  const activeTab: QueueTab = isQueueTab(statusParam) ? statusParam : 'Submitted';
+
+  const setActiveTab = (tab: QueueTab) => {
+    setSearchParams({ status: tab });
+  };
+
+  const {
+    data: proposals,
+    isLoading,
+    isError,
+  } = useQuery({ queryKey: ['proposals'], queryFn: listProposals });
+
+  const { data: orgs } = useQuery({ queryKey: ['organisations'], queryFn: listOrganisations });
+  const { data: users } = useQuery({ queryKey: ['users'], queryFn: listUsers, enabled: isAdmin });
+
+  const orgMap = useMemo(
+    () => Object.fromEntries((orgs ?? []).map((o) => [o.id, o.name])),
+    [orgs],
+  );
+  const authorMap = useMemo(
+    () => Object.fromEntries((users ?? []).map((u) => [u.id, u.fullName])),
+    [users],
+  );
+
+  const filtered = useMemo(() => {
+    if (activeTab === 'All') return proposals ?? [];
+    return (proposals ?? []).filter((p) => p.status === (activeTab as ProposalStatus));
+  }, [proposals, activeTab]);
+
   return (
-    <div className="max-w-[1080px] mx-auto px-6 py-8">
-      <p className="text-sm text-neutral-500">Proposal review is coming soon.</p>
+    <div className="max-w-[1120px] mx-auto px-6 py-8 pb-16">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-neutral-900 mb-1">Proposal review queue</h1>
+        <p className="text-sm text-neutral-500">
+          Staff drive proposals from Submitted through Approved. There is no reject transition — deletion is the
+          only negative outcome.
+        </p>
+      </div>
+
+      <div className="flex items-center gap-1 border-b border-neutral-200 mb-5">
+        {PRIMARY_TABS.map((tab) => (
+          <button
+            key={tab.value}
+            onClick={() => setActiveTab(tab.value)}
+            className={`px-1 py-2.5 -mb-px text-sm font-medium border-b-2 transition-colors ${
+              activeTab === tab.value
+                ? 'border-brand text-brand'
+                : 'border-transparent text-neutral-500 hover:text-neutral-900'
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+        <div className="w-px h-5 bg-neutral-200 mx-2" />
+        <button
+          onClick={() => setActiveTab('All')}
+          className={`px-1 py-2.5 -mb-px text-sm font-medium border-b-2 transition-colors ${
+            activeTab === 'All'
+              ? 'border-brand text-brand'
+              : 'border-transparent text-neutral-500 hover:text-neutral-900'
+          }`}
+        >
+          All proposals
+        </button>
+      </div>
+
+      {activeTab === 'All' && (
+        <p className="mb-4 px-3.5 py-2.5 text-xs text-neutral-500 bg-neutral-50 border border-dashed border-neutral-200 rounded-lg leading-relaxed">
+          Staff read-access spans every proposal regardless of visibility — Private proposals submitted by an expat
+          are included in this tab by design, not a leak.
+        </p>
+      )}
+
+      {isLoading && <LoadingSpinner />}
+      {isError && (
+        <div className="py-10 text-center text-sm text-status-danger-text">
+          Failed to load proposals. Please try again.
+        </div>
+      )}
+
+      {!isLoading && !isError && (
+        <>
+          {filtered.length === 0 ? (
+            <EmptyState
+              title={EMPTY_STATE_COPY[activeTab].title}
+              description={EMPTY_STATE_COPY[activeTab].description}
+            />
+          ) : (
+            <div className="bg-neutral-0 border border-neutral-200 rounded-lg shadow-soft overflow-hidden">
+              <div className="grid grid-cols-[2.2fr_1.3fr_1.3fr_0.9fr_0.9fr_24px] gap-3 px-5 py-3 border-b border-neutral-200 text-xs font-semibold text-neutral-500 uppercase tracking-wide">
+                <span>Title</span>
+                <span>Author</span>
+                <span>Organisation</span>
+                <span>Status</span>
+                <span>Visibility</span>
+                <span />
+              </div>
+              {filtered.map((proposal) => (
+                <Link
+                  key={proposal.id}
+                  to={`/proposals/${proposal.id}`}
+                  className="grid grid-cols-[2.2fr_1.3fr_1.3fr_0.9fr_0.9fr_24px] gap-3 px-5 py-4 border-b border-neutral-200 last:border-b-0 items-center hover:bg-neutral-50 transition-colors"
+                >
+                  <span className="text-sm font-medium text-neutral-900">{proposal.title}</span>
+                  <span className="text-sm text-neutral-500">{authorMap[proposal.authorId] ?? '—'}</span>
+                  <span className="text-sm text-neutral-500">{orgMap[proposal.organisationId] ?? '—'}</span>
+                  <StatusBadge type="proposal" status={proposal.status} />
+                  <StatusBadge type="visibility" status={proposal.visibility} />
+                  <span className="text-neutral-300">›</span>
+                </Link>
+              ))}
+            </div>
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/staff/src/routes/router.tsx
+++ b/frontend/staff/src/routes/router.tsx
@@ -8,6 +8,7 @@ import RfpsPage from '../pages/app/RfpsPage';
 import RfpEditorPage from '../pages/app/RfpEditorPage';
 import RfpDetailPage from '../pages/app/RfpDetailPage';
 import ProposalsPage from '../pages/app/ProposalsPage';
+import ProposalDetailPage from '../pages/app/ProposalDetailPage';
 import OrganisationsPage from '../pages/app/OrganisationsPage';
 import UsersPage from '../pages/app/UsersPage';
 import AppLayout from '../components/layout/AppLayout';
@@ -31,6 +32,7 @@ export const router = createBrowserRouter([
       { path: '/rfps/:id', element: <RfpDetailPage /> },
       { path: '/rfps/:id/edit', element: <RfpEditorPage /> },
       { path: '/proposals', element: <ProposalsPage /> },
+      { path: '/proposals/:id', element: <ProposalDetailPage /> },
       { path: '/organisations', element: <OrganisationsPage /> },
       { path: '/users', element: <UsersPage /> },
     ],

--- a/frontend/staff/src/types/index.ts
+++ b/frontend/staff/src/types/index.ts
@@ -50,12 +50,15 @@ export type ProposalStatus =
   | 'Approved'
   | 'Withdrawn';
 
+export type ProposalVisibility = 'Private' | 'Shared' | 'Public';
+
 export interface Proposal {
   id: string;
   title: string;
   shortDescription: string;
   longDescription: string;
   status: ProposalStatus;
+  visibility: ProposalVisibility;
   authorId: string;
   organisationId: string;
   rfpId?: string;


### PR DESCRIPTION
## Description

Implements the staff app's proposal review queue at the `/proposals` route per `designs/flow2b/` screen 01 and spec section 2b.

- Primary tabs filter client-side to `Submitted` and `UnderReview`; a third "All proposals" tab shows every status and visibility, with the mockup's footnote that staff read-access spans all visibilities by design.
- Columns: title, author, organisation, status badge, visibility badge. Rows link to `/proposals/:id` (a placeholder page — the full review detail lands in a follow-up issue).
- Empty states per tab, matching the mockup copy.
- `GET /api/v1/Proposals` via the existing `api/proposals.ts` (staff receive every proposal regardless of visibility).
- Author names come from `GET /api/v1/Users`, which is `AdminOrSuperAdmin`-gated on the backend; non-admin Staff reviewers see a `—` fallback for author (same pattern already used for organisation names elsewhere in this app).

## Linked Issue

Closes #289

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- Added `ProposalsPage.test.tsx` covering default tab, tab switching via query param, the "All proposals" footnote, the author-name fallback for non-admin staff, empty states, and row links.
- `npm run build` (tsc + vite build) and `npm test -- --run` both pass in `frontend/staff`.

## Checklist

- [x] Code builds cleanly (`npm run build`)
- [x] Tests pass (`npm test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)