### PR TITLE
Implement the proposal review detail with takedown (flow 2b, screens 02-03)

### DIFF
--- a/frontend/staff/src/api/cfeois.ts
+++ b/frontend/staff/src/api/cfeois.ts
@@ -1,0 +1,5 @@
+import { apiClient } from './client';
+import type { Cfeoi } from '../types';
+
+export const listCfeois = (proposalId: string): Promise<Cfeoi[]> =>
+  apiClient.get('/Cfeoi', { params: { proposalId } }).then((r) => r.data);

--- a/frontend/staff/src/api/eois.ts
+++ b/frontend/staff/src/api/eois.ts
@@ -1,0 +1,5 @@
+import { apiClient } from './client';
+import type { Eoi } from '../types';
+
+export const listEoisByCfeoi = (cfeoiId: string): Promise<Eoi[]> =>
+  apiClient.get('/Eoi', { params: { cfeoiId } }).then((r) => r.data);

--- a/frontend/staff/src/api/proposals.ts
+++ b/frontend/staff/src/api/proposals.ts
@@ -1,4 +1,13 @@
 import { apiClient } from './client';
-import type { Proposal } from '../types';
+import type { Proposal, ProposalStatus } from '../types';
 
 export const listProposals = (): Promise<Proposal[]> => apiClient.get('/Proposals').then((r) => r.data);
+
+export const getProposalById = (id: string): Promise<Proposal> =>
+  apiClient.get(`/Proposals/${id}`).then((r) => r.data);
+
+export const updateProposalStatus = (id: string, status: ProposalStatus): Promise<void> =>
+  apiClient.patch(`/Proposals/${id}/status`, status).then(() => undefined);
+
+export const deleteProposal = (id: string): Promise<void> =>
+  apiClient.delete(`/Proposals/${id}`).then(() => undefined);

