### PR TITLE
Return author identity in Proposal and RFP responses

### DIFF
--- a/frontend/portal/src/types/index.ts
+++ b/frontend/portal/src/types/index.ts
@@ -47,7 +47,9 @@ export interface Rfp {
   longDescription: string;
   status: RfpStatus;
   organisationId: string;
+  organisationName: string;
   authorId: string;
+  authorName: string;
   tags?: string;
 }
 
@@ -59,7 +61,9 @@ export interface Proposal {
   status: ProposalStatus;
   visibility: ProposalVisibility;
   authorId: string;
+  authorName: string;
   organisationId: string;
+  organisationName: string;
   rfpId?: string;
 }
 

--- a/frontend/staff/src/pages/app/DashboardPage.test.tsx
+++ b/frontend/staff/src/pages/app/DashboardPage.test.tsx
@@ -22,17 +22,17 @@ const mockListOrganisations = vi.mocked(listOrganisations);
 const mockListUsers = vi.mocked(listUsers);
 
 const rfps: Rfp[] = [
-  { id: '1', title: 'a', shortDescription: '', longDescription: '', status: 'Draft', organisationId: 'o1', authorId: 'u1' },
-  { id: '2', title: 'b', shortDescription: '', longDescription: '', status: 'Draft', organisationId: 'o1', authorId: 'u1' },
-  { id: '3', title: 'c', shortDescription: '', longDescription: '', status: 'Approved', organisationId: 'o1', authorId: 'u1' },
-  { id: '4', title: 'd', shortDescription: '', longDescription: '', status: 'Published', organisationId: 'o1', authorId: 'u1' },
+  { id: '1', title: 'a', shortDescription: '', longDescription: '', status: 'Draft', organisationId: 'o1', organisationName: 'Org One', authorId: 'u1', authorName: 'Staff One' },
+  { id: '2', title: 'b', shortDescription: '', longDescription: '', status: 'Draft', organisationId: 'o1', organisationName: 'Org One', authorId: 'u1', authorName: 'Staff One' },
+  { id: '3', title: 'c', shortDescription: '', longDescription: '', status: 'Approved', organisationId: 'o1', organisationName: 'Org One', authorId: 'u1', authorName: 'Staff One' },
+  { id: '4', title: 'd', shortDescription: '', longDescription: '', status: 'Published', organisationId: 'o1', organisationName: 'Org One', authorId: 'u1', authorName: 'Staff One' },
 ];
 
 const proposals: Proposal[] = [
-  { id: '1', title: 'a', shortDescription: '', longDescription: '', status: 'Submitted', authorId: 'u1', organisationId: 'o1' },
-  { id: '2', title: 'b', shortDescription: '', longDescription: '', status: 'UnderReview', authorId: 'u1', organisationId: 'o1' },
-  { id: '3', title: 'c', shortDescription: '', longDescription: '', status: 'UnderReview', authorId: 'u1', organisationId: 'o1' },
-  { id: '4', title: 'd', shortDescription: '', longDescription: '', status: 'Approved', authorId: 'u1', organisationId: 'o1' },
+  { id: '1', title: 'a', shortDescription: '', longDescription: '', status: 'Submitted', authorId: 'u1', authorName: 'Staff One', organisationId: 'o1', organisationName: 'Org One' },
+  { id: '2', title: 'b', shortDescription: '', longDescription: '', status: 'UnderReview', authorId: 'u1', authorName: 'Staff One', organisationId: 'o1', organisationName: 'Org One' },
+  { id: '3', title: 'c', shortDescription: '', longDescription: '', status: 'UnderReview', authorId: 'u1', authorName: 'Staff One', organisationId: 'o1', organisationName: 'Org One' },
+  { id: '4', title: 'd', shortDescription: '', longDescription: '', status: 'Approved', authorId: 'u1', authorName: 'Staff One', organisationId: 'o1', organisationName: 'Org One' },
 ];
 
 const organisations: Organisation[] = [{ id: 'o1', name: 'Org One' }, { id: 'o2', name: 'Org Two' }];

