### PR TITLE
Add a Playwright E2E suite for the staff app, including cross-app assertions

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -125,9 +125,74 @@ jobs:
             frontend/portal/e2e/.results
           retention-days: 7
 
+  e2e-staff:
+    runs-on: ubuntu-latest
+    services:
+      mssql:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        env:
+          ACCEPT_EULA: 'Y'
+          MSSQL_SA_PASSWORD: 'HeritE2e!Passw0rd'
+        ports:
+          - 14330:1433
+        options: >-
+          --health-cmd "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'HeritE2e!Passw0rd' -C -Q 'SELECT 1' || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 12
+          --health-start-period 20s
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.x'
+
+      - name: Build API
+        run: dotnet build src/Herit.Api
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: |
+            frontend/portal/package-lock.json
+            frontend/staff/package-lock.json
+
+      # The staff suite serves the portal alongside the staff app for the
+      # cross-app scenarios, so both frontends' dependencies are installed.
+      - name: Install portal dependencies
+        run: npm ci
+        working-directory: frontend/portal
+
+      - name: Install staff dependencies
+        run: npm ci
+        working-directory: frontend/staff
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+        working-directory: frontend/staff
+
+      - name: Run staff E2E suite
+        run: npm run e2e
+        working-directory: frontend/staff
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-staff
+          path: |
+            frontend/staff/e2e/.report
+            frontend/staff/e2e/.results
+          retention-days: 7
+
   cd:
     runs-on: ubuntu-latest
-    needs: [ci, e2e]
+    needs: [ci, e2e, e2e-staff]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     env:
       AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ frontend/**/dist/
 frontend/portal/e2e/.state/
 frontend/portal/e2e/.results/
 frontend/portal/e2e/.report/
+frontend/staff/e2e/.state/
+frontend/staff/e2e/.results/
+frontend/staff/e2e/.report/
 
 # Claude Code task/design working files (kept local, not tracked)
 docs/frontend/portal/designs/flow3c-implementation-tasks.md

--- a/docs/frontend/staff/e2e-testing.md
+++ b/docs/frontend/staff/e2e-testing.md
@@ -1,0 +1,109 @@
+# Staff E2E testing (Playwright)
+
+The Playwright suite in `frontend/staff/e2e/` exercises the staff app against the real
+stack — API, SQL Server, and the Vite-served SPA — and, because several behaviours span
+both apps, it serves the **expat portal alongside the staff app** so the cross-app
+scenarios can drive an expat or anonymous portal session against the same database.
+
+## What is covered
+
+| Spec | Scenario |
+|---|---|
+| `auth-gate.spec.ts` | Role gate (ADR-015): a provisioned staff member reaches the dashboard; admin-only nav and pages are hidden/blocked from plain staff; an org admin sees them; an expat and an unprovisioned identity are both turned away at the access gate. |
+| `rfp-lifecycle.spec.ts` | RFP create → Draft → Approve (bare confirm) → Publish (confirm-with-summary) driven in the staff UI, then asserted on the portal: the published RFP appears, an edit-after-publish reaches the portal without re-approval, and a delete removes it. |
+| `proposal-review.spec.ts` | Submitted → Under Review → Approved through the staff UI, the expat's portal "My Proposals" reflecting Approved, and no reject affordance anywhere in the flow. |
+| `takedown-cascade.spec.ts` | Deleting a proposal cascades to its CFEOI and EOI — the contributor's portal "My EOIs" no longer lists it, and the API confirms both are gone. |
+| `eoi-management.spec.ts` | Staff approve/reject Pending EOIs, see `Private` submissions with the email column, and delete an EOI through the checkbox-gated modal. |
+| `administration.spec.ts` | Organisation-tree CRUD (incl. the bootstrap empty state and the 409 refusal on deleting a non-empty organisation), and user management with the client-side delete guards plus their server backstops (self-delete 403, last-org-admin 409). |
+| `visibility-integrity.spec.ts` | A `Private` proposal is visible in the staff "All proposals" tab by design while staying invisible to an anonymous portal session — one assertion pair proving the staff bypass and public filtering coexist. |
+
+## Authentication strategy
+
+The staff app reuses the portal's test-auth approach: the `e2e` Vite mode
+(`.env.e2e`, `VITE_E2E_AUTH=true`) swaps `PublicClientApplication` for the fake in
+`src/auth/testAuth.ts`, which reads a pre-minted API token from localStorage
+(`herit.e2e.auth`, written via Playwright `storageState`). The two SPAs share the same
+localStorage token contract, so the one token-minting harness (`e2e/support/tokens.ts`,
+using `jose`) signs an identity into either origin — storage-state files are
+origin-scoped (`staff` → :5198, `portal` → :5199). On the API side, the checked-in
+HS256 key from `appsettings.E2E.json` is accepted only outside Production
+(`TestAuthentication.IsEnabled`), and the Graph-backed identity provider is replaced by
+a deterministic local fake so the seeder and staff-creation endpoints work offline
+(`externalId = "e2e-" + email`). See `docs/frontend/portal/e2e-testing.md` for the full
+rationale.
+
+## Test data lifecycle
+
+`e2e/global.setup.ts` builds the baseline through the same paths production uses (never
+direct DB writes):
+
+1. Super admin via the CLI seeder (`--seed-super-admin`) — idempotent.
+2. Organisation hierarchy (root ministry + child agency) as the super admin.
+3. An **org admin** and a plain **staff** user (Graph replaced by the local fake).
+4. Expat users (owner + contributors), JIT-registered via `GET /Users/me` and
+   terms-accepted, so they can drive the portal in the cross-app steps. A further
+   identity is minted but deliberately **not** provisioned — it hits the 404 access gate.
+
+Every record's title carries a per-run `runId`, so runs never depend on data left by
+previous runs. `e2e/global.teardown.ts` deletes what the API allows and logs what it
+leaves behind (records with no delete path, and the last-remaining org admin, are left
+in place — a fresh `runId` keeps future runs unaffected).
+
+## Ports
+
+| Service | Port | Env |
+|---|---|---|
+| API | 5299 | `ASPNETCORE_ENVIRONMENT=E2E` |
+| Staff app (under test) | 5198 | Vite `e2e` mode |
+| Portal (cross-app) | 5199 | Vite `e2e` mode |
+
+Because the two SPAs run on different ports, specs navigate with an absolute URL via
+`session.url(path)`.
+
+## Running locally
+
+1. Start a disposable SQL Server (once):
+
+   ```bash
+   docker run -d --name herit-e2e-sql -e ACCEPT_EULA=Y \
+     -e MSSQL_SA_PASSWORD='HeritE2e!Passw0rd' -p 14330:1433 \
+     --platform linux/amd64 mcr.microsoft.com/mssql/server:2022-latest
+   ```
+
+2. Install both frontends' dependencies (the staff suite serves the portal too):
+
+   ```bash
+   (cd frontend/portal && npm ci)
+   (cd frontend/staff && npm ci)
+   ```
+
+3. Run the suite from `frontend/staff`:
+
+   ```bash
+   npm run e2e        # or: npm run e2e:ui
+   ```
+
+Playwright starts the API (:5299, `E2E` environment), the staff app (:5198) and the
+portal (:5199) itself, reusing them if already running. To reset local E2E data, drop
+the database:
+
+```bash
+docker exec herit-e2e-sql /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa \
+  -P 'HeritE2e!Passw0rd' -C -Q "DROP DATABASE IF EXISTS HeritE2E"
+```
+
+## CI
+
+The `e2e-staff` job in `.github/workflows/azure-dev.yml` runs the suite against a SQL
+Server service container (same port 14330 the config expects), installing both frontends'
+dependencies and uploading the Playwright report and traces on failure. The `cd` deploy
+job requires `ci`, `e2e`, and `e2e-staff` to pass.
+
+## Conventions
+
+- Selectors prefer roles, labels, and visible text; no `data-testid`s were needed.
+- Specs run serially (one worker) because they share a database.
+- Fixture titles embed the `runId` plus the Playwright `workerIndex`, so a worker
+  restart after a failure re-seeds under fresh names instead of colliding.
+- Assert server-enforced behaviour (visibility, role gating, delete guards) on **both**
+  the UI and the API where it matters.

