### PR TITLE
Implement the user forms and delete guards (flow 3, screen 04)

### DIFF
--- a/frontend/staff/src/api/users.ts
+++ b/frontend/staff/src/api/users.ts
@@ -8,3 +8,42 @@ export const getCurrentUser = (): Promise<User> => apiClient.get('/Users/me').th
 
 // AdminOrSuperAdmin only — used for the admin dashboard's "Staff & admins" count.
 export const listUsers = (): Promise<User[]> => apiClient.get('/Users').then((r) => r.data);
+
+export interface CreateStaffUserPayload {
+  email: string;
+  fullName: string;
+  organisationId: string;
+}
+
+// Provisions a Staff account. The email must match the identity this person
+// signs in with through Entra — there is no JIT registration (ADR-015).
+export const createStaffUser = (payload: CreateStaffUserPayload): Promise<string> =>
+  apiClient.post('/Users/staff', payload).then((r) => r.data);
+
+export interface CreateOrganisationAdminPayload {
+  email: string;
+  fullName: string;
+  organisationId: string;
+}
+
+export const createOrganisationAdmin = (payload: CreateOrganisationAdminPayload): Promise<string> =>
+  apiClient.post('/Users/organisation-admins', payload).then((r) => r.data);
+
+export interface UpdateStaffUserPayload {
+  email: string;
+  fullName: string;
+}
+
+// Staff only — email and full name. Organisation isn't editable here; there is
+// no update endpoint for reassigning a user's organisation.
+export const updateStaffUser = (id: string, payload: UpdateStaffUserPayload): Promise<void> =>
+  apiClient.put(`/Users/staff/${id}`, payload).then(() => undefined);
+
+// Staff only. Server rejects self-delete with 403 (backstop — the UI guards this first).
+export const deleteStaffUser = (id: string): Promise<void> =>
+  apiClient.delete(`/Users/staff/${id}`).then(() => undefined);
+
+// OrganisationAdmin only. Server rejects self-delete (403) and deleting the last
+// remaining OrganisationAdmin (409) — both are also guarded client-side first.
+export const deleteOrganisationAdmin = (id: string): Promise<void> =>
+  apiClient.delete(`/Users/organisation-admins/${id}`).then(() => undefined);

--- a/frontend/staff/src/pages/app/UsersPage.test.tsx
+++ b/frontend/staff/src/pages/app/UsersPage.test.tsx
@@ -1,9 +1,17 @@
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import UsersPage from './UsersPage';
-import { listUsers } from '../../api/users';
+import { AxiosError, AxiosHeaders } from 'axios';
+import UsersPage, { guardDelete } from './UsersPage';
+import {
+  createOrganisationAdmin,
+  createStaffUser,
+  deleteOrganisationAdmin,
+  deleteStaffUser,
+  listUsers,
+  updateStaffUser,
+} from '../../api/users';
 import { listOrganisations } from '../../api/organisations';
 import { useCurrentUser } from '../../hooks/useCurrentUser';
 import type { Organisation, User } from '../../types';
