### PR TITLE
Implement the staff EOI list and delete modal (flow 2c, screens 1-2)

### DIFF
--- a/frontend/staff/src/api/cfeois.ts
+++ b/frontend/staff/src/api/cfeois.ts
@@ -3,3 +3,6 @@ import type { Cfeoi } from '../types';
 
 export const listCfeois = (proposalId: string): Promise<Cfeoi[]> =>
   apiClient.get('/Cfeoi', { params: { proposalId } }).then((r) => r.data);
+
+export const getCfeoiById = (id: string): Promise<Cfeoi> =>
+  apiClient.get(`/Cfeoi/${id}`).then((r) => r.data);

--- a/frontend/staff/src/api/eois.ts
+++ b/frontend/staff/src/api/eois.ts
@@ -1,5 +1,11 @@
 import { apiClient } from './client';
-import type { Eoi } from '../types';
+import type { Eoi, EoiStatus } from '../types';
 
 export const listEoisByCfeoi = (cfeoiId: string): Promise<Eoi[]> =>
   apiClient.get('/Eoi', { params: { cfeoiId } }).then((r) => r.data);
+
+export const updateEoiStatus = (id: string, status: EoiStatus): Promise<void> =>
+  apiClient.patch(`/Eoi/${id}/status`, { newStatus: status }).then(() => undefined);
+
+export const deleteEoi = (id: string): Promise<void> =>
+  apiClient.delete(`/Eoi/${id}`).then(() => undefined);