--- a/frontend/staff/e2e/administration.spec.ts
+++ b/frontend/staff/e2e/administration.spec.ts
@@ -1,0 +1,163 @@
+import { expect, test, type Page } from '@playwright/test';
+import { Api } from './support/api';
+import { openSession } from './support/session';
+import { readRunState, type RunState } from './support/run-state';
+
+/**
+ * Scenario 6 — administration surfaces (org admin only): organisation-tree CRUD
+ * including the bootstrap empty state and the 409 refusal on deleting a
+ * non-empty organisation, plus user management with the client-side delete
+ * guards and their server backstops (self-delete 403, last-org-admin 409).
+ */
+
+let state: RunState;
+
+test.beforeAll(() => {
+  state = readRunState();
+});
+
+const dialog = (page: Page) => page.getByRole('dialog');
+/** An organisation-tree row: rows carry `border-b`, the table container does not. */
+const orgRow = (page: Page, name: string) => page.locator('div.border-b').filter({ hasText: name });
+/** A users-table row: header and data rows are `div.grid`; filter by a unique cell. */
+const userRow = (page: Page, cell: string) => page.locator('div.grid').filter({ hasText: cell });
+
+test('the organisation tree shows the bootstrap empty state when there are none', async ({ browser }) => {
+  const s = await openSession(browser, 'staff', 'staff-orgadmin');
+  // Stub the list endpoint so the page renders its zero-organisations bootstrap
+  // without disturbing the shared, seeded hierarchy.
+  await s.page.route('**/api/v1/Organisations', async (route) => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+    }
+    return route.fallback();
+  });
+  await s.page.goto(s.url('/organisations'));
+  await expect(s.page.getByRole('heading', { name: 'No organisations yet' })).toBeVisible();
+  await expect(s.page.getByRole('button', { name: 'Create root organisation' })).toBeVisible();
+  await s.context.close();
+});
+
+test('org admin can create, rename, and delete a sub-organisation, and is refused deleting a non-empty one', async ({ browser }) => {
+  test.setTimeout(120_000);
+
+  const subName = `Analytics Unit (E2E ${state.runId})`;
+  const renamedName = `Analytics & Insights Unit (E2E ${state.runId})`;
+
+  const s = await openSession(browser, 'staff', 'staff-orgadmin');
+  await s.page.goto(s.url('/organisations'));
+  await expect(orgRow(s.page, state.rootOrgName)).toBeVisible();
+
+  await test.step('create a sub-organisation', async () => {
+    // Each tree row also exposes an icon-only "Create sub-organisation" button;
+    // the page-level action is the first in DOM order.
+    await s.page.getByRole('button', { name: 'Create sub-organisation' }).first().click();
+    const createModal = dialog(s.page);
+    await createModal.getByPlaceholder('Organisation name').fill(subName);
+    await createModal.getByRole('button', { name: 'Create' }).click();
+    await expect(dialog(s.page)).toBeHidden();
+    await expect(orgRow(s.page, subName)).toBeVisible();
+  });
+
+  await test.step('rename the sub-organisation', async () => {
+    await orgRow(s.page, subName).getByRole('button', { name: 'Rename' }).click();
+    const renameModal = dialog(s.page);
+    await renameModal.getByPlaceholder('Organisation name').fill(renamedName);
+    await renameModal.getByRole('button', { name: 'Save' }).click();
+    await expect(dialog(s.page)).toBeHidden();
+    await expect(orgRow(s.page, renamedName)).toBeVisible();
+  });
+
+  await test.step('delete the (empty) sub-organisation', async () => {
+    await orgRow(s.page, renamedName).getByRole('button', { name: 'Delete' }).click();
+    const deleteModal = dialog(s.page);
+    await expect(deleteModal.getByRole('button', { name: 'Delete organisation' })).toBeDisabled();
+    await deleteModal.getByRole('checkbox').check();
+    await deleteModal.getByRole('button', { name: 'Delete organisation' }).click();
+    await expect(dialog(s.page)).toBeHidden();
+    await expect(orgRow(s.page, renamedName)).toHaveCount(0);
+  });
+
+  await test.step('deleting the non-empty root is refused with the server message', async () => {
+    await orgRow(s.page, state.rootOrgName).getByRole('button', { name: 'Delete' }).click();
+    const deleteModal = dialog(s.page);
+    await deleteModal.getByRole('checkbox').check();
+    await deleteModal.getByRole('button', { name: 'Delete organisation' }).click();
+    // The 409 swaps in the conflict dialog carrying the API's message.
+    await expect(s.page.getByRole('heading', { name: `Couldn't delete ${state.rootOrgName}` })).toBeVisible();
+    await expect(s.page.getByText(/cannot be deleted/)).toBeVisible();
+    await dialog(s.page).getByRole('button', { name: 'Close' }).click();
+  });
+
+  await s.context.close();
+});
+
+test('org admin manages staff users, and delete guards hold on client and server', async ({ browser }) => {
+  test.setTimeout(120_000);
+
+  const newEmail = `provisioned-staff-${state.runId}@e2e.herit.local`;
+  const newName = 'Provisioned Staff Member';
+  const editedName = 'Provisioned Staff Lead';
+
+  const s = await openSession(browser, 'staff', 'staff-orgadmin');
+  await s.page.goto(s.url('/users'));
+  await expect(s.page.getByRole('heading', { name: 'Users', level: 1 })).toBeVisible();
+
+  await test.step('create a staff user', async () => {
+    await s.page.getByRole('button', { name: 'Create staff' }).click();
+    const createModal = dialog(s.page);
+    await createModal.getByPlaceholder('Work email').fill(newEmail);
+    await createModal.getByPlaceholder('Full name').fill(newName);
+    await createModal.getByRole('combobox').selectOption({ label: state.rootOrgName });
+    await createModal.getByRole('button', { name: 'Create staff user' }).click();
+    await expect(dialog(s.page)).toBeHidden();
+    await expect(userRow(s.page, newEmail)).toBeVisible();
+  });
+
+  await test.step('edit the staff user', async () => {
+    await userRow(s.page, newEmail).getByRole('button', { name: 'Edit' }).click();
+    const editModal = dialog(s.page);
+    await editModal.getByPlaceholder('Full name').fill(editedName);
+    await editModal.getByRole('button', { name: 'Save changes' }).click();
+    await expect(dialog(s.page)).toBeHidden();
+    await expect(userRow(s.page, editedName)).toBeVisible();
+  });
+
+  await test.step('the org admin cannot delete their own account (client guard hides the action)', async () => {
+    const ownRow = userRow(s.page, state.identities.orgAdmin.email);
+    await expect(ownRow.getByText('(you)')).toBeVisible();
+    await expect(ownRow.getByRole('button', { name: 'Delete' })).toHaveCount(0);
+  });
+
+  await test.step('delete the staff user', async () => {
+    await userRow(s.page, editedName).getByRole('button', { name: 'Delete' }).click();
+    const deleteModal = dialog(s.page);
+    await expect(deleteModal.getByRole('button', { name: 'Delete user' })).toBeDisabled();
+    await deleteModal.getByRole('checkbox').check();
+    await deleteModal.getByRole('button', { name: 'Delete user' }).click();
+    await expect(dialog(s.page)).toBeHidden();
+    await expect(userRow(s.page, newEmail)).toHaveCount(0);
+  });
+
+  await test.step('server backstops: self-delete is 403 and last-org-admin delete is 409', async () => {
+    // Self-delete is refused first, regardless of how many admins exist.
+    const orgAdminApi = await Api.forToken(state.identities.orgAdmin.token);
+    const selfDelete = await orgAdminApi.raw('DELETE', `/Users/organisation-admins/${state.orgAdminUserId}`);
+    expect(selfDelete.status()).toBe(403);
+    await orgAdminApi.dispose();
+
+    // Make the seeded org admin the last one (a dirty local DB can carry org
+    // admins left behind by earlier runs), so the last-admin backstop is
+    // deterministic; a super admin deleting it is then refused with 409.
+    const adminApi = await Api.forToken(state.identities.superAdmin.token);
+    const others = (await adminApi.listUsers()).filter(
+      (u) => u.role === 'OrganisationAdmin' && u.id !== state.orgAdminUserId,
+    );
+    for (const other of others) await adminApi.deleteOrganisationAdmin(other.id);
+    const lastAdminDelete = await adminApi.raw('DELETE', `/Users/organisation-admins/${state.orgAdminUserId}`);
+    expect(lastAdminDelete.status()).toBe(409);
+    await adminApi.dispose();
+  });
+
+  await s.context.close();
+});

--- a/frontend/staff/e2e/auth-gate.spec.ts
+++ b/frontend/staff/e2e/auth-gate.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from '@playwright/test';
+import { openSession } from './support/session';
+import { readRunState, type RunState } from './support/run-state';
+
+/**
+ * Scenario 1 — auth & role gate (ADR-015): the staff app is for provisioned
+ * Staff/Admin identities only. A plain staff user reaches the dashboard but
+ * never the admin surfaces; an expat and an unprovisioned identity are both
+ * turned away at the access gate.
+ */
+
+let state: RunState;
+
+test.beforeAll(() => {
+  state = readRunState();
+});
+
+test('a provisioned staff member signs in and reaches the dashboard', async ({ browser }) => {
+  // The identity is staged (pendingAuth), so the sign-in button drives the
+  // fake Entra redirect round-trip itself.
+  const s = await openSession(browser, 'staff', 'staff-staff-pending');
+  await s.page.goto(s.url('/sign-in'));
+  await expect(s.page.getByRole('heading', { name: 'Sign in to Herit Staff' })).toBeVisible();
+  await s.page.getByRole('button', { name: 'Continue with Google' }).click();
+
+  await s.page.goto(s.url('/'));
+  await expect(s.page.getByRole('heading', { name: `Welcome back, ${state.identities.staff.name}` })).toBeVisible();
+  await expect(s.page.getByRole('navigation').getByRole('link', { name: 'Dashboard' })).toBeVisible();
+  await s.context.close();
+});
+
+test('admin-only nav is hidden from a plain staff member, and admin pages are blocked', async ({ browser }) => {
+  const s = await openSession(browser, 'staff', 'staff-staff');
+  await s.page.goto(s.url('/'));
+  const nav = s.page.getByRole('navigation');
+  await expect(nav.getByRole('link', { name: 'RFPs' })).toBeVisible();
+  await expect(nav.getByRole('link', { name: 'Proposals' })).toBeVisible();
+  await expect(nav.getByRole('link', { name: 'Organisations' })).toHaveCount(0);
+  await expect(nav.getByRole('link', { name: 'Users' })).toHaveCount(0);
+
+  // Direct navigation to admin routes is refused at the page level (no data leaks).
+  await s.page.goto(s.url('/organisations'));
+  await expect(s.page.getByText("You don't have access to organisation management.")).toBeVisible();
+  await s.page.goto(s.url('/users'));
+  await expect(s.page.getByText("You don't have access to user management.")).toBeVisible();
+  await s.context.close();
+});
+
+test('an org admin sees the admin-only nav items', async ({ browser }) => {
+  const s = await openSession(browser, 'staff', 'staff-orgadmin');
+  await s.page.goto(s.url('/'));
+  const nav = s.page.getByRole('navigation');
+  await expect(nav.getByRole('link', { name: 'Organisations' })).toBeVisible();
+  await expect(nav.getByRole('link', { name: 'Users' })).toBeVisible();
+  await s.context.close();
+});
+
+test('an expat identity is turned away at the access gate', async ({ browser }) => {
+  const s = await openSession(browser, 'staff', 'staff-expat');
+  await s.page.goto(s.url('/'));
+  await s.page.waitForURL('**/access-denied');
+  await expect(s.page.getByRole('heading', { name: 'This application is for Herit staff' })).toBeVisible();
+  await s.context.close();
+});
+
+test('an unprovisioned identity is turned away at the access gate', async ({ browser }) => {
+  const s = await openSession(browser, 'staff', 'staff-unprovisioned');
+  await s.page.goto(s.url('/'));
+  await s.page.waitForURL('**/access-denied');
+  await expect(s.page.getByRole('heading', { name: 'This application is for Herit staff' })).toBeVisible();
+  await s.context.close();
+});