--- a/frontend/staff/src/pages/app/EoiListPage.test.tsx
+++ b/frontend/staff/src/pages/app/EoiListPage.test.tsx
@@ -30,7 +30,9 @@ const proposal: Proposal = {
   status: 'UnderReview',
   visibility: 'Public',
   authorId: 'u1',
+  authorName: 'Amara Chen',
   organisationId: 'o1',
+  organisationName: 'Org One',
 };
 
 const cfeoi: Cfeoi = {

--- a/frontend/staff/src/pages/app/ProposalDetailPage.test.tsx
+++ b/frontend/staff/src/pages/app/ProposalDetailPage.test.tsx
@@ -6,11 +6,8 @@ import ProposalDetailPage from './ProposalDetailPage';
 import { deleteProposal, getProposalById, updateProposalStatus } from '../../api/proposals';
 import { listCfeois } from '../../api/cfeois';
 import { listEoisByCfeoi } from '../../api/eois';
-import { listOrganisations } from '../../api/organisations';
-import { listUsers } from '../../api/users';
 import { getRfpById } from '../../api/rfps';
-import { useCurrentUser } from '../../hooks/useCurrentUser';
-import type { Cfeoi, Eoi, Organisation, Proposal, Rfp, User } from '../../types';
+import type { Cfeoi, Eoi, Proposal, Rfp } from '../../types';
 
 vi.mock('../../api/proposals', () => ({
   getProposalById: vi.fn(),
@@ -19,23 +16,14 @@ vi.mock('../../api/proposals', () => ({
 }));
 vi.mock('../../api/cfeois', () => ({ listCfeois: vi.fn() }));
 vi.mock('../../api/eois', () => ({ listEoisByCfeoi: vi.fn() }));
-vi.mock('../../api/organisations', () => ({ listOrganisations: vi.fn() }));
-vi.mock('../../api/users', () => ({ listUsers: vi.fn() }));
 vi.mock('../../api/rfps', () => ({ getRfpById: vi.fn() }));
-vi.mock('../../hooks/useCurrentUser', () => ({ useCurrentUser: vi.fn() }));
 
 const mockGetProposalById = vi.mocked(getProposalById);
 const mockUpdateProposalStatus = vi.mocked(updateProposalStatus);
 const mockDeleteProposal = vi.mocked(deleteProposal);
 const mockListCfeois = vi.mocked(listCfeois);
 const mockListEoisByCfeoi = vi.mocked(listEoisByCfeoi);
-const mockListOrganisations = vi.mocked(listOrganisations);
-const mockListUsers = vi.mocked(listUsers);
 const mockGetRfpById = vi.mocked(getRfpById);
-const mockUseCurrentUser = vi.mocked(useCurrentUser);
-
-const organisations: Organisation[] = [{ id: 'o1', name: 'Ministry of Health' }];
-const users: User[] = [{ id: 'u1', email: 'amara@example.com', fullName: 'Amara Chen', role: 'Expat' }];
 
 const baseProposal: Proposal = {
   id: 'p1',
@@ -45,7 +33,9 @@ const baseProposal: Proposal = {
   status: 'Submitted',
   visibility: 'Public',
   authorId: 'u1',
+  authorName: 'Amara Chen',
   organisationId: 'o1',
+  organisationName: 'Ministry of Health',
 };
 
 const cfeois: Cfeoi[] = [
@@ -67,17 +57,9 @@ const eois: Eoi[] = [
 function renderPage(proposal: Proposal, initialEntries = ['/proposals/p1']) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   mockGetProposalById.mockResolvedValue(proposal);
-  mockListOrganisations.mockResolvedValue(organisations);
-  mockListUsers.mockResolvedValue(users);
   mockListCfeois.mockResolvedValue(cfeois);
   mockListEoisByCfeoi.mockResolvedValue(eois);
   mockGetRfpById.mockResolvedValue({ id: 'rfp1', title: 'Rural Clinics Modernisation' } as Rfp);
-  mockUseCurrentUser.mockReturnValue({
-    user: { id: 'staff-1', email: 'jonas@example.com', fullName: 'Jonas Weber', role: 'SuperAdmin' },
-    isLoading: false,
-    error: null,
-    isNotFound: false,
-  });
   return render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={initialEntries}>

--- a/frontend/staff/src/pages/app/ProposalDetailPage.tsx
+++ b/frontend/staff/src/pages/app/ProposalDetailPage.tsx
@@ -5,11 +5,8 @@ import { deleteProposal, getProposalById, updateProposalStatus } from '../../api
 import { listCfeois } from '../../api/cfeois';
 import { listEoisByCfeoi } from '../../api/eois';
 import { getErrorMessage } from '../../api/errors';
-import { listOrganisations } from '../../api/organisations';
-import { listUsers } from '../../api/users';
 import { getRfpById } from '../../api/rfps';
-import { useCurrentUser } from '../../hooks/useCurrentUser';
-import { isAdminRole, type ProposalStatus } from '../../types';
+import type { ProposalStatus } from '../../types';
 import StatusBadge from '../../components/StatusBadge';
 import Modal from '../../components/Modal';
 import LoadingSpinner from '../../components/LoadingSpinner';
@@ -48,8 +45,6 @@ export default function ProposalDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { user } = useCurrentUser();
-  const isAdmin = !!user && isAdminRole(user.role);
 
   const [modal, setModal] = useState<ModalKind>(null);
   const [deleteChecked, setDeleteChecked] = useState(false);
@@ -59,9 +54,6 @@ export default function ProposalDetailPage() {
     isLoading,
     isError,
   } = useQuery({ queryKey: ['proposals', id], queryFn: () => getProposalById(id!) });
-
-  const { data: organisations } = useQuery({ queryKey: ['organisations'], queryFn: listOrganisations });
-  const { data: users } = useQuery({ queryKey: ['users'], queryFn: listUsers, enabled: isAdmin });
 
   const { data: rfp } = useQuery({
     queryKey: ['rfps', proposal?.rfpId],
@@ -119,9 +111,6 @@ export default function ProposalDetailPage() {
       </div>
     );
   }
-
-  const org = organisations?.find((o) => o.id === proposal.organisationId);
-  const author = users?.find((u) => u.id === proposal.authorId);
 
   return (
     <div className="max-w-[1120px] mx-auto px-6 py-8 pb-16">
@@ -198,11 +187,11 @@ export default function ProposalDetailPage() {
             <h3 className="text-xs font-semibold text-neutral-500 uppercase tracking-wide mb-3">Submitted by</h3>
             <div className="flex items-center gap-2.5">
               <span className="w-9 h-9 rounded-full bg-brand-100 text-brand-700 flex items-center justify-center text-sm font-semibold">
-                {(author?.fullName ?? '?').slice(0, 1).toUpperCase()}
+                {proposal.authorName.slice(0, 1).toUpperCase()}
               </span>
               <div>
-                <div className="text-sm font-medium text-neutral-900">{author?.fullName ?? '—'}</div>
-                <div className="text-xs text-neutral-500">{org?.name ?? '—'}</div>
+                <div className="text-sm font-medium text-neutral-900">{proposal.authorName}</div>
+                <div className="text-xs text-neutral-500">{proposal.organisationName}</div>
               </div>
             </div>
           </div>

--- a/frontend/staff/src/pages/app/ProposalsPage.test.tsx
+++ b/frontend/staff/src/pages/app/ProposalsPage.test.tsx
@@ -4,36 +4,61 @@ import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import ProposalsPage from './ProposalsPage';
 import { listProposals } from '../../api/proposals';
-import { listOrganisations } from '../../api/organisations';
-import { listUsers } from '../../api/users';
-import { useCurrentUser } from '../../hooks/useCurrentUser';
-import type { Organisation, Proposal, User } from '../../types';
+import type { Proposal } from '../../types';
 
 vi.mock('../../api/proposals', () => ({ listProposals: vi.fn() }));
-vi.mock('../../api/organisations', () => ({ listOrganisations: vi.fn() }));
-vi.mock('../../api/users', () => ({ listUsers: vi.fn() }));
-vi.mock('../../hooks/useCurrentUser', () => ({ useCurrentUser: vi.fn() }));
 
 const mockListProposals = vi.mocked(listProposals);
-const mockListOrganisations = vi.mocked(listOrganisations);
-const mockListUsers = vi.mocked(listUsers);
-const mockUseCurrentUser = vi.mocked(useCurrentUser);
 
 const proposals: Proposal[] = [
-  { id: '1', title: 'Community Health Outreach Expansion', shortDescription: '', longDescription: '', status: 'Submitted', visibility: 'Public', authorId: 'u1', organisationId: 'o1' },
-  { id: '2', title: 'Youth Coding Bootcamp', shortDescription: '', longDescription: '', status: 'Submitted', visibility: 'Private', authorId: 'u2', organisationId: 'o2' },
-  { id: '3', title: 'Diaspora Mentorship Network', shortDescription: '', longDescription: '', status: 'UnderReview', visibility: 'Shared', authorId: 'u1', organisationId: 'o2' },
-  { id: '4', title: 'Digital Literacy for Elders', shortDescription: '', longDescription: '', status: 'Approved', visibility: 'Public', authorId: 'u1', organisationId: 'o1' },
-];
-
-const organisations: Organisation[] = [
-  { id: 'o1', name: 'Ministry of Health' },
-  { id: 'o2', name: 'Ministry of Education' },
-];
-
-const users: User[] = [
-  { id: 'u1', email: 'amara@example.com', fullName: 'Amara Chen', role: 'Staff' },
-  { id: 'u2', email: 'sara@example.com', fullName: 'Sara Osei', role: 'Staff' },
+  {
+    id: '1',
+    title: 'Community Health Outreach Expansion',
+    shortDescription: '',
+    longDescription: '',
+    status: 'Submitted',
+    visibility: 'Public',
+    authorId: 'u1',
+    authorName: 'Amara Chen',
+    organisationId: 'o1',
+    organisationName: 'Ministry of Health',
+  },
+  {
+    id: '2',
+    title: 'Youth Coding Bootcamp',
+    shortDescription: '',
+    longDescription: '',
+    status: 'Submitted',
+    visibility: 'Private',
+    authorId: 'u2',
+    authorName: 'Sara Osei',
+    organisationId: 'o2',
+    organisationName: 'Ministry of Education',
+  },
+  {
+    id: '3',
+    title: 'Diaspora Mentorship Network',
+    shortDescription: '',
+    longDescription: '',
+    status: 'UnderReview',
+    visibility: 'Shared',
+    authorId: 'u1',
+    authorName: 'Amara Chen',
+    organisationId: 'o2',
+    organisationName: 'Ministry of Education',
+  },
+  {
+    id: '4',
+    title: 'Digital Literacy for Elders',
+    shortDescription: '',
+    longDescription: '',
+    status: 'Approved',
+    visibility: 'Public',
+    authorId: 'u1',
+    authorName: 'Amara Chen',
+    organisationId: 'o1',
+    organisationName: 'Ministry of Health',
+  },
 ];
 
 function renderPage(initialEntries = ['/proposals']) {
@@ -50,14 +75,6 @@ function renderPage(initialEntries = ['/proposals']) {
 beforeEach(() => {
   vi.clearAllMocks();
   mockListProposals.mockResolvedValue(proposals);
-  mockListOrganisations.mockResolvedValue(organisations);
-  mockListUsers.mockResolvedValue(users);
-  mockUseCurrentUser.mockReturnValue({
-    user: { id: 'staff-1', email: 'jonas@example.com', fullName: 'Jonas Weber', role: 'SuperAdmin' },
-    isLoading: false,
-    error: null,
-    isNotFound: false,
-  });
 });
 
 describe('ProposalsPage', () => {
@@ -67,8 +84,8 @@ describe('ProposalsPage', () => {
     expect(await screen.findByText('Community Health Outreach Expansion')).toBeInTheDocument();
     expect(screen.getByText('Youth Coding Bootcamp')).toBeInTheDocument();
     expect(screen.queryByText('Diaspora Mentorship Network')).not.toBeInTheDocument();
-    expect(screen.getByText('Amara Chen')).toBeInTheDocument();
-    expect(screen.getByText('Ministry of Health')).toBeInTheDocument();
+    expect(screen.getAllByText('Amara Chen').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Ministry of Health').length).toBeGreaterThan(0);
   });
 
   it('respects a status query param and switches tabs on click', async () => {
@@ -82,21 +99,6 @@ describe('ProposalsPage', () => {
     expect(
       screen.getByText(/Staff read-access spans every proposal regardless of visibility/),
     ).toBeInTheDocument();
-  });
-
-  it('falls back to a dash for the author when the user list is unavailable', async () => {
-    mockUseCurrentUser.mockReturnValue({
-      user: { id: 'staff-1', email: 'jonas@example.com', fullName: 'Jonas Weber', role: 'Staff' },
-      isLoading: false,
-      error: null,
-      isNotFound: false,
-    });
-    renderPage();
-
-    await screen.findByText('Community Health Outreach Expansion');
-    expect(mockListUsers).not.toHaveBeenCalled();
-    const dashes = screen.getAllByText('—');
-    expect(dashes.length).toBeGreaterThan(0);
   });
 
   it('shows an empty state when a status tab has no proposals', async () => {

--- a/frontend/staff/src/pages/app/ProposalsPage.tsx
+++ b/frontend/staff/src/pages/app/ProposalsPage.tsx
@@ -2,10 +2,7 @@ import { useMemo } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { listProposals } from '../../api/proposals';
-import { listOrganisations } from '../../api/organisations';
-import { listUsers } from '../../api/users';
-import { useCurrentUser } from '../../hooks/useCurrentUser';
-import { isAdminRole, type ProposalStatus } from '../../types';
+import type { ProposalStatus } from '../../types';
 import StatusBadge from '../../components/StatusBadge';
 import EmptyState from '../../components/EmptyState';
 import LoadingSpinner from '../../components/LoadingSpinner';
@@ -38,8 +35,6 @@ function isQueueTab(value: string | null): value is QueueTab {
 
 export default function ProposalsPage() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const { user } = useCurrentUser();
-  const isAdmin = !!user && isAdminRole(user.role);
 
   const deleted = searchParams.get('deleted') === 'true';
 
@@ -55,18 +50,6 @@ export default function ProposalsPage() {
     isLoading,
     isError,
   } = useQuery({ queryKey: ['proposals'], queryFn: listProposals });
-
-  const { data: orgs } = useQuery({ queryKey: ['organisations'], queryFn: listOrganisations });
-  const { data: users } = useQuery({ queryKey: ['users'], queryFn: listUsers, enabled: isAdmin });
-
-  const orgMap = useMemo(
-    () => Object.fromEntries((orgs ?? []).map((o) => [o.id, o.name])),
-    [orgs],
-  );
-  const authorMap = useMemo(
-    () => Object.fromEntries((users ?? []).map((u) => [u.id, u.fullName])),
-    [users],
-  );
 
   const filtered = useMemo(() => {
     if (activeTab === 'All') return proposals ?? [];
@@ -153,8 +136,8 @@ export default function ProposalsPage() {
                   className="grid grid-cols-[2.2fr_1.3fr_1.3fr_0.9fr_0.9fr_24px] gap-3 px-5 py-4 border-b border-neutral-200 last:border-b-0 items-center hover:bg-neutral-50 transition-colors"
                 >
                   <span className="text-sm font-medium text-neutral-900">{proposal.title}</span>
-                  <span className="text-sm text-neutral-500">{authorMap[proposal.authorId] ?? '—'}</span>
-                  <span className="text-sm text-neutral-500">{orgMap[proposal.organisationId] ?? '—'}</span>
+                  <span className="text-sm text-neutral-500">{proposal.authorName}</span>
+                  <span className="text-sm text-neutral-500">{proposal.organisationName}</span>
                   <StatusBadge type="proposal" status={proposal.status} />
                   <StatusBadge type="visibility" status={proposal.visibility} />
                   <span className="text-neutral-300">›</span>

--- a/frontend/staff/src/pages/app/RfpDetailPage.test.tsx
+++ b/frontend/staff/src/pages/app/RfpDetailPage.test.tsx
@@ -4,22 +4,17 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import RfpDetailPage from './RfpDetailPage';
 import { deleteRfp, getRfpById, updateRfpStatus } from '../../api/rfps';
-import { listOrganisations } from '../../api/organisations';
-import type { Organisation, Rfp } from '../../types';
+import type { Rfp } from '../../types';
 
 vi.mock('../../api/rfps', () => ({
   getRfpById: vi.fn(),
   updateRfpStatus: vi.fn(),
   deleteRfp: vi.fn(),
 }));
-vi.mock('../../api/organisations', () => ({ listOrganisations: vi.fn() }));
 
 const mockGetRfpById = vi.mocked(getRfpById);
 const mockUpdateRfpStatus = vi.mocked(updateRfpStatus);
 const mockDeleteRfp = vi.mocked(deleteRfp);
-const mockListOrganisations = vi.mocked(listOrganisations);
-
-const organisations: Organisation[] = [{ id: 'o1', name: 'Ministry of Digital Economy' }];
 
 const baseRfp: Rfp = {
   id: 'rfp-1',
@@ -28,14 +23,15 @@ const baseRfp: Rfp = {
   longDescription: 'A long description.',
   status: 'Draft',
   organisationId: 'o1',
+  organisationName: 'Ministry of Digital Economy',
   authorId: 'u1',
+  authorName: 'Amara Chen',
   tags: 'identity',
 };
 
 function renderPage(rfp: Rfp, initialEntries = ['/rfps/rfp-1']) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   mockGetRfpById.mockResolvedValue(rfp);
-  mockListOrganisations.mockResolvedValue(organisations);
   return render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={initialEntries}>

--- a/frontend/staff/src/pages/app/RfpDetailPage.tsx
+++ b/frontend/staff/src/pages/app/RfpDetailPage.tsx
@@ -3,7 +3,6 @@ import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { deleteRfp, getRfpById, updateRfpStatus } from '../../api/rfps';
 import { getErrorMessage } from '../../api/errors';
-import { listOrganisations } from '../../api/organisations';
 import type { RfpStatus } from '../../types';
 import StatusBadge from '../../components/StatusBadge';
 import Modal from '../../components/Modal';
@@ -58,8 +57,6 @@ export default function RfpDetailPage() {
     isError,
   } = useQuery({ queryKey: ['rfps', id], queryFn: () => getRfpById(id!) });
 
-  const { data: organisations } = useQuery({ queryKey: ['organisations'], queryFn: listOrganisations });
-
   const statusMutation = useMutation({
     mutationFn: (status: RfpStatus) => updateRfpStatus(id!, status),
     onSuccess: () => {
@@ -98,8 +95,7 @@ export default function RfpDetailPage() {
     );
   }
 
-  const org = organisations?.find((o) => o.id === rfp.organisationId);
-  const subtitle = [org?.name, rfp.tags].filter(Boolean).join(' · ');
+  const subtitle = [rfp.organisationName, rfp.tags].filter(Boolean).join(' · ');
   const publicUrl = `${PORTAL_URL}/rfps/${rfp.id}`;
 
   const deleteDescription =

--- a/frontend/staff/src/pages/app/RfpEditorPage.test.tsx
+++ b/frontend/staff/src/pages/app/RfpEditorPage.test.tsx
@@ -31,7 +31,9 @@ const draftRfp: Rfp = {
   longDescription: 'A long description.',
   status: 'Draft',
   organisationId: 'o1',
+  organisationName: 'Ministry of Digital Economy',
   authorId: 'u1',
+  authorName: 'Amara Chen',
   tags: 'identity',
 };
 

--- a/frontend/staff/src/pages/app/RfpsPage.test.tsx
+++ b/frontend/staff/src/pages/app/RfpsPage.test.tsx
@@ -4,25 +4,17 @@ import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import RfpsPage from './RfpsPage';
 import { listRfps } from '../../api/rfps';
-import { listOrganisations } from '../../api/organisations';
-import type { Organisation, Rfp } from '../../types';
+import type { Rfp } from '../../types';
 
 vi.mock('../../api/rfps', () => ({ listRfps: vi.fn() }));
-vi.mock('../../api/organisations', () => ({ listOrganisations: vi.fn() }));
 
 const mockListRfps = vi.mocked(listRfps);
-const mockListOrganisations = vi.mocked(listOrganisations);
 
 const rfps: Rfp[] = [
-  { id: '1', title: 'Digital ID Verification', shortDescription: '', longDescription: '', status: 'Draft', organisationId: 'o1', authorId: 'u1', tags: 'identity' },
-  { id: '2', title: 'Remote Voting Portal', shortDescription: '', longDescription: '', status: 'Draft', organisationId: 'o2', authorId: 'u1' },
-  { id: '3', title: 'Consular Records', shortDescription: '', longDescription: '', status: 'Approved', organisationId: 'o1', authorId: 'u1' },
-  { id: '4', title: 'Diaspora Outreach', shortDescription: '', longDescription: '', status: 'Published', organisationId: 'o1', authorId: 'u1' },
-];
-
-const organisations: Organisation[] = [
-  { id: 'o1', name: 'Ministry of Digital Economy' },
-  { id: 'o2', name: 'Diaspora Engagement Bureau' },
+  { id: '1', title: 'Digital ID Verification', shortDescription: '', longDescription: '', status: 'Draft', organisationId: 'o1', organisationName: 'Ministry of Digital Economy', authorId: 'u1', authorName: 'Amara Chen', tags: 'identity' },
+  { id: '2', title: 'Remote Voting Portal', shortDescription: '', longDescription: '', status: 'Draft', organisationId: 'o2', organisationName: 'Diaspora Engagement Bureau', authorId: 'u1', authorName: 'Amara Chen' },
+  { id: '3', title: 'Consular Records', shortDescription: '', longDescription: '', status: 'Approved', organisationId: 'o1', organisationName: 'Ministry of Digital Economy', authorId: 'u1', authorName: 'Amara Chen' },
+  { id: '4', title: 'Diaspora Outreach', shortDescription: '', longDescription: '', status: 'Published', organisationId: 'o1', organisationName: 'Ministry of Digital Economy', authorId: 'u1', authorName: 'Amara Chen' },
 ];
 
 function renderPage(initialEntries = ['/rfps']) {
@@ -38,7 +30,6 @@ function renderPage(initialEntries = ['/rfps']) {
 
 beforeEach(() => {
   mockListRfps.mockResolvedValue(rfps);
-  mockListOrganisations.mockResolvedValue(organisations);
 });
 
 describe('RfpsPage', () => {

--- a/frontend/staff/src/pages/app/RfpsPage.tsx
+++ b/frontend/staff/src/pages/app/RfpsPage.tsx
@@ -2,7 +2,6 @@ import { useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { listRfps } from '../../api/rfps';
-import { listOrganisations } from '../../api/organisations';
 import type { RfpStatus } from '../../types';
 import StatusBadge from '../../components/StatusBadge';
 import EmptyState from '../../components/EmptyState';
@@ -45,13 +44,6 @@ export default function RfpsPage() {
     isError,
   } = useQuery({ queryKey: ['rfps'], queryFn: listRfps });
 
-  const { data: orgs } = useQuery({ queryKey: ['organisations'], queryFn: listOrganisations });
-
-  const orgMap = useMemo(
-    () => Object.fromEntries((orgs ?? []).map((o) => [o.id, o.name])),
-    [orgs],
-  );
-
   const counts = useMemo(() => {
     const result: Record<RfpStatus, number> = { Draft: 0, Approved: 0, Published: 0 };
     for (const rfp of rfps ?? []) result[rfp.status]++;
@@ -65,11 +57,11 @@ export default function RfpsPage() {
       if (!query) return true;
       return (
         rfp.title.toLowerCase().includes(query) ||
-        (orgMap[rfp.organisationId] ?? '').toLowerCase().includes(query) ||
+        rfp.organisationName.toLowerCase().includes(query) ||
         (rfp.tags ?? '').toLowerCase().includes(query)
       );
     });
-  }, [rfps, activeTab, search, orgMap]);
+  }, [rfps, activeTab, search]);
 
   return (
     <div className="max-w-[1080px] mx-auto px-6 py-8 pb-16">
@@ -154,7 +146,7 @@ export default function RfpsPage() {
                     <div className="text-sm font-medium text-neutral-900 mb-0.5">{rfp.title}</div>
                     {rfp.tags && <div className="text-xs text-neutral-400">{rfp.tags}</div>}
                   </div>
-                  <span className="text-sm text-neutral-500">{orgMap[rfp.organisationId] ?? '—'}</span>
+                  <span className="text-sm text-neutral-500">{rfp.organisationName}</span>
                   <StatusBadge type="rfp" status={rfp.status} />
                 </Link>
               ))}

--- a/frontend/staff/src/types/index.ts
+++ b/frontend/staff/src/types/index.ts
@@ -39,7 +39,9 @@ export interface Rfp {
   longDescription: string;
   status: RfpStatus;
   organisationId: string;
+  organisationName: string;
   authorId: string;
+  authorName: string;
   tags?: string;
 }
 
@@ -61,7 +63,9 @@ export interface Proposal {
   status: ProposalStatus;
   visibility: ProposalVisibility;
   authorId: string;
+  authorName: string;
   organisationId: string;
+  organisationName: string;
   rfpId?: string;
 }
 

--- a/src/Herit.Application/Features/Proposal/Dtos/ProposalResponseDto.cs
+++ b/src/Herit.Application/Features/Proposal/Dtos/ProposalResponseDto.cs
@@ -1,0 +1,39 @@
+using Herit.Domain.Enums;
+using ProposalEntity = Herit.Domain.Entities.Proposal;
+using UserEntity = Herit.Domain.Entities.User;
+using OrganisationEntity = Herit.Domain.Entities.Organisation;
+
+namespace Herit.Application.Features.Proposal.Dtos;
+
+/// <summary>
+/// Proposal list/detail response shape. Author and organisation names are resolved server-side
+/// and always included — both are on the record the caller is already authorized to read
+/// (list/detail endpoints are anonymous-readable), so no role-gating is needed (see issue #309).
+/// </summary>
+public record ProposalResponseDto(
+    Guid Id,
+    string Title,
+    string ShortDescription,
+    Guid AuthorId,
+    string AuthorName,
+    Guid OrganisationId,
+    string OrganisationName,
+    string LongDescription,
+    ProposalStatus Status,
+    ProposalVisibility Visibility,
+    Guid? RfpId)
+{
+    public static ProposalResponseDto From(ProposalEntity proposal, UserEntity? author, OrganisationEntity? organisation)
+        => new(
+            proposal.Id,
+            proposal.Title,
+            proposal.ShortDescription,
+            proposal.AuthorId,
+            author?.FullName ?? "Unknown author",
+            proposal.OrganisationId,
+            organisation?.Name ?? "Unknown organisation",
+            proposal.LongDescription,
+            proposal.Status,
+            proposal.Visibility,
+            proposal.RfpId);
+}

--- a/src/Herit.Application/Features/Proposal/Queries/GetProposalById/GetProposalByIdQuery.cs
+++ b/src/Herit.Application/Features/Proposal/Queries/GetProposalById/GetProposalByIdQuery.cs
@@ -1,25 +1,37 @@
 using Herit.Application.Exceptions;
+using Herit.Application.Features.Proposal.Dtos;
 using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.Proposal.Queries.GetProposalById;
 
-public record GetProposalByIdQuery(Guid Id) : IRequest<Herit.Domain.Entities.Proposal>;
+public record GetProposalByIdQuery(Guid Id) : IRequest<ProposalResponseDto>;
 
-public class GetProposalByIdQueryHandler : IRequestHandler<GetProposalByIdQuery, Herit.Domain.Entities.Proposal>
+public class GetProposalByIdQueryHandler : IRequestHandler<GetProposalByIdQuery, ProposalResponseDto>
 {
     private readonly IProposalRepository _proposalRepository;
+    private readonly IUserRepository _userRepository;
+    private readonly IOrganisationRepository _organisationRepository;
 
-    public GetProposalByIdQueryHandler(IProposalRepository proposalRepository)
+    public GetProposalByIdQueryHandler(
+        IProposalRepository proposalRepository,
+        IUserRepository userRepository,
+        IOrganisationRepository organisationRepository)
     {
         _proposalRepository = proposalRepository;
+        _userRepository = userRepository;
+        _organisationRepository = organisationRepository;
     }
 
-    public async Task<Herit.Domain.Entities.Proposal> Handle(GetProposalByIdQuery request, CancellationToken cancellationToken)
+    public async Task<ProposalResponseDto> Handle(GetProposalByIdQuery request, CancellationToken cancellationToken)
     {
         var proposal = await _proposalRepository.GetByIdAsync(request.Id, cancellationToken);
         if (proposal is null)
             throw new NotFoundException($"Proposal '{request.Id}' was not found.");
-        return proposal;
+
+        var author = await _userRepository.GetByIdAsync(proposal.AuthorId, cancellationToken);
+        var organisation = await _organisationRepository.GetByIdAsync(proposal.OrganisationId, cancellationToken);
+
+        return ProposalResponseDto.From(proposal, author, organisation);
     }
 }

--- a/src/Herit.Application/Features/Proposal/Queries/ListProposals/ListProposalsQuery.cs
+++ b/src/Herit.Application/Features/Proposal/Queries/ListProposals/ListProposalsQuery.cs
@@ -1,23 +1,32 @@
 using Herit.Application.Authorization;
+using Herit.Application.Features.Proposal.Dtos;
 using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.Proposal.Queries.ListProposals;
 
-public record ListProposalsQuery(Guid? RfpId = null) : IRequest<IEnumerable<Herit.Domain.Entities.Proposal>>;
+public record ListProposalsQuery(Guid? RfpId = null) : IRequest<IEnumerable<ProposalResponseDto>>;
 
-public class ListProposalsQueryHandler : IRequestHandler<ListProposalsQuery, IEnumerable<Herit.Domain.Entities.Proposal>>
+public class ListProposalsQueryHandler : IRequestHandler<ListProposalsQuery, IEnumerable<ProposalResponseDto>>
 {
     private readonly IProposalRepository _proposalRepository;
+    private readonly IUserRepository _userRepository;
+    private readonly IOrganisationRepository _organisationRepository;
     private readonly ICurrentUserService _currentUserService;
 
-    public ListProposalsQueryHandler(IProposalRepository proposalRepository, ICurrentUserService currentUserService)
+    public ListProposalsQueryHandler(
+        IProposalRepository proposalRepository,
+        IUserRepository userRepository,
+        IOrganisationRepository organisationRepository,
+        ICurrentUserService currentUserService)
     {
         _proposalRepository = proposalRepository;
+        _userRepository = userRepository;
+        _organisationRepository = organisationRepository;
         _currentUserService = currentUserService;
     }
 
-    public async Task<IEnumerable<Herit.Domain.Entities.Proposal>> Handle(ListProposalsQuery request, CancellationToken cancellationToken)
+    public async Task<IEnumerable<ProposalResponseDto>> Handle(ListProposalsQuery request, CancellationToken cancellationToken)
     {
         var user = await _currentUserService.GetCurrentUserOrNullAsync(cancellationToken);
         var proposals = await _proposalRepository.ListAsync(cancellationToken);
@@ -27,6 +36,15 @@ public class ListProposalsQueryHandler : IRequestHandler<ListProposalsQuery, IEn
         if (request.RfpId is not null)
             visible = visible.Where(p => p.RfpId == request.RfpId);
 
-        return visible.ToList();
+        var visibleList = visible.ToList();
+
+        var authors = (await _userRepository.ListByIdsAsync(visibleList.Select(p => p.AuthorId).Distinct(), cancellationToken))
+            .ToDictionary(u => u.Id);
+        var organisations = (await _organisationRepository.ListAsync(cancellationToken))
+            .ToDictionary(o => o.Id);
+
+        return visibleList
+            .Select(p => ProposalResponseDto.From(p, authors.GetValueOrDefault(p.AuthorId), organisations.GetValueOrDefault(p.OrganisationId)))
+            .ToList();
     }
 }

--- a/src/Herit.Application/Features/Rfp/Dtos/RfpResponseDto.cs
+++ b/src/Herit.Application/Features/Rfp/Dtos/RfpResponseDto.cs
@@ -1,0 +1,37 @@
+using Herit.Domain.Enums;
+using RfpEntity = Herit.Domain.Entities.Rfp;
+using UserEntity = Herit.Domain.Entities.User;
+using OrganisationEntity = Herit.Domain.Entities.Organisation;
+
+namespace Herit.Application.Features.Rfp.Dtos;
+
+/// <summary>
+/// RFP list/detail response shape. Author and organisation names are resolved server-side
+/// and always included — both are on the record the caller is already authorized to read
+/// (list/detail endpoints are anonymous-readable), so no role-gating is needed (see issue #309).
+/// </summary>
+public record RfpResponseDto(
+    Guid Id,
+    string Title,
+    string ShortDescription,
+    Guid AuthorId,
+    string AuthorName,
+    Guid OrganisationId,
+    string OrganisationName,
+    string LongDescription,
+    RfpStatus Status,
+    string? Tags)
+{
+    public static RfpResponseDto From(RfpEntity rfp, UserEntity? author, OrganisationEntity? organisation)
+        => new(
+            rfp.Id,
+            rfp.Title,
+            rfp.ShortDescription,
+            rfp.AuthorId,
+            author?.FullName ?? "Unknown author",
+            rfp.OrganisationId,
+            organisation?.Name ?? "Unknown organisation",
+            rfp.LongDescription,
+            rfp.Status,
+            rfp.Tags);
+}

--- a/src/Herit.Application/Features/Rfp/Queries/GetRfpById/GetRfpByIdQuery.cs
+++ b/src/Herit.Application/Features/Rfp/Queries/GetRfpById/GetRfpByIdQuery.cs
@@ -1,25 +1,37 @@
 using Herit.Application.Exceptions;
+using Herit.Application.Features.Rfp.Dtos;
 using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.Rfp.Queries.GetRfpById;
 
-public record GetRfpByIdQuery(Guid Id) : IRequest<Herit.Domain.Entities.Rfp>;
+public record GetRfpByIdQuery(Guid Id) : IRequest<RfpResponseDto>;
 
-public class GetRfpByIdQueryHandler : IRequestHandler<GetRfpByIdQuery, Herit.Domain.Entities.Rfp>
+public class GetRfpByIdQueryHandler : IRequestHandler<GetRfpByIdQuery, RfpResponseDto>
 {
     private readonly IRfpRepository _repository;
+    private readonly IUserRepository _userRepository;
+    private readonly IOrganisationRepository _organisationRepository;
 
-    public GetRfpByIdQueryHandler(IRfpRepository repository)
+    public GetRfpByIdQueryHandler(
+        IRfpRepository repository,
+        IUserRepository userRepository,
+        IOrganisationRepository organisationRepository)
     {
         _repository = repository;
+        _userRepository = userRepository;
+        _organisationRepository = organisationRepository;
     }
 
-    public async Task<Herit.Domain.Entities.Rfp> Handle(GetRfpByIdQuery request, CancellationToken cancellationToken)
+    public async Task<RfpResponseDto> Handle(GetRfpByIdQuery request, CancellationToken cancellationToken)
     {
         var rfp = await _repository.GetByIdAsync(request.Id, cancellationToken);
         if (rfp is null)
             throw new NotFoundException($"Rfp '{request.Id}' was not found.");
-        return rfp;
+
+        var author = await _userRepository.GetByIdAsync(rfp.AuthorId, cancellationToken);
+        var organisation = await _organisationRepository.GetByIdAsync(rfp.OrganisationId, cancellationToken);
+
+        return RfpResponseDto.From(rfp, author, organisation);
     }
 }

--- a/src/Herit.Application/Features/Rfp/Queries/ListRfps/ListRfpsQuery.cs
+++ b/src/Herit.Application/Features/Rfp/Queries/ListRfps/ListRfpsQuery.cs
@@ -1,27 +1,45 @@
 using Herit.Application.Authorization;
+using Herit.Application.Features.Rfp.Dtos;
 using Herit.Application.Interfaces;
 using MediatR;
 
 namespace Herit.Application.Features.Rfp.Queries.ListRfps;
 
-public record ListRfpsQuery() : IRequest<IEnumerable<Herit.Domain.Entities.Rfp>>;
+public record ListRfpsQuery() : IRequest<IEnumerable<RfpResponseDto>>;
 
-public class ListRfpsQueryHandler : IRequestHandler<ListRfpsQuery, IEnumerable<Herit.Domain.Entities.Rfp>>
+public class ListRfpsQueryHandler : IRequestHandler<ListRfpsQuery, IEnumerable<RfpResponseDto>>
 {
     private readonly IRfpRepository _repository;
+    private readonly IUserRepository _userRepository;
+    private readonly IOrganisationRepository _organisationRepository;
     private readonly ICurrentUserService _currentUserService;
 
-    public ListRfpsQueryHandler(IRfpRepository repository, ICurrentUserService currentUserService)
+    public ListRfpsQueryHandler(
+        IRfpRepository repository,
+        IUserRepository userRepository,
+        IOrganisationRepository organisationRepository,
+        ICurrentUserService currentUserService)
     {
         _repository = repository;
+        _userRepository = userRepository;
+        _organisationRepository = organisationRepository;
         _currentUserService = currentUserService;
     }
 
-    public async Task<IEnumerable<Herit.Domain.Entities.Rfp>> Handle(ListRfpsQuery request, CancellationToken cancellationToken)
+    public async Task<IEnumerable<RfpResponseDto>> Handle(ListRfpsQuery request, CancellationToken cancellationToken)
     {
         var user = await _currentUserService.GetCurrentUserOrNullAsync(cancellationToken);
         var rfps = await _repository.ListAsync(cancellationToken);
 
-        return rfps.Where(r => VisibilityPolicy.CanViewRfp(r, user)).ToList();
+        var visible = rfps.Where(r => VisibilityPolicy.CanViewRfp(r, user)).ToList();
+
+        var authors = (await _userRepository.ListByIdsAsync(visible.Select(r => r.AuthorId).Distinct(), cancellationToken))
+            .ToDictionary(u => u.Id);
+        var organisations = (await _organisationRepository.ListAsync(cancellationToken))
+            .ToDictionary(o => o.Id);
+
+        return visible
+            .Select(r => RfpResponseDto.From(r, authors.GetValueOrDefault(r.AuthorId), organisations.GetValueOrDefault(r.OrganisationId)))
+            .ToList();
     }
 }

--- a/tests/Herit.Application.Tests/Features/Proposal/Queries/GetProposalByIdQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Proposal/Queries/GetProposalByIdQueryHandlerTests.cs
@@ -2,31 +2,61 @@ using Herit.Application.Exceptions;
 using Herit.Application.Features.Proposal.Queries.GetProposalById;
 using Herit.Application.Interfaces;
 using NSubstitute;
+using OrganisationEntity = Herit.Domain.Entities.Organisation;
 using ProposalEntity = Herit.Domain.Entities.Proposal;
+using UserEntity = Herit.Domain.Entities.User;
+using Herit.Domain.Enums;
 
 namespace Herit.Application.Tests.Features.Proposal.Queries;
 
 public class GetProposalByIdQueryHandlerTests
 {
     private readonly IProposalRepository _proposalRepository = Substitute.For<IProposalRepository>();
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly IOrganisationRepository _organisationRepository = Substitute.For<IOrganisationRepository>();
     private readonly GetProposalByIdQueryHandler _handler;
 
     public GetProposalByIdQueryHandlerTests()
     {
-        _handler = new GetProposalByIdQueryHandler(_proposalRepository);
+        _handler = new GetProposalByIdQueryHandler(_proposalRepository, _userRepository, _organisationRepository);
     }
 
     [Fact]
-    public async Task Handle_ProposalFound_ReturnsProposal()
+    public async Task Handle_ProposalFound_ReturnsProposalWithAuthorAndOrganisationName()
     {
         var proposalId = Guid.NewGuid();
-        var proposal = ProposalEntity.Create(proposalId, "Title", "Short", Guid.NewGuid(), Guid.NewGuid(), "Long");
+        var authorId = Guid.NewGuid();
+        var organisationId = Guid.NewGuid();
+        var proposal = ProposalEntity.Create(proposalId, "Title", "Short", authorId, organisationId, "Long");
+        var author = UserEntity.Create(authorId, "ext-1", "author@example.com", "Author Name", UserRole.Expat);
+        var organisation = OrganisationEntity.Create(organisationId, "Acme Org");
+
         _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>()).Returns(proposal);
+        _userRepository.GetByIdAsync(authorId, Arg.Any<CancellationToken>()).Returns(author);
+        _organisationRepository.GetByIdAsync(organisationId, Arg.Any<CancellationToken>()).Returns(organisation);
 
         var result = await _handler.Handle(new GetProposalByIdQuery(proposalId), CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(proposalId, result.Id);
+        Assert.Equal("Author Name", result.AuthorName);
+        Assert.Equal("Acme Org", result.OrganisationName);
+    }
+
+    [Fact]
+    public async Task Handle_AuthorOrOrganisationMissing_FallsBackToPlaceholderNames()
+    {
+        var proposalId = Guid.NewGuid();
+        var proposal = ProposalEntity.Create(proposalId, "Title", "Short", Guid.NewGuid(), Guid.NewGuid(), "Long");
+
+        _proposalRepository.GetByIdAsync(proposalId, Arg.Any<CancellationToken>()).Returns(proposal);
+        _userRepository.GetByIdAsync(proposal.AuthorId, Arg.Any<CancellationToken>()).Returns((UserEntity?)null);
+        _organisationRepository.GetByIdAsync(proposal.OrganisationId, Arg.Any<CancellationToken>()).Returns((OrganisationEntity?)null);
+
+        var result = await _handler.Handle(new GetProposalByIdQuery(proposalId), CancellationToken.None);
+
+        Assert.Equal("Unknown author", result.AuthorName);
+        Assert.Equal("Unknown organisation", result.OrganisationName);
     }
 
     [Fact]

--- a/tests/Herit.Application.Tests/Features/Proposal/Queries/ListProposalsQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Proposal/Queries/ListProposalsQueryHandlerTests.cs
@@ -11,6 +11,8 @@ namespace Herit.Application.Tests.Features.Proposal.Queries;
 public class ListProposalsQueryHandlerTests
 {
     private readonly IProposalRepository _proposalRepository = Substitute.For<IProposalRepository>();
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly IOrganisationRepository _organisationRepository = Substitute.For<IOrganisationRepository>();
     private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
     private readonly ListProposalsQueryHandler _handler;
 
@@ -21,7 +23,7 @@ public class ListProposalsQueryHandlerTests
 
     public ListProposalsQueryHandlerTests()
     {
-        _handler = new ListProposalsQueryHandler(_proposalRepository, _currentUserService);
+        _handler = new ListProposalsQueryHandler(_proposalRepository, _userRepository, _organisationRepository, _currentUserService);
 
         _public = MakeProposal(ProposalVisibility.Public, _ownerId);
         _shared = MakeProposal(ProposalVisibility.Shared, _ownerId);
@@ -29,6 +31,10 @@ public class ListProposalsQueryHandlerTests
 
         _proposalRepository.ListAsync(Arg.Any<CancellationToken>())
             .Returns(new[] { _public, _shared, _privateOwned });
+        _userRepository.ListByIdsAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(Enumerable.Empty<UserEntity>());
+        _organisationRepository.ListAsync(Arg.Any<CancellationToken>())
+            .Returns(Enumerable.Empty<Herit.Domain.Entities.Organisation>());
     }
 
     private static ProposalEntity MakeProposal(ProposalVisibility visibility, Guid authorId)

--- a/tests/Herit.Application.Tests/Features/Rfp/Queries/GetRfpByIdQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Rfp/Queries/GetRfpByIdQueryHandlerTests.cs
@@ -2,31 +2,61 @@ using Herit.Application.Exceptions;
 using Herit.Application.Features.Rfp.Queries.GetRfpById;
 using Herit.Application.Interfaces;
 using NSubstitute;
+using OrganisationEntity = Herit.Domain.Entities.Organisation;
 using RfpEntity = Herit.Domain.Entities.Rfp;
+using UserEntity = Herit.Domain.Entities.User;
+using Herit.Domain.Enums;
 
 namespace Herit.Application.Tests.Features.Rfp.Queries;
 
 public class GetRfpByIdQueryHandlerTests
 {
     private readonly IRfpRepository _repository = Substitute.For<IRfpRepository>();
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly IOrganisationRepository _organisationRepository = Substitute.For<IOrganisationRepository>();
     private readonly GetRfpByIdQueryHandler _handler;
 
     public GetRfpByIdQueryHandlerTests()
     {
-        _handler = new GetRfpByIdQueryHandler(_repository);
+        _handler = new GetRfpByIdQueryHandler(_repository, _userRepository, _organisationRepository);
     }
 
     [Fact]
-    public async Task Handle_WhenRfpExists_ReturnsRfp()
+    public async Task Handle_WhenRfpExists_ReturnsRfpWithAuthorAndOrganisationName()
     {
         var id = Guid.NewGuid();
-        var rfp = RfpEntity.Create(id, "Title", "Short", Guid.NewGuid(), Guid.NewGuid(), "Long");
+        var authorId = Guid.NewGuid();
+        var organisationId = Guid.NewGuid();
+        var rfp = RfpEntity.Create(id, "Title", "Short", authorId, organisationId, "Long");
+        var author = UserEntity.Create(authorId, "ext-1", "author@example.com", "Author Name", UserRole.Staff);
+        var organisation = OrganisationEntity.Create(organisationId, "Acme Org");
+
         _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(rfp);
+        _userRepository.GetByIdAsync(authorId, Arg.Any<CancellationToken>()).Returns(author);
+        _organisationRepository.GetByIdAsync(organisationId, Arg.Any<CancellationToken>()).Returns(organisation);
 
         var result = await _handler.Handle(new GetRfpByIdQuery(id), CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(id, result.Id);
+        Assert.Equal("Author Name", result.AuthorName);
+        Assert.Equal("Acme Org", result.OrganisationName);
+    }
+
+    [Fact]
+    public async Task Handle_AuthorOrOrganisationMissing_FallsBackToPlaceholderNames()
+    {
+        var id = Guid.NewGuid();
+        var rfp = RfpEntity.Create(id, "Title", "Short", Guid.NewGuid(), Guid.NewGuid(), "Long");
+
+        _repository.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(rfp);
+        _userRepository.GetByIdAsync(rfp.AuthorId, Arg.Any<CancellationToken>()).Returns((UserEntity?)null);
+        _organisationRepository.GetByIdAsync(rfp.OrganisationId, Arg.Any<CancellationToken>()).Returns((OrganisationEntity?)null);
+
+        var result = await _handler.Handle(new GetRfpByIdQuery(id), CancellationToken.None);
+
+        Assert.Equal("Unknown author", result.AuthorName);
+        Assert.Equal("Unknown organisation", result.OrganisationName);
     }
 
     [Fact]

--- a/tests/Herit.Application.Tests/Features/Rfp/Queries/ListRfpsQueryHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/Rfp/Queries/ListRfpsQueryHandlerTests.cs
@@ -11,6 +11,8 @@ namespace Herit.Application.Tests.Features.Rfp.Queries;
 public class ListRfpsQueryHandlerTests
 {
     private readonly IRfpRepository _repository = Substitute.For<IRfpRepository>();
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly IOrganisationRepository _organisationRepository = Substitute.For<IOrganisationRepository>();
     private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
     private readonly ListRfpsQueryHandler _handler;
 
@@ -20,7 +22,7 @@ public class ListRfpsQueryHandlerTests
 
     public ListRfpsQueryHandlerTests()
     {
-        _handler = new ListRfpsQueryHandler(_repository, _currentUserService);
+        _handler = new ListRfpsQueryHandler(_repository, _userRepository, _organisationRepository, _currentUserService);
 
         _draft = MakeRfp(RfpStatus.Draft);
         _approved = MakeRfp(RfpStatus.Approved);
@@ -28,6 +30,10 @@ public class ListRfpsQueryHandlerTests
 
         _repository.ListAsync(Arg.Any<CancellationToken>())
             .Returns(new[] { _draft, _approved, _published });
+        _userRepository.ListByIdsAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(Enumerable.Empty<UserEntity>());
+        _organisationRepository.ListAsync(Arg.Any<CancellationToken>())
+            .Returns(Enumerable.Empty<Herit.Domain.Entities.Organisation>());
     }
 
     private static RfpEntity MakeRfp(RfpStatus status)


### PR DESCRIPTION
## Description

The staff review queue (`ProposalsPage`) and detail page resolved author identity via a client-side join against `GET /Users`, an `AdminOrSuperAdmin`-gated endpoint. Plain Staff callers — the primary audience of the review queue — got `—` in the Author column for every proposal, contradicting spec section 2b (author is a required column).

This PR follows the `EoiResponseDto` pattern from #285: `ProposalResponseDto` and `RfpResponseDto` resolve `authorName` and `organisationName` server-side via a join, replacing the raw-entity returns from `ListProposalsQuery`/`GetProposalByIdQuery`/`ListRfpsQuery`/`GetRfpByIdQuery`.

**Field-exposure reasoning:** author name and organisation name are not sensitive — both are on the record the caller is already authorized to read (the Proposals/Rfps list/detail endpoints are `[AllowAnonymous]`) — so no role-gating is needed, unlike the EOI submitter email in #285.

Frontend changes remove the now-redundant client-side joins in the staff app:
- `ProposalsPage` / `ProposalDetailPage`: dropped the `GET /Users` author join and `—` fallback.
- `ProposalsPage` / `ProposalDetailPage` / `RfpsPage` / `RfpDetailPage`: dropped the separate `GET /Organisations` join, now that `organisationName` comes from the same DTO in one pass.

The portal app doesn't currently display author identity anywhere (only uses `authorId` for ownership checks), so no portal UI changes were needed; its `Proposal`/`Rfp` types were still updated to match the new response shape.

## Linked Issue

Closes #309

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- Added/updated DTO-mapping unit tests for all four query handlers (`ListProposalsQueryHandlerTests`, `GetProposalByIdQueryHandlerTests`, `ListRfpsQueryHandlerTests`, `GetRfpByIdQueryHandlerTests`), including fallback-to-placeholder-name cases when the author or organisation record is missing.
- Updated affected staff page tests (`ProposalsPage`, `ProposalDetailPage`, `RfpsPage`, `RfpDetailPage`, plus `DashboardPage`/`EoiListPage`/`RfpEditorPage` fixtures) to assert real names instead of asserting on `listUsers`/`listOrganisations` joins.
- `dotnet build` / `dotnet test` (Release) pass across all four projects.
- Staff and portal frontend `tsc -b && vite build` and `vitest run` both pass.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)