### PR TITLE
Implement the staff organisation tree and modals (flow 3, screens 01-02)

### DIFF
--- a/frontend/staff/src/api/organisations.ts
+++ b/frontend/staff/src/api/organisations.ts
@@ -3,3 +3,17 @@ import type { Organisation } from '../types';
 
 export const listOrganisations = (): Promise<Organisation[]> =>
   apiClient.get('/Organisations').then((r) => r.data);
+
+export interface CreateOrganisationPayload {
+  name: string;
+  parentId?: string;
+}
+
+export const createOrganisation = (payload: CreateOrganisationPayload): Promise<string> =>
+  apiClient.post('/Organisations', payload).then((r) => r.data);
+
+export const updateOrganisation = (id: string, name: string): Promise<void> =>
+  apiClient.put(`/Organisations/${id}`, { name }).then(() => undefined);
+
+export const deleteOrganisation = (id: string): Promise<void> =>
+  apiClient.delete(`/Organisations/${id}`).then(() => undefined);

--- a/frontend/staff/src/pages/app/OrganisationsPage.test.tsx
+++ b/frontend/staff/src/pages/app/OrganisationsPage.test.tsx
@@ -1,0 +1,174 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import OrganisationsPage from './OrganisationsPage';
+import { createOrganisation, deleteOrganisation, listOrganisations, updateOrganisation } from '../../api/organisations';
+import { useCurrentUser } from '../../hooks/useCurrentUser';
+import type { Organisation, User } from '../../types';
+
+vi.mock('../../api/organisations', () => ({
+  listOrganisations: vi.fn(),
+  createOrganisation: vi.fn(),
+  updateOrganisation: vi.fn(),
+  deleteOrganisation: vi.fn(),
+}));
+vi.mock('../../hooks/useCurrentUser', () => ({ useCurrentUser: vi.fn() }));
+
+const mockListOrganisations = vi.mocked(listOrganisations);
+const mockCreateOrganisation = vi.mocked(createOrganisation);
+const mockUpdateOrganisation = vi.mocked(updateOrganisation);
+const mockDeleteOrganisation = vi.mocked(deleteOrganisation);
+const mockUseCurrentUser = vi.mocked(useCurrentUser);
+
+const adminUser: User = { id: 'u1', email: 'amara@example.com', fullName: 'Amara Chen', role: 'SuperAdmin' };
+const staffUser: User = { id: 'u2', email: 'jonas@example.com', fullName: 'Jonas Weber', role: 'Staff' };
+
+const organisations: Organisation[] = [
+  { id: 'root', name: 'Republic of Herit Government' },
+  { id: 'health', name: 'Ministry of Health', parentId: 'root' },
+  { id: 'piv', name: 'Patient Identity Verification Unit', parentId: 'health' },
+];
+
+function renderPage() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/organisations']}>
+        <OrganisationsPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseCurrentUser.mockReturnValue({
+    user: adminUser,
+    isLoading: false,
+    error: null,
+    isNotFound: false,
+  });
+});
+
+describe('OrganisationsPage', () => {
+  it('denies access to non-admin staff', async () => {
+    mockUseCurrentUser.mockReturnValue({
+      user: staffUser,
+      isLoading: false,
+      error: null,
+      isNotFound: false,
+    });
+    mockListOrganisations.mockResolvedValue(organisations);
+    renderPage();
+
+    expect(screen.getByText(/don't have access/i)).toBeInTheDocument();
+    expect(screen.queryByText('Republic of Herit Government')).not.toBeInTheDocument();
+  });
+
+  it('renders the tree flat-indented by depth with a Root badge on the top node', async () => {
+    mockListOrganisations.mockResolvedValue(organisations);
+    renderPage();
+
+    await screen.findByText('Republic of Herit Government');
+    expect(screen.getByText('Ministry of Health')).toBeInTheDocument();
+    expect(screen.getByText('Patient Identity Verification Unit')).toBeInTheDocument();
+    expect(screen.getByText('Root')).toBeInTheDocument();
+  });
+
+  it('shows the bootstrap empty state and creates the root organisation', async () => {
+    const user = userEvent.setup();
+    mockListOrganisations.mockResolvedValue([]);
+    mockCreateOrganisation.mockResolvedValue('new-id');
+    renderPage();
+
+    expect(await screen.findByText('No organisations yet')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /create root organisation/i }));
+    const dialog = screen.getByRole('dialog', { name: 'Create root organisation' });
+    await user.type(within(dialog).getByPlaceholderText('Organisation name'), 'Republic of Herit Government');
+    await user.click(within(dialog).getByRole('button', { name: 'Create' }));
+
+    await waitFor(() =>
+      expect(mockCreateOrganisation).toHaveBeenCalledWith({ name: 'Republic of Herit Government', parentId: undefined }),
+    );
+  });
+
+  it('creates a sub-organisation under the selected node', async () => {
+    const user = userEvent.setup();
+    mockListOrganisations.mockResolvedValue(organisations);
+    mockCreateOrganisation.mockResolvedValue('new-id');
+    renderPage();
+
+    await screen.findByText('Ministry of Health');
+    await user.click(screen.getAllByTitle('Create sub-organisation')[1]);
+
+    const dialog = screen.getByRole('dialog', { name: 'Create sub-organisation' });
+    expect(within(dialog).getByText(/under Ministry of Health/)).toBeInTheDocument();
+    await user.type(within(dialog).getByPlaceholderText('Organisation name'), 'New Unit');
+    await user.click(within(dialog).getByRole('button', { name: 'Create' }));
+
+    await waitFor(() => expect(mockCreateOrganisation).toHaveBeenCalledWith({ name: 'New Unit', parentId: 'health' }));
+  });
+
+  it('renames an organisation', async () => {
+    const user = userEvent.setup();
+    mockListOrganisations.mockResolvedValue(organisations);
+    mockUpdateOrganisation.mockResolvedValue(undefined);
+    renderPage();
+
+    await screen.findByText('Ministry of Health');
+    await user.click(screen.getAllByTitle('Rename')[1]);
+
+    const dialog = screen.getByRole('dialog', { name: 'Rename organisation' });
+    const input = within(dialog).getByDisplayValue('Ministry of Health');
+    await user.clear(input);
+    await user.type(input, 'Ministry of Public Health');
+    await user.click(within(dialog).getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(mockUpdateOrganisation).toHaveBeenCalledWith('health', 'Ministry of Public Health'));
+  });
+
+  it('gates delete on the checkbox and calls the delete endpoint', async () => {
+    const user = userEvent.setup();
+    mockListOrganisations.mockResolvedValue(organisations);
+    mockDeleteOrganisation.mockResolvedValue(undefined);
+    renderPage();
+
+    await screen.findByText('Patient Identity Verification Unit');
+    await user.click(screen.getAllByTitle('Delete')[2]);
+
+    const dialog = screen.getByRole('dialog', { name: 'Delete Patient Identity Verification Unit?' });
+    const confirmButton = within(dialog).getByRole('button', { name: 'Delete organisation' });
+    expect(confirmButton).toBeDisabled();
+
+    await user.click(within(dialog).getByRole('checkbox'));
+    expect(confirmButton).toBeEnabled();
+
+    await user.click(confirmButton);
+    await waitFor(() => expect(mockDeleteOrganisation).toHaveBeenCalledWith('piv'));
+  });
+
+  it('surfaces the 409 conflict as a delete-refused message instead of deleting', async () => {
+    const user = userEvent.setup();
+    mockListOrganisations.mockResolvedValue(organisations);
+    mockDeleteOrganisation.mockRejectedValue({
+      isAxiosError: true,
+      toJSON: () => ({}),
+      response: { status: 409, data: { detail: "Organisation 'health' still has attached users and cannot be deleted." } },
+    });
+    renderPage();
+
+    await screen.findByText('Ministry of Health');
+    await user.click(screen.getAllByTitle('Delete')[1]);
+
+    const confirmDialog = screen.getByRole('dialog', { name: "Delete Ministry of Health?" });
+    await user.click(within(confirmDialog).getByRole('checkbox'));
+    await user.click(within(confirmDialog).getByRole('button', { name: 'Delete organisation' }));
+
+    const refusedDialog = await screen.findByRole('dialog', { name: "Couldn't delete Ministry of Health" });
+    expect(
+      within(refusedDialog).getByText("Organisation 'health' still has attached users and cannot be deleted."),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/staff/src/pages/app/OrganisationsPage.tsx
+++ b/frontend/staff/src/pages/app/OrganisationsPage.tsx
@@ -1,8 +1,427 @@
-// Placeholder — organisation hierarchy management (flow 3a) lands in a later issue.
-export default function OrganisationsPage() {
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import axios from 'axios';
+import { createOrganisation, deleteOrganisation, listOrganisations, updateOrganisation } from '../../api/organisations';
+import { getErrorMessage } from '../../api/errors';
+import { useCurrentUser } from '../../hooks/useCurrentUser';
+import { isAdminRole } from '../../types';
+import type { Organisation } from '../../types';
+import Modal from '../../components/Modal';
+import EmptyState from '../../components/EmptyState';
+import LoadingSpinner from '../../components/LoadingSpinner';
+
+const INDENT_PER_LEVEL = 28;
+const BASE_INDENT = 16;
+
+interface TreeNode extends Organisation {
+  depth: number;
+}
+
+function buildTree(organisations: Organisation[]): TreeNode[] {
+  const byParent = new Map<string | undefined, Organisation[]>();
+  for (const org of organisations) {
+    const key = org.parentId;
+    const siblings = byParent.get(key) ?? [];
+    siblings.push(org);
+    byParent.set(key, siblings);
+  }
+  for (const siblings of byParent.values()) siblings.sort((a, b) => a.name.localeCompare(b.name));
+
+  const result: TreeNode[] = [];
+  const visit = (parentId: string | undefined, depth: number) => {
+    for (const org of byParent.get(parentId) ?? []) {
+      result.push({ ...org, depth });
+      visit(org.id, depth + 1);
+    }
+  };
+  visit(undefined, 0);
+  return result;
+}
+
+type ModalState =
+  | { kind: 'create'; parent: Organisation | null }
+  | { kind: 'rename'; org: Organisation }
+  | { kind: 'delete'; org: Organisation }
+  | null;
+
+const BuildingIcon = () => (
+  <svg className="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M3 21h18M5 21V7l7-4 7 4v14M9 9h1m4 0h1m-6 4h1m4 0h1m-6 4h1m4 0h1"
+    />
+  </svg>
+);
+
+const PlusIcon = () => (
+  <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+  </svg>
+);
+
+const PenIcon = () => (
+  <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+    />
+  </svg>
+);
+
+const TrashIcon = () => (
+  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M9.5 4h5a1 1 0 011 1v2h-7V5a1 1 0 011-1z"
+    />
+  </svg>
+);
+
+const AlertIcon = () => (
+  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 4.5c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+    />
+  </svg>
+);
+
+function TrashSmallIcon() {
   return (
-    <div className="max-w-[1080px] mx-auto px-6 py-8">
-      <p className="text-sm text-neutral-500">Organisation management is coming soon.</p>
+    <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M9.5 4h5a1 1 0 011 1v2h-7V5a1 1 0 011-1z"
+      />
+    </svg>
+  );
+}
+
+function isConflict(error: unknown): boolean {
+  return axios.isAxiosError(error) && error.response?.status === 409;
+}
+
+interface NameModalProps {
+  readonly icon: React.ReactNode;
+  readonly title: string;
+  readonly description: string;
+  readonly initialName: string;
+  readonly submitLabel: string;
+  readonly pendingLabel: string;
+  readonly isPending: boolean;
+  readonly error: unknown;
+  readonly onSubmit: (name: string) => void;
+  readonly onClose: () => void;
+}
+
+function NameModal({
+  icon,
+  title,
+  description,
+  initialName,
+  submitLabel,
+  pendingLabel,
+  isPending,
+  error,
+  onSubmit,
+  onClose,
+}: NameModalProps) {
+  const [name, setName] = useState(initialName);
+  const trimmed = name.trim();
+
+  return (
+    <Modal
+      tone="neutral"
+      icon={icon}
+      title={title}
+      description={description}
+      onClose={onClose}
+      actions={
+        <>
+          <button
+            onClick={onClose}
+            className="inline-flex items-center px-4 h-9 text-sm font-medium text-neutral-500 hover:text-neutral-900 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => onSubmit(trimmed)}
+            disabled={!trimmed || isPending}
+            className="inline-flex items-center px-4 h-9 bg-brand text-white text-sm font-medium rounded-lg hover:bg-brand-dark transition-colors disabled:opacity-60"
+          >
+            {isPending ? pendingLabel : submitLabel}
+          </button>
+        </>
+      }
+    >
+      <div className="pt-2 border-t border-neutral-200">
+        <input
+          type="text"
+          autoFocus
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Organisation name"
+          className="w-full px-3.5 h-11 bg-white border border-neutral-200 rounded-lg text-sm focus:outline-none focus:border-brand focus:ring-1 focus:ring-brand transition-shadow"
+        />
+      </div>
+      {error !== undefined && error !== null && (
+        <p className="mt-3 text-sm text-status-danger-text text-center">
+          {getErrorMessage(error, 'Something went wrong. Please try again.')}
+        </p>
+      )}
+    </Modal>
+  );
+}
+
+export default function OrganisationsPage() {
+  const queryClient = useQueryClient();
+  const { user } = useCurrentUser();
+  const isAdmin = !!user && isAdminRole(user.role);
+
+  const [modal, setModal] = useState<ModalState>(null);
+  const [deleteChecked, setDeleteChecked] = useState(false);
+
+  const {
+    data: organisations,
+    isLoading,
+    isError,
+  } = useQuery({ queryKey: ['organisations'], queryFn: listOrganisations });
+
+  const tree = useMemo(() => buildTree(organisations ?? []), [organisations]);
+  const root = organisations?.find((o) => !o.parentId) ?? null;
+
+  const closeModal = () => {
+    if (createMutation.isPending || renameMutation.isPending || deleteMutation.isPending) return;
+    setModal(null);
+    setDeleteChecked(false);
+    createMutation.reset();
+    renameMutation.reset();
+    deleteMutation.reset();
+  };
+
+  const createMutation = useMutation({
+    mutationFn: (payload: { name: string; parentId?: string }) => createOrganisation(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['organisations'] });
+      setModal(null);
+    },
+  });
+
+  const renameMutation = useMutation({
+    mutationFn: ({ id, name }: { id: string; name: string }) => updateOrganisation(id, name),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['organisations'] });
+      setModal(null);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteOrganisation(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['organisations'] });
+      setModal(null);
+      setDeleteChecked(false);
+    },
+  });
+
+  if (!isAdmin) {
+    return (
+      <div className="max-w-[1080px] mx-auto px-6 py-8">
+        <p className="text-sm text-neutral-500">You don't have access to organisation management.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-[1080px] mx-auto px-6 py-8 pb-16">
+      <div className="flex items-start justify-between gap-4 mb-5">
+        <div>
+          <h1 className="text-2xl font-bold text-neutral-900 mb-1">Organisations</h1>
+          <p className="text-sm text-neutral-500">
+            Single root hierarchy. This spans every organisation on the platform — there is no per-admin scoping yet.
+          </p>
+        </div>
+        {!!organisations?.length && (
+          <button
+            onClick={() => setModal({ kind: 'create', parent: root })}
+            className="shrink-0 inline-flex items-center gap-2 px-4 h-10 bg-neutral-0 border border-neutral-200 text-sm font-medium text-neutral-900 rounded-lg hover:bg-neutral-50 transition-colors"
+          >
+            <PlusIcon /> Create sub-organisation
+          </button>
+        )}
+      </div>
+
+      {isLoading && <LoadingSpinner className="py-32" />}
+      {isError && (
+        <div className="py-10 text-center text-sm text-status-danger-text">
+          Failed to load organisations. Please try again.
+        </div>
+      )}
+
+      {!isLoading && !isError && organisations?.length === 0 && (
+        <EmptyState
+          title="No organisations yet"
+          description="Create the root organisation to get started — Herit has a single root, and every other organisation nests underneath it."
+          action={
+            <button
+              onClick={() => setModal({ kind: 'create', parent: null })}
+              className="inline-flex items-center gap-2 px-4 h-10 bg-brand text-white text-sm font-medium rounded-lg hover:bg-brand-dark transition-colors"
+            >
+              <PlusIcon /> Create root organisation
+            </button>
+          }
+        />
+      )}
+
+      {!isLoading && !isError && !!organisations?.length && (
+        <div className="bg-neutral-0 border border-neutral-200 rounded-lg shadow-soft overflow-hidden">
+          {tree.map((node) => (
+            <div
+              key={node.id}
+              className="flex items-center gap-2.5 px-4 py-3 border-b border-neutral-200 last:border-b-0"
+              style={{ paddingLeft: BASE_INDENT + node.depth * INDENT_PER_LEVEL }}
+            >
+              <span className="text-neutral-500">
+                <BuildingIcon />
+              </span>
+              <span className="text-sm font-medium text-neutral-900">{node.name}</span>
+              {node.depth === 0 && (
+                <span className="px-1.5 py-0.5 rounded text-[10px] font-bold uppercase tracking-wider bg-status-info-bg text-status-info-text">
+                  Root
+                </span>
+              )}
+              <div className="ml-auto flex gap-1.5">
+                <button
+                  onClick={() => setModal({ kind: 'create', parent: node })}
+                  title="Create sub-organisation"
+                  className="w-7 h-7 rounded-md border border-neutral-200 bg-neutral-0 text-neutral-500 flex items-center justify-center hover:bg-neutral-50 transition-colors"
+                >
+                  <PlusIcon />
+                </button>
+                <button
+                  onClick={() => setModal({ kind: 'rename', org: node })}
+                  title="Rename"
+                  className="w-7 h-7 rounded-md border border-neutral-200 bg-neutral-0 text-neutral-500 flex items-center justify-center hover:bg-neutral-50 transition-colors"
+                >
+                  <PenIcon />
+                </button>
+                <button
+                  onClick={() => setModal({ kind: 'delete', org: node })}
+                  title="Delete"
+                  className="w-7 h-7 rounded-md border border-neutral-200 bg-neutral-0 text-status-danger-text flex items-center justify-center hover:bg-neutral-50 transition-colors"
+                >
+                  <TrashSmallIcon />
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {modal?.kind === 'create' && (
+        <NameModal
+          key={modal.parent?.id ?? 'root'}
+          icon={<PlusIcon />}
+          title={modal.parent ? 'Create sub-organisation' : 'Create root organisation'}
+          description={
+            modal.parent
+              ? `Creating a sub-organisation under ${modal.parent.name}. It will appear nested one level below its parent in the tree.`
+              : 'This becomes the single root of the hierarchy — every other organisation nests underneath it.'
+          }
+          initialName=""
+          submitLabel="Create"
+          pendingLabel="Creating..."
+          isPending={createMutation.isPending}
+          error={createMutation.error}
+          onClose={closeModal}
+          onSubmit={(name) => createMutation.mutate({ name, parentId: modal.parent?.id })}
+        />
+      )}
+
+      {modal?.kind === 'rename' && (
+        <NameModal
+          key={modal.org.id}
+          icon={<PenIcon />}
+          title="Rename organisation"
+          description={`Renaming ${modal.org.name}. This only changes the display name — its position in the hierarchy is unaffected.`}
+          initialName={modal.org.name}
+          submitLabel="Save"
+          pendingLabel="Saving..."
+          isPending={renameMutation.isPending}
+          error={renameMutation.error}
+          onClose={closeModal}
+          onSubmit={(name) => renameMutation.mutate({ id: modal.org.id, name })}
+        />
+      )}
+
+      {modal?.kind === 'delete' &&
+        (isConflict(deleteMutation.error) ? (
+          <Modal
+            tone="danger"
+            icon={<AlertIcon />}
+            title={`Couldn't delete ${modal.org.name}`}
+            description={getErrorMessage(
+              deleteMutation.error,
+              'This organisation still has attached records and cannot be deleted.',
+            )}
+            onClose={closeModal}
+            actions={
+              <button
+                onClick={closeModal}
+                className="inline-flex items-center px-4 h-9 bg-neutral-0 border border-neutral-200 text-sm font-medium text-neutral-900 rounded-lg hover:bg-neutral-50 transition-colors"
+              >
+                Close
+              </button>
+            }
+          />
+        ) : (
+          <Modal
+            tone="danger"
+            icon={<TrashIcon />}
+            title={`Delete ${modal.org.name}?`}
+            description="This permanently deletes the organisation. Organisations with attached users, child organisations, RFPs, or proposals cannot be deleted — move or remove those first. This action cannot be undone once it succeeds."
+            onClose={closeModal}
+            actions={
+              <>
+                <button
+                  onClick={closeModal}
+                  className="inline-flex items-center px-4 h-9 text-sm font-medium text-neutral-500 hover:text-neutral-900 transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={() => deleteMutation.mutate(modal.org.id)}
+                  disabled={!deleteChecked || deleteMutation.isPending}
+                  className="inline-flex items-center px-4 h-9 bg-status-danger-text text-white text-sm font-medium rounded-lg hover:opacity-90 transition-colors disabled:opacity-60"
+                >
+                  {deleteMutation.isPending ? 'Deleting...' : 'Delete organisation'}
+                </button>
+              </>
+            }
+          >
+            <label className="flex items-start gap-3 cursor-pointer pt-2 border-t border-neutral-200">
+              <input
+                type="checkbox"
+                checked={deleteChecked}
+                onChange={(e) => setDeleteChecked(e.target.checked)}
+                className="mt-0.5 w-4 h-4 accent-brand"
+              />
+              <span className="text-sm text-neutral-700 text-left">
+                I understand this cannot be undone.
+              </span>
+            </label>
+          </Modal>
+        ))}
     </div>
   );
 }


### PR DESCRIPTION
## Description

Implements the admin-only Organisations route in the Herit Staff app: a flat-indented hierarchy tree (28px/level) with per-node create-sub-organisation, rename, and delete actions, sourced from `GET /api/v1/Organisations`.

- Super-admin **bootstrap empty state** — "No organisations yet" with a "Create root organisation" action that POSTs with no parent.
- Shared create/rename modal: single name field with parent context copy, backed by `POST` / `PUT /api/v1/Organisations/{id}`.
- Delete confirmation with checkbox gate; on a **409** conflict (PR #288 — non-empty organisation) the modal swaps to a "Couldn't delete …" state showing the server's message, per the mockup's "Delete refused" screen. This is the expected path for organisations with attached users/children/RFPs/proposals, not an edge case.
- Page-level admin gate (`isAdminRole`) as a backstop to the nav-level hiding, since the route itself wasn't previously gated.

## Linked Issue

Closes #292

## Type of Change

- [x] Feature

## Testing Notes

- `npx tsc --noEmit` — clean
- `npx vitest run` — 62/62 passing (7 new tests covering tree rendering, bootstrap empty state, create/rename/delete, the 409 conflict path, and the non-admin gate)
- `npm run build` — succeeds
- No backend changes in this PR, so `dotnet build`/`dotnet test` were not run.

## Checklist

- [x] Code builds cleanly (`npm run build`)
- [x] Tests pass (`vitest run`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)