--- a/frontend/staff/e2e/eoi-management.spec.ts
+++ b/frontend/staff/e2e/eoi-management.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test, type Page } from '@playwright/test';
+import { Api } from './support/api';
+import { openSession } from './support/session';
+import { readRunState, type RunState } from './support/run-state';
+
+/**
+ * Scenario 5 — staff EOI management: staff approve and reject Pending EOIs, see
+ * submissions the applicant marked Private together with their email (staff
+ * read-access spans every visibility level), and delete an EOI through the
+ * checkbox-gated modal.
+ */
+
+let state: RunState;
+let expatApi: Api;
+let expatBApi: Api;
+let expatCApi: Api;
+let proposalId = '';
+let cfeoiId = '';
+
+const dialog = (page: Page) => page.getByRole('dialog');
+/** Header and data rows are both `div.grid`; filtering by a submitter name selects the data row. */
+const rowFor = (page: Page, name: string) => page.locator('div.grid').filter({ hasText: name });
+
+test.beforeAll(async ({}, testInfo) => {
+  state = readRunState();
+  const scope = `${state.runId}-w${testInfo.workerIndex}`;
+  expatApi = await Api.forToken(state.identities.expat.token);
+  expatBApi = await Api.forToken(state.identities.expatB.token);
+  expatCApi = await Api.forToken(state.identities.expatC.token);
+
+  proposalId = await expatApi.createProposal({
+    title: `Border Health Screening (E2E ${scope})`,
+    shortDescription: 'Screening kiosks at major crossings.',
+    longDescription: 'Deploy health-screening kiosks and staff them with trained volunteers.',
+    organisationId: state.childOrgId,
+  });
+  await expatApi.setProposalStatus(proposalId, 'Resourcing');
+  await expatApi.setProposalVisibility(proposalId, 'Shared');
+  cfeoiId = await expatApi.publishCfeoi({
+    title: `Screening Volunteer Lead (E2E ${scope})`,
+    description: 'Coordinate volunteer screening teams.',
+    resourceType: 'Human',
+    proposalId,
+  });
+  // Both left Pending and Private (the default) so staff review from a clean slate.
+  await expatBApi.submitEoi(cfeoiId, `Volunteer coordination is my background. (E2E ${scope})`);
+  await expatCApi.submitEoi(cfeoiId, `I ran the last screening drive. (E2E ${scope})`);
+});
+
+test.afterAll(async () => {
+  await Promise.all([expatApi.dispose(), expatBApi.dispose(), expatCApi.dispose()]);
+});
+
+test('staff approve, reject, and delete EOIs, seeing Private submissions and emails', async ({ browser }) => {
+  test.setTimeout(120_000);
+
+  const nameB = state.identities.expatB.name;
+  const nameC = state.identities.expatC.name;
+
+  const staff = await openSession(browser, 'staff', 'staff-staff');
+  await staff.page.goto(staff.url(`/proposals/${proposalId}/cfeois/${cfeoiId}/eois`));
+  await expect(staff.page.getByRole('heading', { name: 'Expressions of Interest' })).toBeVisible();
+
+  await test.step('staff see both Private submissions with the email column', async () => {
+    await expect(staff.page.getByText(state.identities.expatB.email)).toBeVisible();
+    await expect(staff.page.getByText(state.identities.expatC.email)).toBeVisible();
+    await expect(rowFor(staff.page, nameB).getByText('Private')).toBeVisible();
+  });
+
+  await test.step('staff approve one EOI and reject the other', async () => {
+    await rowFor(staff.page, nameB).getByRole('button', { name: 'Approve' }).click();
+    await expect(rowFor(staff.page, nameB).getByText('Approved')).toBeVisible();
+
+    await rowFor(staff.page, nameC).getByRole('button', { name: 'Reject' }).click();
+    await expect(rowFor(staff.page, nameC).getByText('Rejected')).toBeVisible();
+  });
+
+  await test.step('staff delete an EOI through the checkbox-gated modal', async () => {
+    await rowFor(staff.page, nameC).getByRole('button', { name: 'Delete (staff only)' }).click();
+    const deleteModal = dialog(staff.page);
+    await expect(deleteModal.getByRole('heading', { name: 'Delete this expression of interest?' })).toBeVisible();
+    await expect(deleteModal.getByRole('button', { name: 'Delete permanently' })).toBeDisabled();
+    await deleteModal.getByRole('checkbox').check();
+    await deleteModal.getByRole('button', { name: 'Delete permanently' }).click();
+
+    // The deleted submission disappears from the list once the query refetches.
+    await expect(rowFor(staff.page, nameC)).toHaveCount(0);
+    // The approved submission is untouched.
+    await expect(rowFor(staff.page, nameB).getByText('Approved')).toBeVisible();
+  });
+
+  await staff.context.close();
+});

--- a/frontend/staff/e2e/global.setup.ts
+++ b/frontend/staff/e2e/global.setup.ts
@@ -1,0 +1,100 @@
+import { execFileSync } from 'node:child_process';
+import { test as setup } from '@playwright/test';
+import { API_PROJECT, REPO_ROOT, SUPER_ADMIN_EMAIL, SUPER_ADMIN_NAME } from './support/config';
+import { Api } from './support/api';
+import { externalIdFor, mintToken } from './support/tokens';
+import { writeRunState, writeStorageState, type TestIdentity } from './support/run-state';
+
+/**
+ * Builds the known-good baseline every spec depends on, going through the same
+ * paths production uses (CLI seeder + public API — never direct DB writes):
+ *
+ *  1. Super admin via the existing CLI seeder (`--seed-super-admin`). Only this
+ *     actor can bootstrap the organisation hierarchy. Idempotent across runs.
+ *  2. Organisation hierarchy (root ministry + child agency) as the super admin.
+ *  3. An org admin and a plain staff user (Graph replaced by the local fake), so
+ *     the admin-only surfaces and the role gate both have real identities.
+ *  4. Expat users (owner + contributor), registered through the same JIT path
+ *     the portal uses (GET /Users/me) and terms-accepted via the API, so they
+ *     can drive the portal in the cross-app scenarios. A further identity is
+ *     minted but deliberately NOT provisioned — it exercises the 404 access gate.
+ *
+ * Storage states are origin-scoped (staff vs portal): the same identity can be
+ * signed into either app because both read the shared localStorage token
+ * contract. All run-scoped records carry the runId in their titles so runs
+ * never depend on (or collide with) data left behind by earlier local runs.
+ */
+setup('seed the E2E baseline', async () => {
+  setup.setTimeout(180_000);
+
+  execFileSync('dotnet', [
+    'run', '--no-launch-profile', '--project', API_PROJECT, '--',
+    '--seed-super-admin', '--email', SUPER_ADMIN_EMAIL, '--display-name', SUPER_ADMIN_NAME,
+  ], {
+    cwd: REPO_ROOT,
+    stdio: 'inherit',
+    env: { ...process.env, ASPNETCORE_ENVIRONMENT: 'E2E' },
+  });
+
+  const runId = Date.now().toString(36);
+
+  const identityFor = async (slug: string, name: string): Promise<TestIdentity> => {
+    const email = `${slug}-${runId}@e2e.herit.local`;
+    return { email, name, externalId: externalIdFor(email), token: await mintToken(email, name) };
+  };
+
+  const superAdmin: TestIdentity = {
+    email: SUPER_ADMIN_EMAIL,
+    name: SUPER_ADMIN_NAME,
+    externalId: externalIdFor(SUPER_ADMIN_EMAIL),
+    token: await mintToken(SUPER_ADMIN_EMAIL, SUPER_ADMIN_NAME),
+  };
+  const orgAdmin = await identityFor('org-admin', 'E2E Org Admin');
+  const staff = await identityFor('staff', 'E2E Staff Member');
+  const expat = await identityFor('expat', 'Expat Owner');
+  const expatB = await identityFor('expat-b', 'Expat Contributor');
+  const expatC = await identityFor('expat-c', 'Expat Applicant');
+  const unprovisioned = await identityFor('unprovisioned', 'Unprovisioned Visitor');
+
+  const admin = await Api.forToken(superAdmin.token);
+
+  const rootOrgName = `Ministry of Health (E2E ${runId})`;
+  const rootOrgId = await admin.createOrganisation(rootOrgName);
+  const childOrgName = `Digital Health Agency (E2E ${runId})`;
+  const childOrgId = await admin.createOrganisation(childOrgName, rootOrgId);
+
+  const orgAdminUserId = await admin.createOrganisationAdmin(orgAdmin.email, orgAdmin.name, rootOrgId);
+  const staffUserId = await admin.createStaffUser(staff.email, staff.name, rootOrgId);
+
+  // JIT-register the expats, then accept terms so the portal's ProtectedRoute
+  // lets them in for the cross-app steps.
+  for (const identity of [expat, expatB, expatC]) {
+    const api = await Api.forToken(identity.token);
+    await api.getMe();
+    await api.acceptTerms({ email: identity.email, nationality: 'Australia', location: 'Sydney', expertiseTags: 'Health IT' });
+    await api.dispose();
+  }
+
+  // Staff-app identities.
+  writeStorageState('staff-orgadmin', 'staff', orgAdmin);
+  writeStorageState('staff-staff', 'staff', staff);
+  writeStorageState('staff-staff-pending', 'staff', staff, { pending: true });
+  writeStorageState('staff-expat', 'staff', expat);
+  writeStorageState('staff-unprovisioned', 'staff', unprovisioned);
+  // Portal identities (for cross-app assertions).
+  writeStorageState('portal-expat', 'portal', expat);
+  writeStorageState('portal-expatB', 'portal', expatB);
+
+  writeRunState({
+    runId,
+    rootOrgId,
+    rootOrgName,
+    childOrgId,
+    childOrgName,
+    orgAdminUserId,
+    staffUserId,
+    identities: { superAdmin, orgAdmin, staff, expat, expatB, expatC, unprovisioned },
+  });
+
+  await admin.dispose();
+});