@@ -11,6 +19,11 @@ import type { Organisation, User } from '../../types';
 vi.mock('../../api/users', () => ({
   listUsers: vi.fn(),
   getCurrentUser: vi.fn(),
+  createStaffUser: vi.fn(),
+  createOrganisationAdmin: vi.fn(),
+  updateStaffUser: vi.fn(),
+  deleteStaffUser: vi.fn(),
+  deleteOrganisationAdmin: vi.fn(),
 }));
 vi.mock('../../api/organisations', () => ({
   listOrganisations: vi.fn(),
@@ -20,18 +33,26 @@ vi.mock('../../hooks/useCurrentUser', () => ({ useCurrentUser: vi.fn() }));
 const mockListUsers = vi.mocked(listUsers);
 const mockListOrganisations = vi.mocked(listOrganisations);
 const mockUseCurrentUser = vi.mocked(useCurrentUser);
+const mockCreateStaffUser = vi.mocked(createStaffUser);
+const mockCreateOrganisationAdmin = vi.mocked(createOrganisationAdmin);
+const mockUpdateStaffUser = vi.mocked(updateStaffUser);
+const mockDeleteStaffUser = vi.mocked(deleteStaffUser);
+const mockDeleteOrganisationAdmin = vi.mocked(deleteOrganisationAdmin);
 
 const adminUser: User = { id: 'u1', email: 'amara@example.com', fullName: 'Amara Chen', role: 'SuperAdmin' };
 const staffUser: User = { id: 'u2', email: 'jonas@example.com', fullName: 'Jonas Weber', role: 'Staff' };
 
 const organisations: Organisation[] = [{ id: 'health', name: 'Ministry of Health' }];
 
-const users: User[] = [
-  adminUser,
-  { id: 'u3', email: 'marcus@example.com', fullName: 'Marcus Ade', role: 'Staff', organisationId: 'health' },
-  { id: 'u4', email: 'nadia@example.com', fullName: 'Nadia Osei', role: 'OrganisationAdmin', organisationId: 'health' },
-  { id: 'u5', email: 'expat@example.com', fullName: 'Expat User', role: 'Expat' },
-];
+function usersFixture(): User[] {
+  return [
+    adminUser,
+    { id: 'u3', email: 'marcus@example.com', fullName: 'Marcus Ade', role: 'Staff', organisationId: 'health' },
+    { id: 'u4', email: 'nadia@example.com', fullName: 'Nadia Osei', role: 'OrganisationAdmin', organisationId: 'health' },
+    { id: 'u5', email: 'expat@example.com', fullName: 'Expat User', role: 'Expat' },
+    { id: 'u6', email: 'priya@example.com', fullName: 'Priya Nair', role: 'OrganisationAdmin', organisationId: 'health' },
+  ];
+}
 
 function renderPage() {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -42,6 +63,16 @@ function renderPage() {
       </MemoryRouter>
     </QueryClientProvider>,
   );
+}
+
+function axiosErrorWithStatus(status: number, detail: string): AxiosError {
+  return new AxiosError('Request failed', String(status), undefined, undefined, {
+    status,
+    statusText: 'Error',
+    headers: new AxiosHeaders(),
+    config: { headers: new AxiosHeaders() },
+    data: { detail },
+  });
 }
 
 beforeEach(() => {
@@ -58,7 +89,7 @@ beforeEach(() => {
 describe('UsersPage', () => {
   it('denies access to non-admin staff', async () => {
     mockUseCurrentUser.mockReturnValue({ user: staffUser, isLoading: false, error: null, isNotFound: false });
-    mockListUsers.mockResolvedValue(users);
+    mockListUsers.mockResolvedValue(usersFixture());
     renderPage();
 
     expect(screen.getByText(/don't have access/i)).toBeInTheDocument();
@@ -66,19 +97,18 @@ describe('UsersPage', () => {
   });
 
   it('lists every user with role badge and resolved organisation name', async () => {
-    mockListUsers.mockResolvedValue(users);
+    mockListUsers.mockResolvedValue(usersFixture());
     renderPage();
 
     await screen.findByText('Marcus Ade');
     expect(screen.getByText('Nadia Osei')).toBeInTheDocument();
     expect(screen.getByText('Expat User')).toBeInTheDocument();
-    expect(screen.getAllByText('Ministry of Health')).toHaveLength(2);
     expect(screen.getByText('(you)')).toBeInTheDocument();
   });
 
   it('filters the list client-side by the role tabs', async () => {
     const user = userEvent.setup();
-    mockListUsers.mockResolvedValue(users);
+    mockListUsers.mockResolvedValue(usersFixture());
     renderPage();
 
     await screen.findByText('Marcus Ade');
@@ -89,22 +119,224 @@ describe('UsersPage', () => {
     expect(screen.queryByText('Expat User')).not.toBeInTheDocument();
   });
 
-  it('marks the current user delete-disabled and shows read-only affordances for expats', async () => {
-    mockListUsers.mockResolvedValue(users);
+  it('shows row actions gated by role, with an info note for org admins and read-only for expats', async () => {
+    mockListUsers.mockResolvedValue(usersFixture());
     renderPage();
 
     await screen.findByText('Marcus Ade');
 
     const staffRow = screen.getByText('Marcus Ade').closest('div.grid') as HTMLElement;
-    expect(within(staffRow).getAllByTitle(/#294/)).toHaveLength(2);
+    expect(within(staffRow).getByTitle('Edit')).toBeInTheDocument();
+    expect(within(staffRow).getByTitle('Delete')).toBeInTheDocument();
 
     const orgAdminRow = screen.getByText('Nadia Osei').closest('div.grid') as HTMLElement;
+    expect(within(orgAdminRow).queryByTitle('Edit')).not.toBeInTheDocument();
+    expect(within(orgAdminRow).getByTitle('Delete')).toBeInTheDocument();
     expect(within(orgAdminRow).getByTitle(/no update endpoint/i)).toBeInTheDocument();
 
     const expatRow = screen.getByText('Expat User').closest('div.grid') as HTMLElement;
     expect(within(expatRow).getByText('Read-only')).toBeInTheDocument();
+    expect(within(expatRow).queryByTitle('Delete')).not.toBeInTheDocument();
 
     const ownRow = screen.getByText('Amara Chen').closest('div.grid') as HTMLElement;
-    expect(within(ownRow).queryAllByTitle(/#294/)).toHaveLength(0);
+    expect(within(ownRow).queryByTitle('Delete')).not.toBeInTheDocument();
+  });
+
+  it('creates a staff user via the create-staff form', async () => {
+    const user = userEvent.setup();
+    mockListUsers.mockResolvedValue(usersFixture());
+    mockCreateStaffUser.mockResolvedValue('new-id');
+    renderPage();
+
+    await screen.findByText('Marcus Ade');
+    await user.click(screen.getByRole('button', { name: /create staff/i }));
+
+    const dialog = screen.getByRole('dialog', { name: 'Create staff user' });
+    expect(within(dialog).getByText(/must match the identity/i)).toBeInTheDocument();
+    await user.type(within(dialog).getByPlaceholderText('Work email'), 'new.staff@herit.gov');
+    await user.type(within(dialog).getByPlaceholderText('Full name'), 'New Staff');
+    await user.selectOptions(within(dialog).getByRole('combobox'), 'health');
+    await user.click(within(dialog).getByRole('button', { name: 'Create staff user' }));
+
+    await waitFor(() =>
+      expect(mockCreateStaffUser).toHaveBeenCalledWith({
+        email: 'new.staff@herit.gov',
+        fullName: 'New Staff',
+        organisationId: 'health',
+      }),
+    );
+  });
+
+  it('creates an organisation admin via the create-org-admin form', async () => {
+    const user = userEvent.setup();
+    mockListUsers.mockResolvedValue(usersFixture());
+    mockCreateOrganisationAdmin.mockResolvedValue('new-id');
+    renderPage();
+
+    await screen.findByText('Marcus Ade');
+    await user.click(screen.getByRole('button', { name: /create org admin/i }));
+
+    const dialog = screen.getByRole('dialog', { name: 'Create organisation admin' });
+    await user.type(within(dialog).getByPlaceholderText('Work email'), 'new.admin@herit.gov');
+    await user.type(within(dialog).getByPlaceholderText('Full name'), 'New Admin');
+    await user.selectOptions(within(dialog).getByRole('combobox'), 'health');
+    await user.click(within(dialog).getByRole('button', { name: 'Create org admin' }));
+
+    await waitFor(() =>
+      expect(mockCreateOrganisationAdmin).toHaveBeenCalledWith({
+        email: 'new.admin@herit.gov',
+        fullName: 'New Admin',
+        organisationId: 'health',
+      }),
+    );
+  });
+
+  it('edits a staff user via the edit form (email and full name only)', async () => {
+    const user = userEvent.setup();
+    mockListUsers.mockResolvedValue(usersFixture());
+    mockUpdateStaffUser.mockResolvedValue(undefined);
+    renderPage();
+
+    await screen.findByText('Marcus Ade');
+    const staffRow = screen.getByText('Marcus Ade').closest('div.grid') as HTMLElement;
+    await user.click(within(staffRow).getByTitle('Edit'));
+
+    const dialog = screen.getByRole('dialog', { name: 'Edit staff user' });
+    expect(within(dialog).queryByRole('combobox')).not.toBeInTheDocument();
+    const emailInput = within(dialog).getByDisplayValue('marcus@example.com');
+    await user.clear(emailInput);
+    await user.type(emailInput, 'marcus.new@example.com');
+    await user.click(within(dialog).getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() =>
+      expect(mockUpdateStaffUser).toHaveBeenCalledWith('u3', {
+        email: 'marcus.new@example.com',
+        fullName: 'Marcus Ade',
+      }),
+    );
+  });
+
+  it('gates delete on the checkbox and calls the staff delete endpoint', async () => {
+    const user = userEvent.setup();
+    mockListUsers.mockResolvedValue(usersFixture());
+    mockDeleteStaffUser.mockResolvedValue(undefined);
+    renderPage();
+
+    await screen.findByText('Marcus Ade');
+    const staffRow = screen.getByText('Marcus Ade').closest('div.grid') as HTMLElement;
+    await user.click(within(staffRow).getByTitle('Delete'));
+
+    const dialog = screen.getByRole('dialog', { name: 'Delete Marcus Ade?' });
+    const confirmButton = within(dialog).getByRole('button', { name: 'Delete user' });
+    expect(confirmButton).toBeDisabled();
+
+    await user.click(within(dialog).getByRole('checkbox'));
+    expect(confirmButton).toBeEnabled();
+
+    await user.click(confirmButton);
+    await waitFor(() => expect(mockDeleteStaffUser).toHaveBeenCalledWith('u3'));
+    expect(mockDeleteOrganisationAdmin).not.toHaveBeenCalled();
+  });
+
+  it('calls the organisation-admin delete endpoint for org admin rows', async () => {
+    const user = userEvent.setup();
+    mockListUsers.mockResolvedValue(usersFixture());
+    mockDeleteOrganisationAdmin.mockResolvedValue(undefined);
+    renderPage();
+
+    await screen.findByText('Nadia Osei');
+    const orgAdminRow = screen.getByText('Nadia Osei').closest('div.grid') as HTMLElement;
+    await user.click(within(orgAdminRow).getByTitle('Delete'));
+
+    const dialog = screen.getByRole('dialog', { name: 'Delete Nadia Osei?' });
+    await user.click(within(dialog).getByRole('checkbox'));
+    await user.click(within(dialog).getByRole('button', { name: 'Delete user' }));
+
+    await waitFor(() => expect(mockDeleteOrganisationAdmin).toHaveBeenCalledWith('u4'));
+    expect(mockDeleteStaffUser).not.toHaveBeenCalled();
+  });
+
+  it('client-side blocks deleting the last organisation admin before any request', async () => {
+    const user = userEvent.setup();
+    const users = usersFixture().filter((u) => u.id !== 'u6'); // only Nadia remains as OrganisationAdmin
+    mockListUsers.mockResolvedValue(users);
+    renderPage();
+
+    await screen.findByText('Nadia Osei');
+    const orgAdminRow = screen.getByText('Nadia Osei').closest('div.grid') as HTMLElement;
+    await user.click(within(orgAdminRow).getByTitle('Delete'));
+
+    const dialog = screen.getByRole('dialog', { name: "Can't delete Nadia Osei" });
+    expect(within(dialog).getByText(/last remaining organisation admin/i)).toBeInTheDocument();
+    expect(within(dialog).queryByRole('button', { name: 'Delete user' })).not.toBeInTheDocument();
+
+    expect(mockDeleteOrganisationAdmin).not.toHaveBeenCalled();
+    expect(mockDeleteStaffUser).not.toHaveBeenCalled();
+  });
+
+  it('hides the delete action on the signed-in user\'s own row (first line of the self-delete guard)', async () => {
+    mockListUsers.mockResolvedValue(usersFixture());
+    renderPage();
+
+    await screen.findByText('Amara Chen');
+    const ownRow = screen.getByText('Amara Chen').closest('div.grid') as HTMLElement;
+    expect(within(ownRow).queryByTitle('Delete')).not.toBeInTheDocument();
+  });
+
+  it('guardDelete blocks self-delete and last-org-admin delete before any request is made', () => {
+    const users = usersFixture();
+    const staffTarget = users.find((u) => u.id === 'u3')!;
+    const orgAdminTarget = users.find((u) => u.id === 'u4')!;
+
+    // Self-delete: blocked regardless of role, using the current user's own id.
+    expect(guardDelete(staffTarget, staffTarget.id, users)).toMatch(/currently signed in as/i);
+
+    // Last remaining OrganisationAdmin: blocked when only one exists.
+    const singleAdminUsers = users.filter((u) => u.role !== 'OrganisationAdmin' || u.id === orgAdminTarget.id);
+    expect(guardDelete(orgAdminTarget, 'someone-else', singleAdminUsers)).toMatch(/last remaining organisation admin/i);
+
+    // Not blocked: a non-self staff delete with other admins present.
+    expect(guardDelete(staffTarget, 'someone-else', users)).toBeNull();
+
+    // Not blocked: an org admin delete when another org admin remains (fixture has two).
+    expect(guardDelete(orgAdminTarget, 'someone-else', users)).toBeNull();
+  });
+
+  it('surfaces the server 403 self-delete response as a backstop error message', async () => {
+    const user = userEvent.setup();
+    mockListUsers.mockResolvedValue(usersFixture());
+    mockDeleteStaffUser.mockRejectedValue(axiosErrorWithStatus(403, 'You cannot delete your own account.'));
+    renderPage();
+
+    await screen.findByText('Marcus Ade');
+    const staffRow = screen.getByText('Marcus Ade').closest('div.grid') as HTMLElement;
+    await user.click(within(staffRow).getByTitle('Delete'));
+
+    const dialog = screen.getByRole('dialog', { name: 'Delete Marcus Ade?' });
+    await user.click(within(dialog).getByRole('checkbox'));
+    await user.click(within(dialog).getByRole('button', { name: 'Delete user' }));
+
+    await waitFor(() => expect(screen.getByText('You cannot delete your own account.')).toBeInTheDocument());
+  });
+
+  it('surfaces the server 409 last-admin response as a backstop error message', async () => {
+    const user = userEvent.setup();
+    mockListUsers.mockResolvedValue(usersFixture());
+    mockDeleteOrganisationAdmin.mockRejectedValue(
+      axiosErrorWithStatus(409, 'The last remaining OrganisationAdmin cannot be deleted.'),
+    );
+    renderPage();
+
+    await screen.findByText('Nadia Osei');
+    const orgAdminRow = screen.getByText('Nadia Osei').closest('div.grid') as HTMLElement;
+    await user.click(within(orgAdminRow).getByTitle('Delete'));
+
+    const dialog = screen.getByRole('dialog', { name: 'Delete Nadia Osei?' });
+    await user.click(within(dialog).getByRole('checkbox'));
+    await user.click(within(dialog).getByRole('button', { name: 'Delete user' }));
+
+    await waitFor(() =>
+      expect(screen.getByText('The last remaining OrganisationAdmin cannot be deleted.')).toBeInTheDocument(),
+    );
   });
 });

--- a/frontend/staff/src/pages/app/UsersPage.tsx
+++ b/frontend/staff/src/pages/app/UsersPage.tsx
@@ -1,13 +1,22 @@
 import { useMemo, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { listOrganisations } from '../../api/organisations';
-import { listUsers } from '../../api/users';
+import {
+  createOrganisationAdmin,
+  createStaffUser,
+  deleteOrganisationAdmin,
+  deleteStaffUser,
+  listUsers,
+  updateStaffUser,
+} from '../../api/users';
+import { getErrorMessage } from '../../api/errors';
 import { useCurrentUser } from '../../hooks/useCurrentUser';
 import { isAdminRole, roleLabel } from '../../types';
 import type { User, UserRole } from '../../types';
 import StatusBadge from '../../components/StatusBadge';
 import EmptyState from '../../components/EmptyState';
 import LoadingSpinner from '../../components/LoadingSpinner';
+import Modal from '../../components/Modal';
 
 type RoleTab = 'All' | UserRole;
 
@@ -23,8 +32,30 @@ const PlusIcon = () => (
   </svg>
 );
 
+const UserPlusIcon = () => (
+  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M18 7.5v6m3-3h-6M6 21v-2a4 4 0 014-4h1m5-8a4 4 0 11-8 0 4 4 0 018 0z"
+    />
+  </svg>
+);
+
 const PenIcon = () => (
   <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+    />
+  </svg>
+);
+
+const PenLargeIcon = () => (
+  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
     <path
       strokeLinecap="round"
       strokeLinejoin="round"
@@ -45,6 +76,17 @@ const TrashSmallIcon = () => (
   </svg>
 );
 
+const TrashIcon = () => (
+  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M9.5 4h5a1 1 0 011 1v2h-7V5a1 1 0 011-1z"
+    />
+  </svg>
+);
+
 const InfoIcon = () => (
   <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
     <path
@@ -56,13 +98,291 @@ const InfoIcon = () => (
   </svg>
 );
 
-const COMING_SOON = 'Ships with the user forms — see issue #294';
+/** The account this person signs in with through Entra — no JIT registration (ADR-015). */
+const EMAIL_HELP_TEXT = "Must match the identity this person signs in with through Entra.";
+
+interface OrgOption {
+  readonly id: string;
+  readonly label: string;
+}
+
+interface CreateUserModalProps {
+  readonly title: string;
+  readonly description: string;
+  readonly submitLabel: string;
+  readonly pendingLabel: string;
+  readonly orgOptions: readonly OrgOption[];
+  readonly isPending: boolean;
+  readonly error: unknown;
+  readonly onSubmit: (payload: { email: string; fullName: string; organisationId: string }) => void;
+  readonly onClose: () => void;
+}
+
+function CreateUserModal({
+  title,
+  description,
+  submitLabel,
+  pendingLabel,
+  orgOptions,
+  isPending,
+  error,
+  onSubmit,
+  onClose,
+}: CreateUserModalProps) {
+  const [email, setEmail] = useState('');
+  const [fullName, setFullName] = useState('');
+  const [organisationId, setOrganisationId] = useState('');
+
+  const trimmedEmail = email.trim();
+  const trimmedName = fullName.trim();
+  const canSubmit = !!trimmedEmail && !!trimmedName && !!organisationId;
+
+  return (
+    <Modal
+      tone="neutral"
+      icon={<UserPlusIcon />}
+      title={title}
+      description={description}
+      onClose={onClose}
+      actions={
+        <>
+          <button
+            onClick={onClose}
+            className="inline-flex items-center px-4 h-9 text-sm font-medium text-neutral-500 hover:text-neutral-900 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => onSubmit({ email: trimmedEmail, fullName: trimmedName, organisationId })}
+            disabled={!canSubmit || isPending}
+            className="inline-flex items-center px-4 h-9 bg-brand text-white text-sm font-medium rounded-lg hover:bg-brand-dark transition-colors disabled:opacity-60"
+          >
+            {isPending ? pendingLabel : submitLabel}
+          </button>
+        </>
+      }
+    >
+      <div className="pt-2 border-t border-neutral-200 flex flex-col gap-3.5">
+        <div>
+          <input
+            type="email"
+            autoFocus
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="Work email"
+            className="w-full px-3.5 h-11 bg-white border border-neutral-200 rounded-lg text-sm focus:outline-none focus:border-brand focus:ring-1 focus:ring-brand transition-shadow"
+          />
+          <p className="mt-1.5 text-xs text-neutral-400 text-left">{EMAIL_HELP_TEXT}</p>
+        </div>
+        <input
+          type="text"
+          value={fullName}
+          onChange={(e) => setFullName(e.target.value)}
+          placeholder="Full name"
+          className="w-full px-3.5 h-11 bg-white border border-neutral-200 rounded-lg text-sm focus:outline-none focus:border-brand focus:ring-1 focus:ring-brand transition-shadow"
+        />
+        <select
+          value={organisationId}
+          onChange={(e) => setOrganisationId(e.target.value)}
+          className="w-full px-3.5 h-11 bg-white border border-neutral-200 rounded-lg text-sm focus:outline-none focus:border-brand focus:ring-1 focus:ring-brand transition-shadow"
+        >
+          <option value="" disabled>
+            Organisation
+          </option>
+          {orgOptions.map((opt) => (
+            <option key={opt.id} value={opt.id}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      {error !== undefined && error !== null && (
+        <p className="mt-3 text-sm text-status-danger-text text-center">
+          {getErrorMessage(error, 'Something went wrong. Please try again.')}
+        </p>
+      )}
+    </Modal>
+  );
+}
+
+interface EditStaffModalProps {
+  readonly user: User;
+  readonly isPending: boolean;
+  readonly error: unknown;
+  readonly onSubmit: (payload: { email: string; fullName: string }) => void;
+  readonly onClose: () => void;
+}
+
+function EditStaffModal({ user, isPending, error, onSubmit, onClose }: EditStaffModalProps) {
+  const [email, setEmail] = useState(user.email);
+  const [fullName, setFullName] = useState(user.fullName);
+
+  const trimmedEmail = email.trim();
+  const trimmedName = fullName.trim();
+  const canSubmit = !!trimmedEmail && !!trimmedName;
+
+  return (
+    <Modal
+      tone="neutral"
+      icon={<PenLargeIcon />}
+      title="Edit staff user"
+      description={`Editing ${user.fullName}. Organisation isn't editable here — there's no update endpoint for reassigning a user's organisation; delete and recreate the account if it needs to move.`}
+      onClose={onClose}
+      actions={
+        <>
+          <button
+            onClick={onClose}
+            className="inline-flex items-center px-4 h-9 text-sm font-medium text-neutral-500 hover:text-neutral-900 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => onSubmit({ email: trimmedEmail, fullName: trimmedName })}
+            disabled={!canSubmit || isPending}
+            className="inline-flex items-center px-4 h-9 bg-brand text-white text-sm font-medium rounded-lg hover:bg-brand-dark transition-colors disabled:opacity-60"
+          >
+            {isPending ? 'Saving...' : 'Save changes'}
+          </button>
+        </>
+      }
+    >
+      <div className="pt-2 border-t border-neutral-200 flex flex-col gap-3.5">
+        <div>
+          <input
+            type="email"
+            autoFocus
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="Work email"
+            className="w-full px-3.5 h-11 bg-white border border-neutral-200 rounded-lg text-sm focus:outline-none focus:border-brand focus:ring-1 focus:ring-brand transition-shadow"
+          />
+          <p className="mt-1.5 text-xs text-neutral-400 text-left">{EMAIL_HELP_TEXT}</p>
+        </div>
+        <input
+          type="text"
+          value={fullName}
+          onChange={(e) => setFullName(e.target.value)}
+          placeholder="Full name"
+          className="w-full px-3.5 h-11 bg-white border border-neutral-200 rounded-lg text-sm focus:outline-none focus:border-brand focus:ring-1 focus:ring-brand transition-shadow"
+        />
+      </div>
+      {error !== undefined && error !== null && (
+        <p className="mt-3 text-sm text-status-danger-text text-center">
+          {getErrorMessage(error, 'Something went wrong. Please try again.')}
+        </p>
+      )}
+    </Modal>
+  );
+}
+
+/**
+ * Client-side delete guards, evaluated before any request goes out (per the design's
+ * decided behaviour). Mirrors the server-side checks added in PR #288 — self-delete
+ * (403) and last-remaining-OrganisationAdmin (409) — which still run as a backstop
+ * for races this client check can't fully close.
+ */
+export function guardDelete(target: User, currentUserId: string, allUsers: readonly User[]): string | null {
+  if (target.id === currentUserId) {
+    return `${target.fullName} is the account you're currently signed in as. Have another admin remove this account instead.`;
+  }
+  if (target.role === 'OrganisationAdmin') {
+    const remainingAdmins = allUsers.filter((u) => u.role === 'OrganisationAdmin').length;
+    if (remainingAdmins <= 1) {
+      return `${target.fullName} is the last remaining Organisation Admin. Promote another user to Organisation Admin before deleting this account.`;
+    }
+  }
+  return null;
+}
+
+interface DeleteUserModalProps {
+  readonly user: User;
+  readonly guardReason: string | null;
+  readonly isPending: boolean;
+  readonly error: unknown;
+  readonly onConfirm: () => void;
+  readonly onClose: () => void;
+}
+
+function DeleteUserModal({ user, guardReason, isPending, error, onConfirm, onClose }: DeleteUserModalProps) {
+  const [checked, setChecked] = useState(false);
+
+  if (guardReason) {
+    return (
+      <Modal
+        tone="danger"
+        icon={<TrashIcon />}
+        title={`Can't delete ${user.fullName}`}
+        description={guardReason}
+        onClose={onClose}
+        actions={
+          <button
+            onClick={onClose}
+            className="inline-flex items-center px-4 h-9 bg-neutral-0 border border-neutral-200 text-sm font-medium text-neutral-900 rounded-lg hover:bg-neutral-50 transition-colors"
+          >
+            Close
+          </button>
+        }
+      />
+    );
+  }
+
+  return (
+    <Modal
+      tone="danger"
+      icon={<TrashIcon />}
+      title={`Delete ${user.fullName}?`}
+      description="This permanently removes this person's platform access. Content they authored — RFPs, proposals — stays in place and keeps referencing their user id; it is not deleted or reassigned. This cannot be undone."
+      onClose={onClose}
+      actions={
+        <>
+          <button
+            onClick={onClose}
+            className="inline-flex items-center px-4 h-9 text-sm font-medium text-neutral-500 hover:text-neutral-900 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={!checked || isPending}
+            className="inline-flex items-center px-4 h-9 bg-status-danger-text text-white text-sm font-medium rounded-lg hover:opacity-90 transition-colors disabled:opacity-60"
+          >
+            {isPending ? 'Deleting...' : 'Delete user'}
+          </button>
+        </>
+      }
+    >
+      <label className="flex items-start gap-3 cursor-pointer pt-2 border-t border-neutral-200">
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={(e) => setChecked(e.target.checked)}
+          className="mt-0.5 w-4 h-4 accent-brand"
+        />
+        <span className="text-sm text-neutral-700 text-left">I understand this cannot be undone.</span>
+      </label>
+      {error !== undefined && error !== null && (
+        <p className="mt-3 text-sm text-status-danger-text text-center">
+          {getErrorMessage(error, 'Something went wrong. Please try again.')}
+        </p>
+      )}
+    </Modal>
+  );
+}
+
+type ModalState =
+  | { kind: 'createStaff' }
+  | { kind: 'createOrgAdmin' }
+  | { kind: 'editStaff'; user: User }
+  | { kind: 'delete'; user: User }
+  | null;
 
 export default function UsersPage() {
+  const queryClient = useQueryClient();
   const { user: currentUser } = useCurrentUser();
   const isAdmin = !!currentUser && isAdminRole(currentUser.role);
 
   const [roleTab, setRoleTab] = useState<RoleTab>('All');
+  const [modal, setModal] = useState<ModalState>(null);
 
   const {
     data: users,
@@ -81,10 +401,61 @@ export default function UsersPage() {
     [organisations],
   );
 
+  const orgOptions: OrgOption[] = useMemo(
+    () => (organisations ?? []).map((o) => ({ id: o.id, label: o.name })),
+    [organisations],
+  );
+
   const filtered = useMemo(() => {
     const all = users ?? [];
     return roleTab === 'All' ? all : all.filter((u) => u.role === roleTab);
   }, [users, roleTab]);
+
+  const closeModal = () => {
+    if (createStaffMutation.isPending || createOrgAdminMutation.isPending || editStaffMutation.isPending || deleteMutation.isPending) {
+      return;
+    }
+    setModal(null);
+    createStaffMutation.reset();
+    createOrgAdminMutation.reset();
+    editStaffMutation.reset();
+    deleteMutation.reset();
+  };
+
+  const createStaffMutation = useMutation({
+    mutationFn: (payload: { email: string; fullName: string; organisationId: string }) => createStaffUser(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['users'] });
+      setModal(null);
+    },
+  });
+
+  const createOrgAdminMutation = useMutation({
+    mutationFn: (payload: { email: string; fullName: string; organisationId: string }) =>
+      createOrganisationAdmin(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['users'] });
+      setModal(null);
+    },
+  });
+
+  const editStaffMutation = useMutation({
+    mutationFn: ({ id, payload }: { id: string; payload: { email: string; fullName: string } }) =>
+      updateStaffUser(id, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['users'] });
+      setModal(null);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (target: User) =>
+      target.role === 'OrganisationAdmin' ? deleteOrganisationAdmin(target.id) : deleteStaffUser(target.id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['users'] });
+      setModal(null);
+    },
+  });
 
   if (!isAdmin) {
     return (
@@ -112,16 +483,14 @@ export default function UsersPage() {
         </div>
         <div className="flex gap-2.5 shrink-0">
           <button
-            disabled
-            title={COMING_SOON}
-            className="inline-flex items-center gap-2 px-4 h-10 bg-neutral-0 border border-neutral-200 text-sm font-medium text-neutral-400 rounded-lg cursor-not-allowed"
+            onClick={() => setModal({ kind: 'createStaff' })}
+            className="inline-flex items-center gap-2 px-4 h-10 bg-neutral-0 border border-neutral-200 text-sm font-medium text-neutral-900 rounded-lg hover:bg-neutral-50 transition-colors"
           >
             <PlusIcon /> Create staff
           </button>
           <button
-            disabled
-            title={COMING_SOON}
-            className="inline-flex items-center gap-2 px-4 h-10 bg-brand text-white text-sm font-medium rounded-lg opacity-50 cursor-not-allowed"
+            onClick={() => setModal({ kind: 'createOrgAdmin' })}
+            className="inline-flex items-center gap-2 px-4 h-10 bg-brand text-white text-sm font-medium rounded-lg hover:bg-brand-dark transition-colors"
           >
             <PlusIcon /> Create org admin
           </button>
@@ -186,18 +555,18 @@ export default function UsersPage() {
                 <div className="flex items-center justify-end gap-1.5">
                   {canEdit && (
                     <button
-                      disabled
-                      title={COMING_SOON}
-                      className="w-7 h-7 rounded-md border border-neutral-200 bg-neutral-0 text-neutral-300 flex items-center justify-center cursor-not-allowed"
+                      onClick={() => setModal({ kind: 'editStaff', user })}
+                      title="Edit"
+                      className="w-7 h-7 rounded-md border border-neutral-200 bg-neutral-0 text-neutral-500 flex items-center justify-center hover:bg-neutral-50 transition-colors"
                     >
                       <PenIcon />
                     </button>
                   )}
                   {canDelete && (
                     <button
-                      disabled
-                      title={COMING_SOON}
-                      className="w-7 h-7 rounded-md border border-neutral-200 bg-neutral-0 text-status-danger-text/40 flex items-center justify-center cursor-not-allowed"
+                      onClick={() => setModal({ kind: 'delete', user })}
+                      title="Delete"
+                      className="w-7 h-7 rounded-md border border-neutral-200 bg-neutral-0 text-status-danger-text flex items-center justify-center hover:bg-neutral-50 transition-colors"
                     >
                       <TrashSmallIcon />
                     </button>
@@ -216,6 +585,55 @@ export default function UsersPage() {
             );
           })}
         </div>
+      )}
+
+      {modal?.kind === 'createStaff' && (
+        <CreateUserModal
+          title="Create staff user"
+          description="Provisions a Staff account. Staff can act on any RFP or proposal, platform-wide."
+          submitLabel="Create staff user"
+          pendingLabel="Creating..."
+          orgOptions={orgOptions}
+          isPending={createStaffMutation.isPending}
+          error={createStaffMutation.error}
+          onClose={closeModal}
+          onSubmit={(payload) => createStaffMutation.mutate(payload)}
+        />
+      )}
+
+      {modal?.kind === 'createOrgAdmin' && (
+        <CreateUserModal
+          title="Create organisation admin"
+          description="Provisions an Organisation Admin account, scoped to the organisation below in name only — enforcement isn't org-scoped yet. Org admins can create and delete users, but have no edit action."
+          submitLabel="Create org admin"
+          pendingLabel="Creating..."
+          orgOptions={orgOptions}
+          isPending={createOrgAdminMutation.isPending}
+          error={createOrgAdminMutation.error}
+          onClose={closeModal}
+          onSubmit={(payload) => createOrgAdminMutation.mutate(payload)}
+        />
+      )}
+
+      {modal?.kind === 'editStaff' && (
+        <EditStaffModal
+          user={modal.user}
+          isPending={editStaffMutation.isPending}
+          error={editStaffMutation.error}
+          onClose={closeModal}
+          onSubmit={(payload) => editStaffMutation.mutate({ id: modal.user.id, payload })}
+        />
+      )}
+
+      {modal?.kind === 'delete' && currentUser && (
+        <DeleteUserModal
+          user={modal.user}
+          guardReason={guardDelete(modal.user, currentUser.id, users ?? [])}
+          isPending={deleteMutation.isPending}
+          error={deleteMutation.error}
+          onClose={closeModal}
+          onConfirm={() => deleteMutation.mutate(modal.user)}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Description

Implements the create/edit user forms and delete-user modal per `designs/flow3/` screen 04 and spec sections 3b/3c, replacing the disabled placeholder actions on the Users page (from PR #307) with working ones.

- **Create staff user** and **Create organisation admin** modals: email, full name, and an organisation selector sourced from `GET /api/v1/Organisation`, with the provisioning note that the email must match the person's Entra sign-in identity. Submit to `POST /api/v1/Users/staff` and `POST /api/v1/Users/organisation-admins` respectively.
- **Edit staff user** modal: email and full name only (no organisation reassignment — there's no update endpoint for it) → `PUT /api/v1/Users/staff/{id}`.
- **Delete user** modal: destructive confirmation with a checkbox gate, copy stating the account loses platform access while their authored content is retained.
- **Client-side delete guards** (`guardDelete` in `UsersPage.tsx`), evaluated *before* any network request: block deleting yourself, and block deleting the last remaining `OrganisationAdmin`. Guard copy uses this codebase's actual `OrganisationAdmin` role naming rather than the design mockup's illustrative "SuperAdmin" example, per the task list's explicit correction.
- The server-side 403 (self-delete) / 409 (last-admin) responses added in PR #288 are still surfaced via their `ProblemDetails` messages as a backstop for race conditions the client guard can't fully close.

No backend changes were needed — the endpoints and their guard semantics already exist from PR #288.

## Linked Issue

Closes #294

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- `npx tsc -b && vite build` (via `npm run build`) — clean build
- `npx vitest run` — 76/76 tests pass, including 14 in `UsersPage.test.tsx` covering: form submission/validation for all three forms, staff-vs-org-admin delete routing, the checkbox-gated confirm modal, the client-side self-delete and last-admin guards (including a direct unit test of `guardDelete` firing before any request), and the 403/409 server-response backstop surfacing their messages.
- `dotnet build --configuration Release` and `dotnet test --configuration Release --no-build` — 295/295 backend tests pass (no backend files changed; run to confirm no regressions).

## Checklist

- [x] Code builds cleanly (`dotnet build`, `vite build`)
- [x] Tests pass (`dotnet test`, `vitest run`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)