--- a/frontend/staff/src/components/StatusBadge.tsx
+++ b/frontend/staff/src/components/StatusBadge.tsx
@@ -1,4 +1,4 @@
-import type { ProposalStatus, ProposalVisibility, RfpStatus } from '../types';
+import type { EoiStatus, EoiVisibility, ProposalStatus, ProposalVisibility, RfpStatus } from '../types';
 
 const rfpStatusStyles: Record<RfpStatus, string> = {
   Draft: 'bg-status-neutral-bg text-status-neutral-text',
@@ -21,10 +21,23 @@ const visibilityStyles: Record<ProposalVisibility, string> = {
   Shared: 'bg-status-info-bg text-status-info-text',
 };
 
+const eoiStatusStyles: Record<EoiStatus, string> = {
+  Pending: 'bg-status-neutral-bg text-status-neutral-text',
+  Approved: 'bg-status-success-bg text-status-success-text',
+  Rejected: 'bg-status-danger-bg text-status-danger-text',
+};
+
+const eoiVisibilityStyles: Record<EoiVisibility, string> = {
+  Private: 'bg-status-neutral-bg text-status-neutral-text',
+  Shared: 'bg-status-info-bg text-status-info-text',
+};
+
 type StatusBadgeProps =
   | { readonly type: 'rfp'; readonly status: RfpStatus }
   | { readonly type: 'proposal'; readonly status: ProposalStatus }
-  | { readonly type: 'visibility'; readonly status: ProposalVisibility };
+  | { readonly type: 'visibility'; readonly status: ProposalVisibility }
+  | { readonly type: 'eoi'; readonly status: EoiStatus }
+  | { readonly type: 'eoiVisibility'; readonly status: EoiVisibility };
 
 function styleFor(props: StatusBadgeProps): string {
   switch (props.type) {
@@ -34,6 +47,10 @@ function styleFor(props: StatusBadgeProps): string {
       return proposalStatusStyles[props.status];
     case 'visibility':
       return visibilityStyles[props.status];
+    case 'eoi':
+      return eoiStatusStyles[props.status];
+    case 'eoiVisibility':
+      return eoiVisibilityStyles[props.status];
   }
 }
 

--- a/frontend/staff/src/pages/app/EoiListPage.test.tsx
+++ b/frontend/staff/src/pages/app/EoiListPage.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import EoiListPage from './EoiListPage';
+import { getCfeoiById } from '../../api/cfeois';
+import { getProposalById } from '../../api/proposals';
+import { deleteEoi, listEoisByCfeoi, updateEoiStatus } from '../../api/eois';
+import type { Cfeoi, Eoi, Proposal } from '../../types';
+
+vi.mock('../../api/cfeois', () => ({ getCfeoiById: vi.fn() }));
+vi.mock('../../api/proposals', () => ({ getProposalById: vi.fn() }));
+vi.mock('../../api/eois', () => ({
+  listEoisByCfeoi: vi.fn(),
+  updateEoiStatus: vi.fn(),
+  deleteEoi: vi.fn(),
+}));
+
+const mockGetCfeoiById = vi.mocked(getCfeoiById);
+const mockGetProposalById = vi.mocked(getProposalById);
+const mockListEoisByCfeoi = vi.mocked(listEoisByCfeoi);
+const mockUpdateEoiStatus = vi.mocked(updateEoiStatus);
+const mockDeleteEoi = vi.mocked(deleteEoi);
+
+const proposal: Proposal = {
+  id: 'p1',
+  title: 'Community Health Outreach Expansion',
+  shortDescription: '',
+  longDescription: '',
+  status: 'UnderReview',
+  visibility: 'Public',
+  authorId: 'u1',
+  organisationId: 'o1',
+};
+
+const cfeoi: Cfeoi = {
+  id: 'c1',
+  title: 'Program Coordinator',
+  description: '',
+  proposalId: 'p1',
+  status: 'Open',
+};
+
+const eois: Eoi[] = [
+  {
+    id: 'e1',
+    message: 'Pending applicant',
+    status: 'Pending',
+    visibility: 'Private',
+    cfeoiId: 'c1',
+    submittedById: 'u2',
+    submitterName: 'Sara Osei',
+    submitterEmail: 'sara@example.com',
+  },
+  {
+    id: 'e2',
+    message: 'Already approved',
+    status: 'Approved',
+    visibility: 'Shared',
+    cfeoiId: 'c1',
+    submittedById: 'u3',
+    submitterName: 'Marcus Johnson',
+    submitterEmail: 'marcus@example.com',
+  },
+];
+
+function renderPage(cfeoiOverrides: Partial<Cfeoi> = {}, eoisOverride = eois) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  mockGetCfeoiById.mockResolvedValue({ ...cfeoi, ...cfeoiOverrides });
+  mockGetProposalById.mockResolvedValue(proposal);
+  mockListEoisByCfeoi.mockResolvedValue(eoisOverride);
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/proposals/p1/cfeois/c1/eois']}>
+        <Routes>
+          <Route path="/proposals/:proposalId/cfeois/:cfeoiId/eois" element={<EoiListPage />} />
+          <Route path="/proposals/:id" element={<div>proposal detail</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('EoiListPage', () => {
+  it('lists EOIs with submitter name, email, visibility and status', async () => {
+    renderPage();
+
+    await screen.findByText('Sara Osei');
+    expect(screen.getByText('sara@example.com')).toBeInTheDocument();
+    expect(screen.getByText('Marcus Johnson')).toBeInTheDocument();
+    expect(screen.getByText('Private')).toBeInTheDocument();
+    expect(screen.getByText('Shared')).toBeInTheDocument();
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+    expect(screen.getByText('Approved')).toBeInTheDocument();
+  });
+
+  it('shows Approve/Reject only on Pending rows and calls the status endpoint', async () => {
+    const user = userEvent.setup();
+    mockUpdateEoiStatus.mockResolvedValue(undefined);
+    renderPage();
+
+    await screen.findByText('Sara Osei');
+    expect(screen.getAllByTitle('Approve')).toHaveLength(1);
+    expect(screen.getAllByTitle('Reject')).toHaveLength(1);
+
+    await user.click(screen.getByTitle('Approve'));
+    await waitFor(() => expect(mockUpdateEoiStatus).toHaveBeenCalledWith('e1', 'Approved'));
+  });
+
+  it('shows the closed-CFEOI banner when the CFEOI is closed', async () => {
+    renderPage({ status: 'Closed' });
+
+    expect(await screen.findByText(/This CFEOI is now closed/)).toBeInTheDocument();
+  });
+
+  it('includes the Private-EOI footnote', async () => {
+    renderPage();
+
+    await screen.findByText('Sara Osei');
+    expect(
+      screen.getByText(/visibility rules restrict other expats, not staff review, by design/),
+    ).toBeInTheDocument();
+  });
+
+  it('gates delete on the checkbox and calls the delete endpoint', async () => {
+    const user = userEvent.setup();
+    mockDeleteEoi.mockResolvedValue(undefined);
+    renderPage();
+
+    await screen.findByText('Sara Osei');
+    const deleteButtons = screen.getAllByTitle('Delete (staff only)');
+    await user.click(deleteButtons[0]);
+
+    const dialog = screen.getByRole('dialog', { name: 'Delete this expression of interest?' });
+    expect(within(dialog).getByText(/Sara Osei's submission/)).toBeInTheDocument();
+
+    const confirmButton = within(dialog).getByRole('button', { name: 'Delete permanently' });
+    expect(confirmButton).toBeDisabled();
+
+    await user.click(within(dialog).getByRole('checkbox'));
+    expect(confirmButton).toBeEnabled();
+
+    await user.click(confirmButton);
+    await waitFor(() => expect(mockDeleteEoi).toHaveBeenCalledWith('e1'));
+  });
+});

--- a/frontend/staff/src/pages/app/EoiListPage.tsx
+++ b/frontend/staff/src/pages/app/EoiListPage.tsx
@@ -1,0 +1,244 @@
+import { useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { getCfeoiById } from '../../api/cfeois';
+import { getProposalById } from '../../api/proposals';
+import { deleteEoi, listEoisByCfeoi, updateEoiStatus } from '../../api/eois';
+import { getErrorMessage } from '../../api/errors';
+import type { Eoi, EoiStatus } from '../../types';
+import StatusBadge from '../../components/StatusBadge';
+import EmptyState from '../../components/EmptyState';
+import LoadingSpinner from '../../components/LoadingSpinner';
+import Modal from '../../components/Modal';
+
+const CheckIcon = () => (
+  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+  </svg>
+);
+
+const XIcon = () => (
+  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+  </svg>
+);
+
+const TrashIcon = () => (
+  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M9.5 4h5a1 1 0 011 1v2h-7V5a1 1 0 011-1z"
+    />
+  </svg>
+);
+
+export default function EoiListPage() {
+  const { proposalId, cfeoiId } = useParams<{ proposalId: string; cfeoiId: string }>();
+  const queryClient = useQueryClient();
+
+  const [statusMutatingId, setStatusMutatingId] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Eoi | null>(null);
+  const [deleteChecked, setDeleteChecked] = useState(false);
+
+  const {
+    data: cfeoi,
+    isLoading: isCfeoiLoading,
+    isError: isCfeoiError,
+  } = useQuery({ queryKey: ['cfeois', cfeoiId], queryFn: () => getCfeoiById(cfeoiId!), enabled: !!cfeoiId });
+
+  const { data: proposal } = useQuery({
+    queryKey: ['proposals', proposalId],
+    queryFn: () => getProposalById(proposalId!),
+    enabled: !!proposalId,
+  });
+
+  const {
+    data: eois,
+    isLoading: isEoisLoading,
+    isError: isEoisError,
+  } = useQuery({
+    queryKey: ['eois', 'cfeoi', cfeoiId],
+    queryFn: () => listEoisByCfeoi(cfeoiId!),
+    enabled: !!cfeoiId,
+  });
+
+  const statusMutation = useMutation({
+    mutationFn: ({ id, status }: { id: string; status: EoiStatus }) => updateEoiStatus(id, status),
+    onMutate: ({ id }) => setStatusMutatingId(id),
+    onSettled: () => setStatusMutatingId(null),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['eois', 'cfeoi', cfeoiId] }),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteEoi(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['eois', 'cfeoi', cfeoiId] });
+      closeDeleteModal();
+    },
+  });
+
+  const closeDeleteModal = () => {
+    if (deleteMutation.isPending) return;
+    setDeleteTarget(null);
+    setDeleteChecked(false);
+    deleteMutation.reset();
+  };
+
+  const isLoading = isCfeoiLoading || isEoisLoading;
+  const isError = isCfeoiError || isEoisError;
+
+  if (isLoading) return <LoadingSpinner className="py-32" />;
+
+  if (isError || !cfeoi) {
+    return (
+      <div className="max-w-[1120px] mx-auto px-6 py-20 text-center">
+        <h2 className="text-xl font-bold text-neutral-900 mb-2">CFEOI not found</h2>
+        <p className="text-sm text-neutral-500 mb-6">This CFEOI may have been removed.</p>
+        {proposalId && (
+          <Link to={`/proposals/${proposalId}`} className="text-brand hover:underline font-medium text-sm">
+            ← Back to proposal
+          </Link>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-[1120px] mx-auto px-6 py-8 pb-16">
+      <Link to={`/proposals/${proposalId}`} className="inline-block text-sm text-neutral-500 hover:text-neutral-900 mb-5">
+        ← Back to {proposal?.title ?? 'proposal'}
+      </Link>
+
+      {cfeoi.status === 'Closed' && (
+        <div className="mb-5 px-4 py-3 rounded-lg border border-status-info-text/20 bg-status-info-bg text-status-info-text text-sm leading-relaxed">
+          This CFEOI is now closed. It is no longer accepting new expressions of interest. Staff can still review,
+          approve, reject, and delete existing submissions below.
+        </div>
+      )}
+
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-neutral-900 mb-1">Expressions of Interest</h1>
+        <p className="text-sm text-neutral-500 max-w-[560px]">
+          Reviewing applicants for {cfeoi.title}. Staff see every submission, including ones the applicant marked
+          Private — visibility rules restrict other expats, not staff review.
+        </p>
+      </div>
+
+      {!eois || eois.length === 0 ? (
+        <EmptyState
+          title="No expressions of interest yet"
+          description="No one has submitted an expression of interest for this CFEOI yet."
+        />
+      ) : (
+        <div className="bg-neutral-0 border border-neutral-200 rounded-lg shadow-soft overflow-hidden">
+          <div className="grid grid-cols-[2fr_1fr_1fr_auto] gap-3 px-5 py-3 border-b border-neutral-200 text-xs font-semibold text-neutral-500 uppercase tracking-wide">
+            <span>Applicant</span>
+            <span>Visibility</span>
+            <span>Status</span>
+            <span className="text-right">Actions</span>
+          </div>
+          {eois.map((eoi) => (
+            <div
+              key={eoi.id}
+              className="grid grid-cols-[2fr_1fr_1fr_auto] gap-3 px-5 py-4 border-b border-neutral-200 last:border-b-0 items-center"
+            >
+              <div className="flex flex-col min-w-0">
+                <span className="text-sm font-medium text-neutral-900 truncate">{eoi.submitterName}</span>
+                <span className="text-xs text-neutral-500 truncate">{eoi.submitterEmail ?? '—'}</span>
+              </div>
+              <StatusBadge type="eoiVisibility" status={eoi.visibility} />
+              <StatusBadge type="eoi" status={eoi.status} />
+              <div className="flex items-center justify-end gap-2">
+                {eoi.status === 'Pending' && (
+                  <>
+                    <button
+                      onClick={() => statusMutation.mutate({ id: eoi.id, status: 'Approved' })}
+                      disabled={statusMutation.isPending && statusMutatingId === eoi.id}
+                      title="Approve"
+                      className="w-8 h-8 rounded-md border border-status-success-bg bg-status-success-bg text-status-success-text flex items-center justify-center hover:opacity-80 transition-opacity disabled:opacity-50"
+                    >
+                      <CheckIcon />
+                    </button>
+                    <button
+                      onClick={() => statusMutation.mutate({ id: eoi.id, status: 'Rejected' })}
+                      disabled={statusMutation.isPending && statusMutatingId === eoi.id}
+                      title="Reject"
+                      className="w-8 h-8 rounded-md border border-status-danger-bg bg-status-danger-bg text-status-danger-text flex items-center justify-center hover:opacity-80 transition-opacity disabled:opacity-50"
+                    >
+                      <XIcon />
+                    </button>
+                  </>
+                )}
+                <button
+                  onClick={() => setDeleteTarget(eoi)}
+                  title="Delete (staff only)"
+                  className="w-8 h-8 rounded-md border border-neutral-200 bg-neutral-0 text-status-danger-text flex items-center justify-center hover:bg-neutral-50 transition-colors"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M9.5 4h5a1 1 0 011 1v2h-7V5a1 1 0 011-1z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <p className="mt-4 text-xs text-neutral-400 leading-relaxed">
+        Staff read-access spans every visibility level by design (Shared, Private) — visibility rules restrict other
+        expats, not staff review, by design.
+      </p>
+
+      {deleteTarget && (
+        <Modal
+          tone="danger"
+          icon={<TrashIcon />}
+          title="Delete this expression of interest?"
+          description={`This permanently removes ${deleteTarget.submitterName}'s submission. They will lose their own record of it — this cannot be undone.`}
+          onClose={closeDeleteModal}
+          actions={
+            <>
+              <button
+                onClick={closeDeleteModal}
+                className="inline-flex items-center px-4 h-9 text-sm font-medium text-neutral-500 hover:text-neutral-900 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => deleteMutation.mutate(deleteTarget.id)}
+                disabled={!deleteChecked || deleteMutation.isPending}
+                className="inline-flex items-center px-4 h-9 bg-status-danger-text text-white text-sm font-medium rounded-lg hover:opacity-90 transition-colors disabled:opacity-60"
+              >
+                {deleteMutation.isPending ? 'Deleting...' : 'Delete permanently'}
+              </button>
+            </>
+          }
+        >
+          <label className="flex items-start gap-3 cursor-pointer pt-2 border-t border-neutral-200">
+            <input
+              type="checkbox"
+              checked={deleteChecked}
+              onChange={(e) => setDeleteChecked(e.target.checked)}
+              className="mt-0.5 w-4 h-4 accent-brand"
+            />
+            <span className="text-sm text-neutral-700 text-left">
+              I understand this permanently deletes another person's submission and cannot be undone.
+            </span>
+          </label>
+          {deleteMutation.isError && (
+            <p className="mt-3 text-sm text-status-danger-text text-center">
+              {getErrorMessage(deleteMutation.error, 'Failed to delete this submission. Please try again.')}
+            </p>
+          )}
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/frontend/staff/src/pages/app/ProposalDetailPage.test.tsx
+++ b/frontend/staff/src/pages/app/ProposalDetailPage.test.tsx
@@ -53,7 +53,15 @@ const cfeois: Cfeoi[] = [
 ];
 
 const eois: Eoi[] = [
-  { id: 'e1', message: 'msg', status: 'Pending', cfeoiId: 'c1', submittedById: 'u2', submitterName: 'Sara Osei' },
+  {
+    id: 'e1',
+    message: 'msg',
+    status: 'Pending',
+    visibility: 'Shared',
+    cfeoiId: 'c1',
+    submittedById: 'u2',
+    submitterName: 'Sara Osei',
+  },
 ];
 
 function renderPage(proposal: Proposal, initialEntries = ['/proposals/p1']) {

--- a/frontend/staff/src/routes/router.tsx
+++ b/frontend/staff/src/routes/router.tsx
@@ -9,6 +9,7 @@ import RfpEditorPage from '../pages/app/RfpEditorPage';
 import RfpDetailPage from '../pages/app/RfpDetailPage';
 import ProposalsPage from '../pages/app/ProposalsPage';
 import ProposalDetailPage from '../pages/app/ProposalDetailPage';
+import EoiListPage from '../pages/app/EoiListPage';
 import OrganisationsPage from '../pages/app/OrganisationsPage';
 import UsersPage from '../pages/app/UsersPage';
 import AppLayout from '../components/layout/AppLayout';
@@ -33,6 +34,7 @@ export const router = createBrowserRouter([
       { path: '/rfps/:id/edit', element: <RfpEditorPage /> },
       { path: '/proposals', element: <ProposalsPage /> },
       { path: '/proposals/:id', element: <ProposalDetailPage /> },
+      { path: '/proposals/:proposalId/cfeois/:cfeoiId/eois', element: <EoiListPage /> },
       { path: '/organisations', element: <OrganisationsPage /> },
       { path: '/users', element: <UsersPage /> },
     ],

--- a/frontend/staff/src/types/index.ts
+++ b/frontend/staff/src/types/index.ts
@@ -83,10 +83,13 @@ export interface Cfeoi {
 
 export type EoiStatus = 'Pending' | 'Approved' | 'Rejected';
 
+export type EoiVisibility = 'Private' | 'Shared';
+
 export interface Eoi {
   id: string;
   message: string;
   status: EoiStatus;
+  visibility: EoiVisibility;
   cfeoiId: string;
   submittedById: string;
   submitterName: string;


### PR DESCRIPTION
## Description

Implements the staff EOI view (flow 2c) reached from the CFEOI entries on the proposal review detail page. Reuses the portal inbox layout with staff-specific additions.

- Visibility column (Private/Shared) plus submitter name **and email** (both from `EoiResponseDto`; email is staff-only).
- Approve/Reject inline on `Pending` rows via `PATCH /api/v1/Eoi/{id}/status` — terminal, so decided rows show no actions.
- Staff-only Delete on every row, opening a checkbox-gated destructive confirmation whose copy states this permanently removes another person's submission → `DELETE /api/v1/Eoi/{id}`.
- Private-EOI footnote and closed-CFEOI banner per the mockup.
- Staff CFEOI publish/edit/close surfaces are intentionally out of scope for this issue.

## Linked Issue

Closes #291

## Type of Change

- [x] Feature

## Testing Notes

- New `EoiListPage.test.tsx` covers listing (name/email/visibility/status), inline approve calling the status endpoint, the closed-CFEOI banner, the Private-EOI footnote, and the checkbox-gated delete flow.
- Updated `ProposalDetailPage.test.tsx` fixture for the new required `visibility` field on `Eoi`.
- `tsc -b`, `vite build`, and the full `vitest` suite (55 tests) all pass.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)