--- a/frontend/staff/e2e/global.teardown.ts
+++ b/frontend/staff/e2e/global.teardown.ts
@@ -1,0 +1,49 @@
+import { test as teardown } from '@playwright/test';
+import { Api } from './support/api';
+import { readRunState } from './support/run-state';
+
+/**
+ * Best-effort cleanup through the public API. Some records intentionally have
+ * no delete path (CFEOIs, withdrawn proposals, expat users), so anything that
+ * refuses deletion is left behind — every record carries the runId in its
+ * title, so later runs neither depend on nor collide with leftovers. CI
+ * databases are ephemeral; local databases can be reset by recreating the
+ * HeritE2E database (see docs/frontend/staff/e2e-testing.md).
+ */
+teardown('clean up run-scoped data', async () => {
+  const state = readRunState();
+  const attempt = async (label: string, action: () => Promise<unknown>) => {
+    try {
+      await action();
+    } catch {
+      console.log(`[e2e teardown] left behind: ${label}`);
+    }
+  };
+
+  // Withdraw the expats' remaining EOIs and delete their still-deletable proposals.
+  for (const key of ['expat', 'expatB'] as const) {
+    const api = await Api.forToken(state.identities[key].token);
+    await attempt(`${key} EOIs`, async () => {
+      for (const eoi of await api.listMyEois()) await attempt(`EOI ${eoi.id}`, () => api.withdrawEoi(eoi.id));
+    });
+    await attempt(`${key} proposals`, async () => {
+      const me = await api.getMe();
+      const mine = (await api.listProposals()).filter((p) => p.authorId === me.id);
+      for (const proposal of mine) await attempt(`proposal "${proposal.title}"`, () => api.deleteProposal(proposal.id));
+    });
+    await api.dispose();
+  }
+
+  const admin = await Api.forToken(state.identities.superAdmin.token);
+  // Remove any run-scoped RFPs still present.
+  await attempt('run RFPs', async () => {
+    for (const rfp of await admin.listRfps()) {
+      if (rfp.title.includes(`E2E ${state.runId}`)) await attempt(`RFP "${rfp.title}"`, () => admin.deleteRfp(rfp.id));
+    }
+  });
+  await attempt('staff user', () => admin.deleteStaffUser(state.staffUserId));
+  await attempt('org admin user', () => admin.deleteOrganisationAdmin(state.orgAdminUserId));
+  await attempt(`organisation "${state.childOrgName}"`, () => admin.deleteOrganisation(state.childOrgId));
+  await attempt(`organisation "${state.rootOrgName}"`, () => admin.deleteOrganisation(state.rootOrgId));
+  await admin.dispose();
+});

--- a/frontend/staff/e2e/proposal-review.spec.ts
+++ b/frontend/staff/e2e/proposal-review.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test, type Page } from '@playwright/test';
+import { Api } from './support/api';
+import { openSession } from './support/session';
+import { readRunState, type RunState } from './support/run-state';
+
+/**
+ * Scenario 3 — the proposal review loop: an expat submits a proposal on the
+ * portal (seeded through the same owner-only API path the portal UI uses),
+ * staff drive it Submitted → Under Review → Approved through the staff UI, and
+ * the expat's portal "My Proposals" reflects Approved. There is no reject
+ * transition anywhere in the flow — deletion is the only negative outcome.
+ */
+
+let state: RunState;
+let expatApi: Api;
+let proposalTitle = '';
+let proposalId = '';
+
+const dialog = (page: Page) => page.getByRole('dialog');
+
+test.beforeAll(async ({}, testInfo) => {
+  state = readRunState();
+  const scope = `${state.runId}-w${testInfo.workerIndex}`;
+  expatApi = await Api.forToken(state.identities.expat.token);
+
+  proposalTitle = `Diaspora Mentorship Network (E2E ${scope})`;
+  proposalId = await expatApi.createProposal({
+    title: proposalTitle,
+    shortDescription: 'Pair returning professionals with early-career locals.',
+    longDescription: 'A structured mentorship network connecting diaspora professionals with local mentees.',
+    organisationId: state.childOrgId,
+  });
+  // Owner-only transitions, exactly what the portal UI performs on submit.
+  await expatApi.setProposalStatus(proposalId, 'Resourcing');
+  await expatApi.setProposalStatus(proposalId, 'Submitted');
+});
+
+test.afterAll(async () => {
+  await expatApi.dispose();
+});
+
+test('staff review a submitted proposal to approval, with no reject affordance', async ({ browser }) => {
+  test.setTimeout(120_000);
+
+  const staff = await openSession(browser, 'staff', 'staff-staff');
+
+  await test.step('the proposal appears in the staff Submitted queue', async () => {
+    await staff.page.goto(staff.url('/proposals?status=Submitted'));
+    const row = staff.page.getByRole('link').filter({ hasText: proposalTitle });
+    await expect(row).toBeVisible();
+    await row.click();
+    await staff.page.waitForURL(`**/proposals/${proposalId}`);
+    await expect(staff.page.getByRole('heading', { name: proposalTitle, level: 1 })).toBeVisible();
+  });
+
+  await test.step('no reject affordance is present at Submitted', async () => {
+    await expect(staff.page.getByRole('button', { name: /reject/i })).toHaveCount(0);
+    await expect(staff.page.getByRole('button', { name: 'Start review' })).toBeVisible();
+  });
+
+  await test.step('staff start the review', async () => {
+    await staff.page.getByRole('button', { name: 'Start review' }).click();
+    await expect(dialog(staff.page).getByRole('heading', { name: 'Start review?' })).toBeVisible();
+    await dialog(staff.page).getByRole('button', { name: 'Start review' }).click();
+    await expect(dialog(staff.page)).toBeHidden();
+    await expect(staff.page.getByRole('button', { name: 'Approve' })).toBeVisible();
+    await expect(staff.page.getByRole('button', { name: /reject/i })).toHaveCount(0);
+  });
+
+  await test.step('staff approve the proposal (terminal)', async () => {
+    await staff.page.getByRole('button', { name: 'Approve' }).click();
+    await expect(dialog(staff.page).getByRole('heading', { name: 'Approve this proposal?' })).toBeVisible();
+    await dialog(staff.page).getByRole('button', { name: 'Approve' }).click();
+    await expect(dialog(staff.page)).toBeHidden();
+    await expect(staff.page.getByText('No further review action — approval is terminal.')).toBeVisible();
+    await expect(staff.page.getByRole('button', { name: /reject/i })).toHaveCount(0);
+  });
+
+  await test.step("the expat's portal My Proposals shows Approved", async () => {
+    const portal = await openSession(browser, 'portal', 'portal-expat');
+    await portal.page.goto(portal.url('/my-proposals'));
+    const card = portal.page.getByRole('link').filter({ hasText: proposalTitle });
+    await expect(card).toBeVisible();
+    await expect(card.getByText('Approved')).toBeVisible();
+    await portal.context.close();
+  });
+
+  await staff.context.close();
+});