--- a/frontend/staff/src/pages/app/ProposalDetailPage.test.tsx
+++ b/frontend/staff/src/pages/app/ProposalDetailPage.test.tsx
@@ -1,0 +1,165 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import ProposalDetailPage from './ProposalDetailPage';
+import { deleteProposal, getProposalById, updateProposalStatus } from '../../api/proposals';
+import { listCfeois } from '../../api/cfeois';
+import { listEoisByCfeoi } from '../../api/eois';
+import { listOrganisations } from '../../api/organisations';
+import { listUsers } from '../../api/users';
+import { getRfpById } from '../../api/rfps';
+import { useCurrentUser } from '../../hooks/useCurrentUser';
+import type { Cfeoi, Eoi, Organisation, Proposal, Rfp, User } from '../../types';
+
+vi.mock('../../api/proposals', () => ({
+  getProposalById: vi.fn(),
+  updateProposalStatus: vi.fn(),
+  deleteProposal: vi.fn(),
+}));
+vi.mock('../../api/cfeois', () => ({ listCfeois: vi.fn() }));
+vi.mock('../../api/eois', () => ({ listEoisByCfeoi: vi.fn() }));
+vi.mock('../../api/organisations', () => ({ listOrganisations: vi.fn() }));
+vi.mock('../../api/users', () => ({ listUsers: vi.fn() }));
+vi.mock('../../api/rfps', () => ({ getRfpById: vi.fn() }));
+vi.mock('../../hooks/useCurrentUser', () => ({ useCurrentUser: vi.fn() }));
+
+const mockGetProposalById = vi.mocked(getProposalById);
+const mockUpdateProposalStatus = vi.mocked(updateProposalStatus);
+const mockDeleteProposal = vi.mocked(deleteProposal);
+const mockListCfeois = vi.mocked(listCfeois);
+const mockListEoisByCfeoi = vi.mocked(listEoisByCfeoi);
+const mockListOrganisations = vi.mocked(listOrganisations);
+const mockListUsers = vi.mocked(listUsers);
+const mockGetRfpById = vi.mocked(getRfpById);
+const mockUseCurrentUser = vi.mocked(useCurrentUser);
+
+const organisations: Organisation[] = [{ id: 'o1', name: 'Ministry of Health' }];
+const users: User[] = [{ id: 'u1', email: 'amara@example.com', fullName: 'Amara Chen', role: 'Expat' }];
+
+const baseProposal: Proposal = {
+  id: 'p1',
+  title: 'Community Health Outreach Expansion',
+  shortDescription: 'A short description.',
+  longDescription: 'A long description.',
+  status: 'Submitted',
+  visibility: 'Public',
+  authorId: 'u1',
+  organisationId: 'o1',
+};
+
+const cfeois: Cfeoi[] = [
+  { id: 'c1', title: 'Program Coordinator', description: '', proposalId: 'p1', status: 'Open' },
+];
+
+const eois: Eoi[] = [
+  { id: 'e1', message: 'msg', status: 'Pending', cfeoiId: 'c1', submittedById: 'u2', submitterName: 'Sara Osei' },
+];
+
+function renderPage(proposal: Proposal, initialEntries = ['/proposals/p1']) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  mockGetProposalById.mockResolvedValue(proposal);
+  mockListOrganisations.mockResolvedValue(organisations);
+  mockListUsers.mockResolvedValue(users);
+  mockListCfeois.mockResolvedValue(cfeois);
+  mockListEoisByCfeoi.mockResolvedValue(eois);
+  mockGetRfpById.mockResolvedValue({ id: 'rfp1', title: 'Rural Clinics Modernisation' } as Rfp);
+  mockUseCurrentUser.mockReturnValue({
+    user: { id: 'staff-1', email: 'jonas@example.com', fullName: 'Jonas Weber', role: 'SuperAdmin' },
+    isLoading: false,
+    error: null,
+    isNotFound: false,
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={initialEntries}>
+        <Routes>
+          <Route path="/proposals/:id" element={<ProposalDetailPage />} />
+          <Route path="/proposals" element={<div>proposals queue</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('ProposalDetailPage — Submitted', () => {
+  it('shows Start review and opens a bare confirm modal', async () => {
+    const user = userEvent.setup();
+    renderPage(baseProposal);
+
+    await screen.findByText('Community Health Outreach Expansion');
+    expect(screen.getByText('Amara Chen')).toBeInTheDocument();
+    expect(screen.getByText('Program Coordinator')).toBeInTheDocument();
+    expect(screen.getByText('1 EOIs')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Start review' }));
+    expect(screen.getByRole('dialog', { name: 'Start review?' })).toBeInTheDocument();
+  });
+
+  it('calls the status endpoint with UnderReview when confirming', async () => {
+    const user = userEvent.setup();
+    mockUpdateProposalStatus.mockResolvedValue(undefined);
+    renderPage(baseProposal);
+
+    await user.click(await screen.findByRole('button', { name: 'Start review' }));
+    const dialog = screen.getByRole('dialog', { name: 'Start review?' });
+    await user.click(within(dialog).getByRole('button', { name: 'Start review' }));
+
+    await waitFor(() => expect(mockUpdateProposalStatus).toHaveBeenCalledWith('p1', 'UnderReview'));
+  });
+});
+
+describe('ProposalDetailPage — UnderReview', () => {
+  it('shows Approve and calls the status endpoint with Approved', async () => {
+    const user = userEvent.setup();
+    mockUpdateProposalStatus.mockResolvedValue(undefined);
+    renderPage({ ...baseProposal, status: 'UnderReview' });
+
+    await user.click(await screen.findByRole('button', { name: 'Approve' }));
+    const dialog = screen.getByRole('dialog', { name: 'Approve this proposal?' });
+    await user.click(within(dialog).getByRole('button', { name: 'Approve' }));
+
+    await waitFor(() => expect(mockUpdateProposalStatus).toHaveBeenCalledWith('p1', 'Approved'));
+  });
+});
+
+describe('ProposalDetailPage — Approved', () => {
+  it('shows the terminal notice with no transition actions', async () => {
+    renderPage({ ...baseProposal, status: 'Approved' });
+
+    expect(await screen.findByText(/completed the review lifecycle/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Start review' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Approve' })).not.toBeInTheDocument();
+  });
+});
+
+describe('ProposalDetailPage — takedown', () => {
+  it('is available in every status, gates on the checkbox, and states the cascade', async () => {
+    const user = userEvent.setup();
+    renderPage(baseProposal);
+
+    await user.click(await screen.findByRole('button', { name: 'Delete proposal' }));
+    const dialog = screen.getByRole('dialog', { name: 'Delete this proposal?' });
+    expect(within(dialog).getByText(/its CFEOIs and their EOIs are permanently deleted/)).toBeInTheDocument();
+
+    const confirmButton = within(dialog).getByRole('button', { name: 'Delete proposal' });
+    expect(confirmButton).toBeDisabled();
+
+    await user.click(within(dialog).getByRole('checkbox'));
+    expect(confirmButton).toBeEnabled();
+  });
+
+  it('deletes and returns to the queue with a confirmation', async () => {
+    const user = userEvent.setup();
+    mockDeleteProposal.mockResolvedValue(undefined);
+    renderPage(baseProposal);
+
+    await user.click(await screen.findByRole('button', { name: 'Delete proposal' }));
+    const dialog = screen.getByRole('dialog', { name: 'Delete this proposal?' });
+    await user.click(within(dialog).getByRole('checkbox'));
+    await user.click(within(dialog).getByRole('button', { name: 'Delete proposal' }));
+
+    await waitFor(() => expect(mockDeleteProposal).toHaveBeenCalledWith('p1'));
+    expect(await screen.findByText('proposals queue')).toBeInTheDocument();
+  });
+});

--- a/frontend/staff/src/pages/app/ProposalDetailPage.tsx
+++ b/frontend/staff/src/pages/app/ProposalDetailPage.tsx
@@ -1,8 +1,372 @@
-// Placeholder — the proposal review detail (flow 2b, screens 02-03) lands in a later issue.
+import { useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
+import { deleteProposal, getProposalById, updateProposalStatus } from '../../api/proposals';
+import { listCfeois } from '../../api/cfeois';
+import { listEoisByCfeoi } from '../../api/eois';
+import { getErrorMessage } from '../../api/errors';
+import { listOrganisations } from '../../api/organisations';
+import { listUsers } from '../../api/users';
+import { getRfpById } from '../../api/rfps';
+import { useCurrentUser } from '../../hooks/useCurrentUser';
+import { isAdminRole, type ProposalStatus } from '../../types';
+import StatusBadge from '../../components/StatusBadge';
+import Modal from '../../components/Modal';
+import LoadingSpinner from '../../components/LoadingSpinner';
+
+type ModalKind = 'start-review' | 'approve' | 'delete' | null;
+
+const SearchIcon = () => (
+  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M21 21l-4.35-4.35M17 11a6 6 0 11-12 0 6 6 0 0112 0z"
+    />
+  </svg>
+);
+
+const CheckIcon = () => (
+  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+  </svg>
+);
+
+const TrashIcon = () => (
+  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M9.5 4h5a1 1 0 011 1v2h-7V5a1 1 0 011-1z"
+    />
+  </svg>
+);
+
 export default function ProposalDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { user } = useCurrentUser();
+  const isAdmin = !!user && isAdminRole(user.role);
+
+  const [modal, setModal] = useState<ModalKind>(null);
+  const [deleteChecked, setDeleteChecked] = useState(false);
+
+  const {
+    data: proposal,
+    isLoading,
+    isError,
+  } = useQuery({ queryKey: ['proposals', id], queryFn: () => getProposalById(id!) });
+
+  const { data: organisations } = useQuery({ queryKey: ['organisations'], queryFn: listOrganisations });
+  const { data: users } = useQuery({ queryKey: ['users'], queryFn: listUsers, enabled: isAdmin });
+
+  const { data: rfp } = useQuery({
+    queryKey: ['rfps', proposal?.rfpId],
+    queryFn: () => getRfpById(proposal!.rfpId!),
+    enabled: !!proposal?.rfpId,
+  });
+
+  const { data: cfeois } = useQuery({
+    queryKey: ['cfeois', id],
+    queryFn: () => listCfeois(id!),
+    enabled: !!id,
+  });
+
+  const eoiCountQueries = useQueries({
+    queries: (cfeois ?? []).map((c) => ({
+      queryKey: ['eois', 'cfeoi', c.id],
+      queryFn: () => listEoisByCfeoi(c.id),
+    })),
+  });
+
+  const statusMutation = useMutation({
+    mutationFn: (status: ProposalStatus) => updateProposalStatus(id!, status),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['proposals'] });
+      setModal(null);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteProposal(id!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['proposals'] });
+      navigate('/proposals?deleted=true');
+    },
+  });
+
+  const closeModal = () => {
+    if (statusMutation.isPending || deleteMutation.isPending) return;
+    setModal(null);
+    setDeleteChecked(false);
+    statusMutation.reset();
+    deleteMutation.reset();
+  };
+
+  if (isLoading) return <LoadingSpinner className="py-32" />;
+
+  if (isError || !proposal) {
+    return (
+      <div className="max-w-[760px] mx-auto px-6 py-20 text-center">
+        <h2 className="text-xl font-bold text-neutral-900 mb-2">Proposal not found</h2>
+        <p className="text-sm text-neutral-500 mb-6">This proposal may have been removed.</p>
+        <Link to="/proposals" className="text-brand hover:underline font-medium text-sm">
+          ← Back to review queue
+        </Link>
+      </div>
+    );
+  }
+
+  const org = organisations?.find((o) => o.id === proposal.organisationId);
+  const author = users?.find((u) => u.id === proposal.authorId);
+
   return (
-    <div className="max-w-[1080px] mx-auto px-6 py-8">
-      <p className="text-sm text-neutral-500">Proposal review detail is coming soon.</p>
+    <div className="max-w-[1120px] mx-auto px-6 py-8 pb-16">
+      <Link to="/proposals" className="inline-block text-sm text-neutral-500 hover:text-neutral-900 mb-5">
+        ← Back to review queue
+      </Link>
+
+      <div className="flex items-center gap-2 mb-2">
+        <StatusBadge type="proposal" status={proposal.status} />
+        <StatusBadge type="visibility" status={proposal.visibility} />
+      </div>
+      <h1 className="text-2xl font-bold text-neutral-900 mb-6">{proposal.title}</h1>
+
+      <div className="grid grid-cols-1 lg:grid-cols-[2fr_1fr] gap-6 items-start">
+        <div className="flex flex-col gap-5">
+          <div className="bg-neutral-0 border border-neutral-200 rounded-lg shadow-soft p-6">
+            <h2 className="text-sm font-semibold text-neutral-900 mb-3">Proposal content</h2>
+            <h3 className="text-xs font-semibold text-neutral-900 uppercase tracking-wide mb-2">Short description</h3>
+            <p className="text-sm text-neutral-500 leading-relaxed mb-4">{proposal.shortDescription}</p>
+            <h3 className="text-xs font-semibold text-neutral-900 uppercase tracking-wide mb-2">Long description</h3>
+            <p className="text-sm text-neutral-500 leading-relaxed whitespace-pre-line mb-4">
+              {proposal.longDescription}
+            </p>
+            <p className="text-xs text-neutral-400 leading-relaxed">
+              This content is read-only here — staff review and move proposals through the lifecycle but never edit
+              what an expat submitted.
+            </p>
+          </div>
+
+          <div className="bg-neutral-0 border border-neutral-200 rounded-lg shadow-soft p-6">
+            <h2 className="text-sm font-semibold text-neutral-900 mb-3">CFEOIs under this proposal</h2>
+            {!cfeois || cfeois.length === 0 ? (
+              <p className="text-sm text-neutral-500">No CFEOIs have been published under this proposal yet.</p>
+            ) : (
+              <div className="flex flex-col gap-2.5">
+                {cfeois.map((c, i) => (
+                  <Link
+                    key={c.id}
+                    to={`/proposals/${proposal.id}/cfeois/${c.id}/eois`}
+                    className="flex items-center justify-between px-3.5 py-2.5 bg-neutral-50 rounded-lg hover:bg-neutral-100 transition-colors"
+                  >
+                    <span className="text-sm font-medium text-neutral-900">{c.title}</span>
+                    <div className="flex items-center gap-3">
+                      <span className="text-xs text-neutral-500">
+                        {eoiCountQueries[i]?.data?.length ?? '—'} EOIs
+                      </span>
+                      <span
+                        className={`inline-block px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider rounded ${
+                          c.status === 'Open'
+                            ? 'bg-status-info-bg text-status-info-text'
+                            : 'bg-status-neutral-bg text-status-neutral-text'
+                        }`}
+                      >
+                        {c.status}
+                      </span>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {proposal.status === 'Approved' && (
+            <div className="px-4 py-3 rounded-lg border border-status-success-text/20 bg-status-success-bg text-status-success-text text-sm leading-relaxed">
+              This proposal has completed the review lifecycle; there is no further staff transition. Project
+              conversion is out of scope for this app. Future: the owner will be notified by email once
+              notifications are available.
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-4">
+          <div className="bg-neutral-0 border border-neutral-200 rounded-lg shadow-soft p-5">
+            <h3 className="text-xs font-semibold text-neutral-500 uppercase tracking-wide mb-3">Submitted by</h3>
+            <div className="flex items-center gap-2.5">
+              <span className="w-9 h-9 rounded-full bg-brand-100 text-brand-700 flex items-center justify-center text-sm font-semibold">
+                {(author?.fullName ?? '?').slice(0, 1).toUpperCase()}
+              </span>
+              <div>
+                <div className="text-sm font-medium text-neutral-900">{author?.fullName ?? '—'}</div>
+                <div className="text-xs text-neutral-500">{org?.name ?? '—'}</div>
+              </div>
+            </div>
+          </div>
+
+          {proposal.rfpId && (
+            <div className="bg-neutral-0 border border-neutral-200 rounded-lg shadow-soft p-5">
+              <h3 className="text-xs font-semibold text-neutral-500 uppercase tracking-wide mb-3">Linked RFP</h3>
+              <Link to={`/rfps/${proposal.rfpId}`} className="text-sm text-brand hover:underline font-medium">
+                {rfp?.title ?? 'View RFP'} →
+              </Link>
+            </div>
+          )}
+
+          <div className="bg-neutral-0 border border-neutral-200 rounded-lg shadow-soft p-5">
+            <h3 className="text-xs font-semibold text-neutral-500 uppercase tracking-wide mb-3">Review action</h3>
+            {proposal.status === 'Submitted' && (
+              <button
+                onClick={() => setModal('start-review')}
+                className="w-full inline-flex items-center justify-center px-4 h-10 bg-brand text-white text-sm font-medium rounded-lg hover:bg-brand-dark transition-colors"
+              >
+                Start review
+              </button>
+            )}
+            {proposal.status === 'UnderReview' && (
+              <button
+                onClick={() => setModal('approve')}
+                className="w-full inline-flex items-center justify-center px-4 h-10 bg-brand text-white text-sm font-medium rounded-lg hover:bg-brand-dark transition-colors"
+              >
+                Approve
+              </button>
+            )}
+            {proposal.status === 'Approved' && (
+              <p className="text-xs text-neutral-500 leading-relaxed">No further review action — approval is terminal.</p>
+            )}
+            {proposal.status !== 'Submitted' && proposal.status !== 'UnderReview' && proposal.status !== 'Approved' && (
+              <p className="text-xs text-neutral-500 leading-relaxed">No staff review action is available in this status.</p>
+            )}
+          </div>
+
+          <div className="border border-status-danger-bg bg-neutral-0 rounded-lg p-5">
+            <h3 className="text-xs font-semibold text-status-danger-text uppercase tracking-wide mb-1.5">Takedown</h3>
+            <p className="text-xs text-neutral-500 leading-relaxed mb-3">
+              Deletion is the only moderation action available — it is separate from the review lifecycle and
+              available in every status.
+            </p>
+            <button
+              onClick={() => setModal('delete')}
+              className="w-full inline-flex items-center justify-center px-4 h-9 bg-status-danger-bg text-status-danger-text text-sm font-medium rounded-lg hover:bg-status-danger-bg/70 transition-colors"
+            >
+              Delete proposal
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {modal === 'start-review' && (
+        <Modal
+          tone="neutral"
+          icon={<SearchIcon />}
+          title="Start review?"
+          description="Moves this proposal to Under Review. You can approve it once you've finished reviewing."
+          onClose={closeModal}
+          actions={
+            <>
+              <button
+                onClick={closeModal}
+                className="inline-flex items-center px-4 h-9 text-sm font-medium text-neutral-500 hover:text-neutral-900 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => statusMutation.mutate('UnderReview')}
+                disabled={statusMutation.isPending}
+                className="inline-flex items-center px-4 h-9 bg-brand text-white text-sm font-medium rounded-lg hover:bg-brand-dark transition-colors disabled:opacity-60"
+              >
+                {statusMutation.isPending ? 'Starting...' : 'Start review'}
+              </button>
+            </>
+          }
+        >
+          {statusMutation.isError && (
+            <p className="text-sm text-status-danger-text text-center">
+              {getErrorMessage(statusMutation.error, 'Failed to start review. Please try again.')}
+            </p>
+          )}
+        </Modal>
+      )}
+
+      {modal === 'approve' && (
+        <Modal
+          tone="neutral"
+          icon={<CheckIcon />}
+          title="Approve this proposal?"
+          description="Marks it Approved — the terminal state in this app. There is no further staff transition."
+          onClose={closeModal}
+          actions={
+            <>
+              <button
+                onClick={closeModal}
+                className="inline-flex items-center px-4 h-9 text-sm font-medium text-neutral-500 hover:text-neutral-900 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => statusMutation.mutate('Approved')}
+                disabled={statusMutation.isPending}
+                className="inline-flex items-center px-4 h-9 bg-brand text-white text-sm font-medium rounded-lg hover:bg-brand-dark transition-colors disabled:opacity-60"
+              >
+                {statusMutation.isPending ? 'Approving...' : 'Approve'}
+              </button>
+            </>
+          }
+        >
+          {statusMutation.isError && (
+            <p className="text-sm text-status-danger-text text-center">
+              {getErrorMessage(statusMutation.error, 'Failed to approve this proposal. Please try again.')}
+            </p>
+          )}
+        </Modal>
+      )}
+
+      {modal === 'delete' && (
+        <Modal
+          tone="danger"
+          icon={<TrashIcon />}
+          title="Delete this proposal?"
+          description={`This permanently removes "${proposal.title}" — the proposal and its CFEOIs and their EOIs are permanently deleted. It cannot be undone.`}
+          onClose={closeModal}
+          actions={
+            <>
+              <button
+                onClick={closeModal}
+                className="inline-flex items-center px-4 h-9 text-sm font-medium text-neutral-500 hover:text-neutral-900 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => deleteMutation.mutate()}
+                disabled={!deleteChecked || deleteMutation.isPending}
+                className="inline-flex items-center px-4 h-9 bg-status-danger-text text-white text-sm font-medium rounded-lg hover:opacity-90 transition-colors disabled:opacity-60"
+              >
+                {deleteMutation.isPending ? 'Deleting...' : 'Delete proposal'}
+              </button>
+            </>
+          }
+        >
+          <label className="flex items-start gap-3 cursor-pointer pt-2 border-t border-neutral-200">
+            <input
+              type="checkbox"
+              checked={deleteChecked}
+              onChange={(e) => setDeleteChecked(e.target.checked)}
+              className="mt-0.5 w-4 h-4 accent-brand"
+            />
+            <span className="text-sm text-neutral-700 text-left">
+              I understand this action is permanent and cannot be undone.
+            </span>
+          </label>
+          {deleteMutation.isError && (
+            <p className="mt-3 text-sm text-status-danger-text text-center">
+              {getErrorMessage(deleteMutation.error, 'Failed to delete this proposal. Please try again.')}
+            </p>
+          )}
+        </Modal>
+      )}
     </div>
   );
 }

--- a/frontend/staff/src/pages/app/ProposalsPage.tsx
+++ b/frontend/staff/src/pages/app/ProposalsPage.tsx
@@ -41,6 +41,8 @@ export default function ProposalsPage() {
   const { user } = useCurrentUser();
   const isAdmin = !!user && isAdminRole(user.role);
 
+  const deleted = searchParams.get('deleted') === 'true';
+
   const statusParam = searchParams.get('status');
   const activeTab: QueueTab = isQueueTab(statusParam) ? statusParam : 'Submitted';
 
@@ -73,6 +75,11 @@ export default function ProposalsPage() {
 
   return (
     <div className="max-w-[1120px] mx-auto px-6 py-8 pb-16">
+      {deleted && (
+        <div className="mb-5 px-4 py-3 rounded-lg border border-status-success-text/20 bg-status-success-bg text-status-success-text text-sm font-medium">
+          Proposal deleted.
+        </div>
+      )}
       <div className="mb-6">
         <h1 className="text-2xl font-bold text-neutral-900 mb-1">Proposal review queue</h1>
         <p className="text-sm text-neutral-500">

--- a/frontend/staff/src/types/index.ts
+++ b/frontend/staff/src/types/index.ts
@@ -69,3 +69,26 @@ export interface Organisation {
   name: string;
   parentId?: string;
 }
+
+export type CfeoiStatus = 'Open' | 'Closed';
+
+export interface Cfeoi {
+  id: string;
+  title: string;
+  description: string;
+  proposalId: string;
+  status: CfeoiStatus;
+  tags?: string;
+}
+
+export type EoiStatus = 'Pending' | 'Approved' | 'Rejected';
+
+export interface Eoi {
+  id: string;
+  message: string;
+  status: EoiStatus;
+  cfeoiId: string;
+  submittedById: string;
+  submitterName: string;
+  submitterEmail?: string;
+}


### PR DESCRIPTION
## Description

Implements the staff app's proposal review detail page across its three status states (Submitted, UnderReview, Approved) plus the destructive takedown modal, per `designs/flow2b/` screens 02-03 and spec section 2b.

- Read-only proposal content, author, organisation, linked RFP (if any), and CFEOIs with per-CFEOI EOI counts.
- **Submitted** → "Start review" (bare confirm) → `PATCH /api/v1/Proposals/{id}/status` → `UnderReview`.
- **UnderReview** → "Approve" (bare confirm) → `PATCH .../status` → `Approved`.
- **Approved** → silent terminal state with the "Future: notify owner" placeholder banner (no confirmation modal, per the decided design behaviour).
- **Takedown**: available in every state, visually separated (danger-bordered card), destructive modal with a checkbox gate; copy states the cascade fact — the proposal and its CFEOIs and their EOIs are permanently deleted → `DELETE /api/v1/Proposals/{id}`, then returns to the queue with a confirmation banner.

Adds the minimal staff-side `Cfeoi`/`Eoi` types and `api/cfeois.ts` / `api/eois.ts` needed to show CFEOI titles, status, and EOI counts on the detail page (full CFEOI/EOI management is out of scope — flow 2c, a later issue).

## Linked Issue

Closes #290

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- Added `ProposalDetailPage.test.tsx` covering all three status states, the Start review / Approve confirm flows, and the takedown modal (checkbox gate, cascade copy, delete + redirect).
- `npx vitest run` — 50/50 passing.
- `npx tsc --noEmit` — clean.
- `npm run build` — succeeds.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)