--- a/frontend/staff/e2e/rfp-lifecycle.spec.ts
+++ b/frontend/staff/e2e/rfp-lifecycle.spec.ts
@@ -1,0 +1,118 @@
+import { expect, test, type Page } from '@playwright/test';
+import { Api } from './support/api';
+import { openSession } from './support/session';
+import { readRunState, type RunState } from './support/run-state';
+
+/**
+ * Scenario 2 — RFP lifecycle driven through the staff UI (create → Draft →
+ * Approve → Publish), with the outcome asserted on the expat portal: a
+ * published RFP appears there, an edit-after-publish reaches the portal with no
+ * re-approval, and a delete removes it from the portal.
+ *
+ * Per ADR-017 any staff user can perform every transition, so a plain staff
+ * identity drives the whole flow.
+ */
+
+let state: RunState;
+
+test.beforeAll(() => {
+  state = readRunState();
+});
+
+/** The staff Modal renders a role="dialog"; scope confirm clicks to it. */
+const dialog = (page: Page) => page.getByRole('dialog');
+
+test('publish an RFP from the staff app and see it flow to the portal', async ({ browser }) => {
+  test.setTimeout(120_000);
+
+  const title = `Coastal Flood Modelling (E2E ${state.runId})`;
+  const originalLong = `Original scope for the coastal flood modelling programme. (E2E ${state.runId})`;
+  const editedLong = `Revised scope — now includes real-time sensor ingest. (E2E ${state.runId})`;
+  let rfpId = '';
+
+  const staff = await openSession(browser, 'staff', 'staff-staff');
+
+  await test.step('staff creates a Draft RFP', async () => {
+    await staff.page.goto(staff.url('/rfps/new'));
+    await staff.page.getByLabel('Title').fill(title);
+    await staff.page.getByLabel('Short description').fill('Model storm-surge risk for the national coastline.');
+    await staff.page.getByLabel('Organisation').selectOption({ label: state.rootOrgName });
+    await staff.page.getByLabel('Long description').fill(originalLong);
+    await staff.page.getByLabel('Tags (optional)').fill('Climate, Modelling');
+    await staff.page.getByRole('button', { name: 'Create RFP' }).click();
+
+    await staff.page.waitForURL(/\/rfps\/[0-9a-f-]+\?created=true/);
+    rfpId = /\/rfps\/([0-9a-f-]+)/.exec(staff.page.url())![1];
+    await expect(staff.page.getByText('RFP created — it starts in Draft.')).toBeVisible();
+    await expect(staff.page.getByRole('heading', { name: title, level: 1 })).toBeVisible();
+  });
+
+  await test.step('the Draft RFP is invisible to an anonymous portal visitor', async () => {
+    const anon = await Api.anonymous();
+    expect((await anon.listRfps()).map((r) => r.title)).not.toContain(title);
+    await anon.dispose();
+  });
+
+  await test.step('staff approves the RFP (bare confirm)', async () => {
+    await staff.page.getByRole('button', { name: 'Approve' }).click();
+    await expect(dialog(staff.page).getByRole('heading', { name: 'Approve this RFP?' })).toBeVisible();
+    await dialog(staff.page).getByRole('button', { name: 'Approve' }).click();
+    await expect(dialog(staff.page)).toBeHidden();
+    // Publish action only appears once the RFP is Approved.
+    await expect(staff.page.getByRole('button', { name: 'Publish' })).toBeVisible();
+  });
+
+  await test.step('staff publishes the RFP (confirm-with-summary)', async () => {
+    await staff.page.getByRole('button', { name: 'Publish' }).click();
+    const publishModal = dialog(staff.page);
+    await expect(publishModal.getByRole('heading', { name: 'Publish this RFP?' })).toBeVisible();
+    // The publish confirm previews exactly what expats will see.
+    await expect(publishModal.getByText(title)).toBeVisible();
+    await publishModal.getByRole('button', { name: 'Publish' }).click();
+    await expect(staff.page.getByText('Live on the portal —', { exact: false })).toBeVisible();
+  });
+
+  const portal = await openSession(browser, 'portal', 'portal-expat');
+
+  await test.step('the published RFP appears in the portal RFP list', async () => {
+    await portal.page.goto(portal.url('/rfps'));
+    await portal.page.getByPlaceholder('Search by title, organisation, or tags…').fill(title);
+    await expect(portal.page.getByRole('heading', { name: title })).toBeVisible();
+  });
+
+  await test.step('an edit after publish reaches the portal without re-approval', async () => {
+    await staff.page.goto(staff.url(`/rfps/${rfpId}/edit`));
+    await expect(staff.page.getByText('This RFP is live on the portal')).toBeVisible();
+    await staff.page.getByLabel('Long description').fill(editedLong);
+    await staff.page.getByRole('button', { name: 'Save changes' }).click();
+    await staff.page.waitForURL(/\/rfps\/[0-9a-f-]+\?updated=true/);
+    await expect(staff.page.getByText('RFP changes saved.')).toBeVisible();
+    // Still Published — no re-approval step.
+    await expect(staff.page.getByText('Live on the portal —', { exact: false })).toBeVisible();
+
+    await portal.page.goto(portal.url(`/rfps/${rfpId}`));
+    await expect(portal.page.getByRole('heading', { name: title, level: 1 })).toBeVisible();
+    await expect(portal.page.getByText(editedLong)).toBeVisible();
+  });
+
+  await test.step('deleting the published RFP removes it from the portal', async () => {
+    await staff.page.goto(staff.url(`/rfps/${rfpId}`));
+    await staff.page.getByRole('button', { name: 'Delete' }).click();
+    const deleteModal = dialog(staff.page);
+    await expect(deleteModal.getByRole('button', { name: 'Delete' })).toBeDisabled();
+    await deleteModal.getByRole('checkbox').check();
+    await deleteModal.getByRole('button', { name: 'Delete' }).click();
+    await staff.page.waitForURL('**/rfps?deleted=true');
+    await expect(staff.page.getByText('RFP deleted.')).toBeVisible();
+
+    await portal.page.goto(portal.url('/rfps'));
+    await portal.page.getByPlaceholder('Search by title, organisation, or tags…').fill(title);
+    await expect(portal.page.getByRole('heading', { name: title })).toHaveCount(0);
+
+    await portal.page.goto(portal.url(`/rfps/${rfpId}`));
+    await expect(portal.page.getByRole('heading', { name: 'RFP not found' })).toBeVisible();
+  });
+
+  await staff.context.close();
+  await portal.context.close();
+});

--- a/frontend/staff/e2e/support/api.ts
+++ b/frontend/staff/e2e/support/api.ts
@@ -1,0 +1,231 @@
+import { request, type APIRequestContext, type APIResponse } from '@playwright/test';
+import { API_HOST } from './config';
+
+export interface ProposalDto {
+  id: string;
+  title: string;
+  shortDescription: string;
+  longDescription: string;
+  authorId: string;
+  organisationId: string;
+  rfpId: string | null;
+  status: string;
+  visibility: string;
+}
+
+export interface CfeoiDto {
+  id: string;
+  title: string;
+  description: string;
+  resourceType: string;
+  proposalId: string;
+  status: string;
+  tags: string | null;
+}
+
+export interface EoiDto {
+  id: string;
+  submittedById: string;
+  submitterName: string;
+  submitterEmail: string | null;
+  message: string;
+  cfeoiId: string;
+  status: string;
+  visibility: string;
+}
+
+export interface UserDto {
+  id: string;
+  externalId: string;
+  email: string;
+  fullName: string;
+  role: string;
+  organisationId: string | null;
+}
+
+export interface RfpDto {
+  id: string;
+  title: string;
+  status: string;
+}
+
+/**
+ * Thin typed wrapper over the Herit API for seeding and network-level
+ * assertions. Every identity (anonymous, expat, staff, org admin, super admin)
+ * gets its own instance so requests carry the right bearer token.
+ */
+export class Api {
+  private constructor(private readonly ctx: APIRequestContext) {}
+
+  static async forToken(token: string): Promise<Api> {
+    return new Api(await request.newContext({
+      baseURL: API_HOST,
+      extraHTTPHeaders: { Authorization: `Bearer ${token}` },
+    }));
+  }
+
+  static async anonymous(): Promise<Api> {
+    return new Api(await request.newContext({ baseURL: API_HOST }));
+  }
+
+  async dispose(): Promise<void> {
+    await this.ctx.dispose();
+  }
+
+  private async send(method: string, url: string, data?: unknown): Promise<APIResponse> {
+    // Content type is set explicitly so pre-serialized bodies (bare enum strings
+    // like `"Resourcing"`, mirroring what the app's axios client sends) parse as JSON.
+    const response = await this.ctx.fetch(`/api/v1${url}`, {
+      method,
+      data,
+      headers: { 'Content-Type': 'application/json' },
+    });
+    if (!response.ok()) {
+      throw new Error(`${method} ${url} failed with ${response.status()}: ${await response.text()}`);
+    }
+    return response;
+  }
+
+  /** Raw fetch that does not throw — for asserting on status codes. */
+  async raw(method: string, url: string, data?: unknown): Promise<APIResponse> {
+    return this.ctx.fetch(`/api/v1${url}`, {
+      method,
+      data,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // --- Users ---
+
+  /** JIT-registers the caller on first call, exactly like the portal does. */
+  async getMe(): Promise<UserDto> {
+    return (await this.send('GET', '/Users/me')).json();
+  }
+
+  async acceptTerms(profile: { email: string; nationality?: string; location?: string; expertiseTags?: string }): Promise<void> {
+    await this.send('PATCH', '/Users/me/profile', { ...profile, termsAcceptedAt: new Date().toISOString() });
+  }
+
+  async listUsers(): Promise<UserDto[]> {
+    return (await this.send('GET', '/Users')).json();
+  }
+
+  async createStaffUser(email: string, fullName: string, organisationId: string): Promise<string> {
+    return (await this.send('POST', '/Users/staff', { email, fullName, organisationId })).json();
+  }
+
+  async updateStaffUser(id: string, payload: { email: string; fullName: string }): Promise<void> {
+    await this.send('PUT', `/Users/staff/${id}`, payload);
+  }
+
+  async deleteStaffUser(id: string): Promise<void> {
+    await this.send('DELETE', `/Users/staff/${id}`);
+  }
+
+  async createOrganisationAdmin(email: string, fullName: string, organisationId: string): Promise<string> {
+    return (await this.send('POST', '/Users/organisation-admins', { email, fullName, organisationId })).json();
+  }
+
+  async deleteOrganisationAdmin(id: string): Promise<void> {
+    await this.send('DELETE', `/Users/organisation-admins/${id}`);
+  }
+
+  // --- Organisations ---
+
+  async createOrganisation(name: string, parentId?: string): Promise<string> {
+    return (await this.send('POST', '/Organisations', { name, parentId })).json();
+  }
+
+  async updateOrganisation(id: string, name: string): Promise<void> {
+    await this.send('PUT', `/Organisations/${id}`, { name });
+  }
+
+  async deleteOrganisation(id: string): Promise<void> {
+    await this.send('DELETE', `/Organisations/${id}`);
+  }
+
+  // --- RFPs ---
+
+  async createRfp(rfp: { title: string; shortDescription: string; organisationId: string; longDescription: string; tags?: string }): Promise<string> {
+    return (await this.send('POST', '/Rfps', rfp)).json();
+  }
+
+  async updateRfpStatus(id: string, newStatus: string): Promise<void> {
+    await this.send('PATCH', `/Rfps/${id}/status`, { newStatus });
+  }
+
+  async deleteRfp(id: string): Promise<void> {
+    await this.send('DELETE', `/Rfps/${id}`);
+  }
+
+  async listRfps(): Promise<RfpDto[]> {
+    return (await this.send('GET', '/Rfps')).json();
+  }
+
+  // --- Proposals ---
+
+  async createProposal(proposal: { title: string; shortDescription: string; longDescription: string; organisationId: string; rfpId?: string }): Promise<string> {
+    return (await this.send('POST', '/Proposals', proposal)).json();
+  }
+
+  async setProposalStatus(id: string, status: string): Promise<void> {
+    await this.send('PATCH', `/Proposals/${id}/status`, JSON.stringify(status));
+  }
+
+  async setProposalVisibility(id: string, visibility: string): Promise<void> {
+    await this.send('PATCH', `/Proposals/${id}/visibility`, JSON.stringify(visibility));
+  }
+
+  async deleteProposal(id: string): Promise<void> {
+    await this.send('DELETE', `/Proposals/${id}`);
+  }
+
+  async listProposals(): Promise<ProposalDto[]> {
+    return (await this.send('GET', '/Proposals')).json();
+  }
+
+  async getProposal(id: string): Promise<ProposalDto> {
+    return (await this.send('GET', `/Proposals/${id}`)).json();
+  }
+
+  // --- CFEOIs ---
+
+  async publishCfeoi(cfeoi: { title: string; description: string; resourceType: string; proposalId: string; tags?: string }): Promise<string> {
+    return (await this.send('POST', '/Cfeoi', cfeoi)).json();
+  }
+
+  async setCfeoiStatus(id: string, newStatus: string): Promise<void> {
+    await this.send('PATCH', `/Cfeoi/${id}/status`, { newStatus });
+  }
+
+  async listCfeois(params?: { status?: string; proposalId?: string }): Promise<CfeoiDto[]> {
+    const query = new URLSearchParams(params as Record<string, string>).toString();
+    return (await this.send('GET', `/Cfeoi${query ? `?${query}` : ''}`)).json();
+  }
+
+  // --- EOIs ---
+
+  async submitEoi(cfeoiId: string, message: string): Promise<string> {
+    return (await this.send('POST', '/Eoi', { cfeoiId, message })).json();
+  }
+
+  async setEoiVisibility(id: string, visibility: string): Promise<void> {
+    await this.send('PATCH', `/Eoi/${id}/visibility`, JSON.stringify(visibility));
+  }
+
+  async setEoiStatus(id: string, newStatus: string): Promise<void> {
+    await this.send('PATCH', `/Eoi/${id}/status`, { newStatus });
+  }
+
+  async withdrawEoi(id: string): Promise<void> {
+    await this.send('PATCH', `/Eoi/${id}/withdraw`);
+  }
+
+  async listMyEois(): Promise<EoiDto[]> {
+    return (await this.send('GET', '/Eoi/my')).json();
+  }
+
+  async listEoisByCfeoi(cfeoiId: string): Promise<EoiDto[]> {
+    return (await this.send('GET', `/Eoi?cfeoiId=${cfeoiId}`)).json();
+  }
+}

--- a/frontend/staff/e2e/support/config.ts
+++ b/frontend/staff/e2e/support/config.ts
@@ -1,0 +1,40 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+/** The staff app under test. */
+export const STAFF_PORT = 5198;
+/** The expat portal, served alongside for the cross-app scenarios. */
+export const PORTAL_PORT = 5199;
+export const API_PORT = 5299;
+
+export const STAFF_URL = `http://localhost:${STAFF_PORT}`;
+export const PORTAL_URL = `http://localhost:${PORTAL_PORT}`;
+export const API_HOST = `http://localhost:${API_PORT}`;
+
+/** Must match TestAuth settings in src/Herit.Api/appsettings.E2E.json. */
+export const SIGNING_KEY = 'herit-e2e-signing-key-not-a-secret-0123456789abcdef0123456789abcdef';
+export const TOKEN_ISSUER = 'https://herit-e2e.local';
+export const TOKEN_AUDIENCE = 'herit-api-e2e';
+
+export const SUPER_ADMIN_EMAIL = 'superadmin@e2e.herit.local';
+export const SUPER_ADMIN_NAME = 'E2E Super Admin';
+
+export const REPO_ROOT = path.resolve(here, '../../../..');
+export const API_PROJECT = path.join(REPO_ROOT, 'src/Herit.Api');
+
+/** Per-run artifacts (storage states, run metadata). Gitignored. */
+export const STATE_DIR = path.resolve(here, '../.state');
+export const RUN_FILE = path.join(STATE_DIR, 'run.json');
+
+/**
+ * Storage states are origin-scoped: the fake MSAL stub reads its token from the
+ * localStorage of whichever app it runs in, so a `staff` state signs an identity
+ * into the staff origin and a `portal` state into the portal origin.
+ */
+export type AppOrigin = 'staff' | 'portal';
+
+export const originUrl = (app: AppOrigin): string => (app === 'portal' ? PORTAL_URL : STAFF_URL);
+
+export const storageStatePath = (name: string): string => path.join(STATE_DIR, `${name}.storage.json`);

--- a/frontend/staff/e2e/support/run-state.ts
+++ b/frontend/staff/e2e/support/run-state.ts
@@ -1,0 +1,75 @@
+import fs from 'node:fs';
+import { originUrl, RUN_FILE, STATE_DIR, storageStatePath, type AppOrigin } from './config';
+
+export interface TestIdentity {
+  email: string;
+  name: string;
+  externalId: string;
+  token: string;
+}
+
+export interface RunState {
+  runId: string;
+  rootOrgId: string;
+  rootOrgName: string;
+  childOrgId: string;
+  childOrgName: string;
+  /** The org admin's own User id — for asserting the self-delete backstop. */
+  orgAdminUserId: string;
+  /** The seeded staff user's id. */
+  staffUserId: string;
+  identities: {
+    superAdmin: TestIdentity;
+    /** OrganisationAdmin — drives the admin-only staff UI (orgs, users). */
+    orgAdmin: TestIdentity;
+    /** Plain Staff — admin nav/routes must be denied to it. */
+    staff: TestIdentity;
+    /** Registered expat — proposal owner and cross-app portal actor. */
+    expat: TestIdentity;
+    /** Registered expat — EOI contributor for the takedown/review scenarios. */
+    expatB: TestIdentity;
+    /** Registered expat — a second EOI submitter (API-only). */
+    expatC: TestIdentity;
+    /** NOT provisioned in the staff app (role Expat) — hits the access gate. */
+    /** Never registered at all — first-time JIT 404 hits the access gate too. */
+    unprovisioned: TestIdentity;
+  };
+}
+
+export function writeRunState(state: RunState): void {
+  fs.mkdirSync(STATE_DIR, { recursive: true });
+  fs.writeFileSync(RUN_FILE, JSON.stringify(state, null, 2));
+}
+
+export function readRunState(): RunState {
+  return JSON.parse(fs.readFileSync(RUN_FILE, 'utf8')) as RunState;
+}
+
+/** localStorage payload the apps' test-auth MSAL stub reads (see src/auth/testAuth.ts). */
+const identityPayload = (identity: TestIdentity): string =>
+  JSON.stringify({
+    token: identity.token,
+    account: { externalId: identity.externalId, email: identity.email, name: identity.name },
+  });
+
+/**
+ * Writes a Playwright storageState file whose localStorage signs the identity
+ * into the given app origin (key `herit.e2e.auth`), or — with `pending: true` —
+ * stages it so the next loginRedirect() call signs it in (key
+ * `herit.e2e.pendingAuth`), which lets a test drive the sign-in UI itself.
+ */
+export function writeStorageState(
+  name: string,
+  app: AppOrigin,
+  identity: TestIdentity,
+  options?: { pending?: boolean },
+): string {
+  const key = options?.pending ? 'herit.e2e.pendingAuth' : 'herit.e2e.auth';
+  const statePath = storageStatePath(name);
+  fs.mkdirSync(STATE_DIR, { recursive: true });
+  fs.writeFileSync(statePath, JSON.stringify({
+    cookies: [],
+    origins: [{ origin: originUrl(app), localStorage: [{ name: key, value: identityPayload(identity) }] }],
+  }, null, 2));
+  return statePath;
+}

--- a/frontend/staff/e2e/support/session.ts
+++ b/frontend/staff/e2e/support/session.ts
@@ -1,0 +1,26 @@
+import type { Browser, BrowserContext, Page } from '@playwright/test';
+import { originUrl, storageStatePath, type AppOrigin } from './config';
+
+export interface Session {
+  context: BrowserContext;
+  page: Page;
+  /** Absolute URL on the app this session targets, e.g. session.url('/rfps'). */
+  url: (path: string) => string;
+}
+
+/**
+ * Opens an isolated browser context for one of the identities whose storage
+ * state global.setup.ts wrote, scoped to a specific app origin (staff or
+ * portal), or an anonymous context when no storage-state name is given.
+ * Because the staff and portal apps run on different ports, `page.goto` needs
+ * an absolute URL — use `session.url(path)`. Callers should close the returned
+ * context (or rely on worker shutdown at the end of the run).
+ */
+export async function openSession(browser: Browser, app: AppOrigin, stateName?: string): Promise<Session> {
+  const context = await browser.newContext(
+    stateName ? { storageState: storageStatePath(stateName) } : {},
+  );
+  const page = await context.newPage();
+  const base = originUrl(app);
+  return { context, page, url: (path: string) => `${base}${path}` };
+}

--- a/frontend/staff/e2e/support/tokens.ts
+++ b/frontend/staff/e2e/support/tokens.ts
@@ -1,0 +1,22 @@
+import { SignJWT } from 'jose';
+import { SIGNING_KEY, TOKEN_AUDIENCE, TOKEN_ISSUER } from './config';
+
+/**
+ * External IDs are derived from the email exactly like the API's
+ * LocalTestIdentityProviderService does, so tokens minted here resolve to the
+ * users the seeder/staff endpoints create.
+ */
+export const externalIdFor = (email: string): string => `e2e-${email}`;
+
+/** Mint an HS256 bearer token the API's TestAuth scheme accepts. */
+export async function mintToken(email: string, name: string): Promise<string> {
+  const key = new TextEncoder().encode(SIGNING_KEY);
+  return new SignJWT({ oid: externalIdFor(email), email, name })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuer(TOKEN_ISSUER)
+    .setAudience(TOKEN_AUDIENCE)
+    .setSubject(externalIdFor(email))
+    .setIssuedAt()
+    .setExpirationTime('2h')
+    .sign(key);
+}

--- a/frontend/staff/e2e/takedown-cascade.spec.ts
+++ b/frontend/staff/e2e/takedown-cascade.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test, type Page } from '@playwright/test';
+import { Api } from './support/api';
+import { openSession } from './support/session';
+import { readRunState, type RunState } from './support/run-state';
+
+/**
+ * Scenario 4 — takedown cascade: deleting a proposal that has a CFEOI with an
+ * EOI removes the whole subtree. The contributor's portal "My EOIs" no longer
+ * lists the CFEOI, and the API confirms the CFEOI and EOI are gone.
+ */
+
+let state: RunState;
+let expatApi: Api;
+let expatBApi: Api;
+let proposalTitle = '';
+let proposalId = '';
+let cfeoiTitle = '';
+let cfeoiId = '';
+let eoiId = '';
+
+const dialog = (page: Page) => page.getByRole('dialog');
+
+test.beforeAll(async ({}, testInfo) => {
+  state = readRunState();
+  const scope = `${state.runId}-w${testInfo.workerIndex}`;
+  expatApi = await Api.forToken(state.identities.expat.token);
+  expatBApi = await Api.forToken(state.identities.expatB.token);
+
+  proposalTitle = `Rural Telehealth Rollout (E2E ${scope})`;
+  proposalId = await expatApi.createProposal({
+    title: proposalTitle,
+    shortDescription: 'Bring telehealth kits to remote clinics.',
+    longDescription: 'A staged rollout of telehealth equipment and training to rural clinics.',
+    organisationId: state.childOrgId,
+  });
+  await expatApi.setProposalStatus(proposalId, 'Resourcing');
+  await expatApi.setProposalVisibility(proposalId, 'Shared');
+
+  cfeoiTitle = `Telehealth Field Engineer (E2E ${scope})`;
+  cfeoiId = await expatApi.publishCfeoi({
+    title: cfeoiTitle,
+    description: 'Install and maintain telehealth kits on site.',
+    resourceType: 'Human',
+    proposalId,
+  });
+  eoiId = await expatBApi.submitEoi(cfeoiId, `Happy to run the rural installs. (E2E ${scope})`);
+});
+
+test.afterAll(async () => {
+  await Promise.all([expatApi.dispose(), expatBApi.dispose()]);
+});
+
+test('deleting a proposal cascades to its CFEOI and EOI', async ({ browser }) => {
+  test.setTimeout(120_000);
+
+  const portal = await openSession(browser, 'portal', 'portal-expatB');
+
+  await test.step("the contributor's My EOIs lists the CFEOI to start", async () => {
+    await portal.page.goto(portal.url('/my-eois'));
+    await expect(portal.page.getByRole('link', { name: cfeoiTitle })).toBeVisible();
+  });
+
+  const staff = await openSession(browser, 'staff', 'staff-staff');
+
+  await test.step('staff delete the proposal (checkbox-gated takedown)', async () => {
+    await staff.page.goto(staff.url(`/proposals/${proposalId}`));
+    await expect(staff.page.getByRole('heading', { name: proposalTitle, level: 1 })).toBeVisible();
+    // The CFEOI is listed under the proposal before deletion (substring match —
+    // the link's accessible name also includes the EOI count and status).
+    await expect(staff.page.getByRole('link', { name: cfeoiTitle })).toBeVisible();
+
+    await staff.page.getByRole('button', { name: 'Delete proposal' }).click();
+    const deleteModal = dialog(staff.page);
+    await expect(deleteModal.getByText('its CFEOIs and their EOIs are permanently deleted', { exact: false })).toBeVisible();
+    await expect(deleteModal.getByRole('button', { name: 'Delete proposal' })).toBeDisabled();
+    await deleteModal.getByRole('checkbox').check();
+    await deleteModal.getByRole('button', { name: 'Delete proposal' }).click();
+    await staff.page.waitForURL('**/proposals?deleted=true');
+    await expect(staff.page.getByText('Proposal deleted.')).toBeVisible();
+  });
+
+  await test.step('the CFEOI and EOI are gone at the API level', async () => {
+    // The CFEOI no longer resolves, and the contributor no longer owns the EOI.
+    const cfeoiLookup = await expatApi.raw('GET', `/Cfeoi/${cfeoiId}`);
+    expect(cfeoiLookup.status()).toBe(404);
+    const remainingEois = await expatBApi.listMyEois();
+    expect(remainingEois.map((e) => e.id)).not.toContain(eoiId);
+  });
+
+  await test.step("the contributor's portal My EOIs no longer lists the CFEOI", async () => {
+    await portal.page.goto(portal.url('/my-eois'));
+    await expect(portal.page.getByRole('link', { name: cfeoiTitle })).toHaveCount(0);
+  });
+
+  await staff.context.close();
+  await portal.context.close();
+});

--- a/frontend/staff/e2e/visibility-integrity.spec.ts
+++ b/frontend/staff/e2e/visibility-integrity.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test';
+import { Api } from './support/api';
+import { openSession } from './support/session';
+import { readRunState, type RunState } from './support/run-state';
+
+/**
+ * Scenario 7 — visibility integrity: a Private proposal is visible to staff in
+ * the "All proposals" tab by design, while remaining invisible to an anonymous
+ * portal session. The staff read bypass and the public visibility filter must
+ * coexist correctly — one assertion pair proves both.
+ */
+
+let state: RunState;
+let expatApi: Api;
+let proposalTitle = '';
+let proposalId = '';
+
+test.beforeAll(async ({}, testInfo) => {
+  state = readRunState();
+  const scope = `${state.runId}-w${testInfo.workerIndex}`;
+  expatApi = await Api.forToken(state.identities.expat.token);
+
+  // Proposals are created Private by default; leave it Private.
+  proposalTitle = `Confidential Vaccine Logistics (E2E ${scope})`;
+  proposalId = await expatApi.createProposal({
+    title: proposalTitle,
+    shortDescription: 'Cold-chain logistics plan — not for public listing.',
+    longDescription: 'A private working proposal for vaccine cold-chain logistics.',
+    organisationId: state.childOrgId,
+  });
+});
+
+test.afterAll(async () => {
+  await expatApi.dispose();
+});
+
+test('a Private proposal is visible to staff but hidden from the public portal', async ({ browser }) => {
+  test.setTimeout(120_000);
+
+  await test.step('staff see the Private proposal in the All tab', async () => {
+    const staff = await openSession(browser, 'staff', 'staff-staff');
+    await staff.page.goto(staff.url('/proposals?status=All'));
+    const row = staff.page.getByRole('link').filter({ hasText: proposalTitle });
+    await expect(row).toBeVisible();
+    await expect(row.getByText('Private')).toBeVisible();
+    await staff.context.close();
+  });
+
+  await test.step('the public API and portal both withhold it from anonymous callers', async () => {
+    const anon = await Api.anonymous();
+    expect((await anon.listProposals()).map((p) => p.title)).not.toContain(proposalTitle);
+    await anon.dispose();
+
+    const portal = await openSession(browser, 'portal');
+    await portal.page.goto(portal.url('/proposals'));
+    await portal.page.getByPlaceholder('Search proposals by title or description...').fill(proposalTitle);
+    await expect(portal.page.getByRole('heading', { name: proposalTitle })).toHaveCount(0);
+
+    await portal.page.goto(portal.url(`/proposals/${proposalId}`));
+    await expect(portal.page.getByText('This proposal is not publicly available.')).toBeVisible();
+    await portal.context.close();
+  });
+});

--- a/frontend/staff/package-lock.json
+++ b/frontend/staff/package-lock.json
@@ -17,6 +17,7 @@
         "react-router-dom": "^6.28.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.1.0",
         "@testing-library/user-event": "^14.5.2",
@@ -24,6 +25,7 @@
         "@types/react-dom": "^18.3.5",
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "^10.4.20",
+        "jose": "^6.2.3",
         "jsdom": "^26.0.0",
         "postcss": "^8.4.49",
         "tailwindcss": "^3.4.17",
@@ -976,6 +978,21 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@remix-run/router": {
@@ -2577,6 +2594,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2929,6 +2955,50 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/staff/package.json
+++ b/frontend/staff/package.json
@@ -10,7 +10,9 @@
     "preview": "vite preview",
     "test": "vitest",
     "test:ui": "vitest --ui",
-    "test:run": "vitest run"
+    "test:run": "vitest run",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@azure/msal-browser": "^3.27.0",
@@ -22,6 +24,7 @@
     "react-router-dom": "^6.28.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",
@@ -29,6 +32,7 @@
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.20",
+    "jose": "^6.2.3",
     "jsdom": "^26.0.0",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",

--- a/frontend/staff/playwright.config.ts
+++ b/frontend/staff/playwright.config.ts
@@ -1,0 +1,78 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * E2E suite for the staff app. Boots the real stack, and — because several
+ * scenarios assert across both frontends — serves the portal alongside it:
+ *  - Herit API in the dedicated E2E environment (test-auth scheme enabled,
+ *    SQL Server from appsettings.E2E.json — locally a Docker container on
+ *    port 14330, in CI a service container), on :5299,
+ *  - the staff app via Vite in `e2e` mode (test-auth MSAL stub enabled), on :5198,
+ *  - the expat portal via Vite in `e2e` mode, on :5199, so the cross-app
+ *    scenarios (RFP publish, proposal review, takedown cascade, visibility) can
+ *    drive an expat/anonymous portal session against the same database.
+ *
+ * The two SPAs share the localStorage token contract (src/auth/testAuth.ts),
+ * so the one token-minting harness signs identities into either origin.
+ *
+ * See docs/frontend/staff/e2e-testing.md for the auth strategy and local setup.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  outputDir: './e2e/.results',
+  // Specs share one database and one seeded baseline; run serially.
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  forbidOnly: !!process.env.CI,
+  timeout: 90_000,
+  expect: { timeout: 10_000 },
+  reporter: process.env.CI
+    ? [['list'], ['html', { open: 'never', outputFolder: 'e2e/.report' }]]
+    : [['list']],
+  use: {
+    baseURL: 'http://localhost:5198',
+    trace: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'setup',
+      testMatch: /global\.setup\.ts/,
+      teardown: 'cleanup',
+    },
+    {
+      name: 'cleanup',
+      testMatch: /global\.teardown\.ts/,
+    },
+    {
+      name: 'chromium',
+      testMatch: /.*\.spec\.ts/,
+      use: { ...devices['Desktop Chrome'] },
+      dependencies: ['setup'],
+    },
+  ],
+  webServer: [
+    {
+      command: 'dotnet run --no-launch-profile --project ../../src/Herit.Api',
+      url: 'http://localhost:5299/api/v1/Organisations',
+      reuseExistingServer: !process.env.CI,
+      timeout: 240_000,
+      env: {
+        ASPNETCORE_ENVIRONMENT: 'E2E',
+        ASPNETCORE_URLS: 'http://localhost:5299',
+      },
+    },
+    {
+      command: 'npx vite --mode e2e --port 5198 --strictPort',
+      url: 'http://localhost:5198',
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+    },
+    {
+      command: 'npx vite --mode e2e --port 5199 --strictPort',
+      cwd: '../portal',
+      url: 'http://localhost:5199',
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+    },
+  ],
+});

--- a/frontend/staff/src/pages/app/OrganisationsPage.test.tsx
+++ b/frontend/staff/src/pages/app/OrganisationsPage.test.tsx
@@ -25,7 +25,7 @@ const adminUser: User = { id: 'u1', email: 'amara@example.com', fullName: 'Amara
 const staffUser: User = { id: 'u2', email: 'jonas@example.com', fullName: 'Jonas Weber', role: 'Staff' };
 
 const organisations: Organisation[] = [
-  { id: 'root', name: 'Republic of Herit Government' },
+  { id: 'root', name: 'Republic of Herit Government', parentId: null },
   { id: 'health', name: 'Ministry of Health', parentId: 'root' },
   { id: 'piv', name: 'Patient Identity Verification Unit', parentId: 'health' },
 ];

--- a/frontend/staff/src/pages/app/OrganisationsPage.tsx
+++ b/frontend/staff/src/pages/app/OrganisationsPage.tsx
@@ -20,7 +20,9 @@ interface TreeNode extends Organisation {
 function buildTree(organisations: Organisation[]): TreeNode[] {
   const byParent = new Map<string | undefined, Organisation[]>();
   for (const org of organisations) {
-    const key = org.parentId;
+    // The API serialises the root's parentId as null; normalise to undefined so
+    // the root is keyed under the same value visit() starts the traversal from.
+    const key = org.parentId ?? undefined;
     const siblings = byParent.get(key) ?? [];
     siblings.push(org);
     byParent.set(key, siblings);

--- a/frontend/staff/src/types/index.ts
+++ b/frontend/staff/src/types/index.ts
@@ -72,7 +72,8 @@ export interface Proposal {
 export interface Organisation {
   id: string;
   name: string;
-  parentId?: string;
+  /** The API serialises the root organisation's parent as null (not omitted). */
+  parentId?: string | null;
 }
 
 export type CfeoiStatus = 'Open' | 'Closed';

--- a/frontend/staff/vite.config.ts
+++ b/frontend/staff/vite.config.ts
@@ -7,5 +7,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './src/test-setup.ts',
+    // Playwright E2E specs live in e2e/ and are run by `npm run e2e`, not vitest.
+    exclude: ['node_modules/**', 'e2e/**'],
   },
 });

--- a/src/Herit.Api/appsettings.E2E.json
+++ b/src/Herit.Api/appsettings.E2E.json
@@ -10,7 +10,7 @@
   "Features": {
     "EnableSwagger": false
   },
-  "AllowedOrigins": [ "http://localhost:5199" ],
+  "AllowedOrigins": [ "http://localhost:5199", "http://localhost:5198" ],
   // Placeholder values: the Entra scheme is registered but no Entra tokens are
   // ever presented during E2E runs — all requests carry TestAuth tokens.
   "AzureAd": {


### PR DESCRIPTION
## Description

Adds a Playwright E2E suite for the staff app in `frontend/staff/e2e/`, mirroring the portal's harness. It reuses the fake-MSAL test auth over the **shared localStorage token contract** (`src/auth/testAuth.ts`), seeds a known baseline through the CLI seeder + public API (never direct DB writes), and uses **origin-scoped storage states** so one token-minting harness signs identities into either the staff app (`:5198`) or the portal (`:5199`) against a single API (`:5299`). Playwright serves **both frontends simultaneously** so the cross-app scenarios work.

### Scenarios covered

1. **Auth & role gate** — staff sign-in reaches the dashboard; admin-only nav hidden from plain staff and admin pages blocked; org admin sees them; expat and unprovisioned identities both hit the access gate.
2. **RFP lifecycle + cross-app** — create → Draft → Approve (bare confirm) → Publish (confirm-with-summary) in the staff UI; the portal shows the published RFP; an edit-after-publish reaches the portal without re-approval; delete removes it.
3. **Proposal review loop + cross-app** — Submitted → Under Review → Approved; the expat's portal *My Proposals* shows `Approved`; no reject affordance anywhere.
4. **Takedown cascade** — deleting a proposal removes its CFEOI + EOI (portal contributor's *My EOIs* no longer lists it; API confirms).
5. **Staff EOI management** — approve/reject Pending EOIs, see `Private` submissions + the email column, delete via the checkbox-gated modal.
6. **Administration** — org-tree CRUD incl. the bootstrap empty state and the **409 refusal** on deleting a non-empty org (server message rendered); user management with client guards and the **self-delete 403 / last-org-admin 409** server backstops.
7. **Visibility integrity** — a `Private` proposal is visible in the staff *All proposals* tab yet invisible to an anonymous portal session (UI + API).

### Bugs the suite surfaced (and fixes)

- **CORS:** `appsettings.E2E.json` only allowed the portal origin, so the staff app's API calls were blocked — added `http://localhost:5198`.
- **Org tree:** `OrganisationsPage.buildTree` started traversal from `parentId === undefined`, but the API serialises the root's `parentId` as `null`, so the real tree rendered empty. Normalised `null → undefined`; the unit test now uses a `null` root to guard it (unit tests only ever mocked `undefined`, which is why it was missed).

## Linked Issue

Closes #310

## Type of Change

- [x] Feature
- [x] Bug fix (two latent bugs surfaced by the new suite)

## Testing Notes

Full suite runs green against a clean E2E database (`15 passed`), verified across repeated runs for stability. Locally: `docker` SQL on `:14330`, then `npm ci` in both `frontend/portal` and `frontend/staff`, then `npm run e2e` from `frontend/staff` (Playwright boots the API + both SPAs). Staff unit tests: `75 passed`.

## Checklist

- [x] Code builds cleanly (`npm run build`)
- [x] Tests pass (staff unit `npm test`; E2E `npm run e2e`)
- [x] Relevant documentation updated (`docs/frontend/staff/e2e-testing.md`)
- [x] Branch follows naming convention (`feature/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)