### PR TITLE
Provision internal users via Graph invitations instead of discarded temp passwords

### DIFF
--- a/docs/ops/super-admin-bootstrap.md
+++ b/docs/ops/super-admin-bootstrap.md
@@ -1,6 +1,13 @@
 # Super Admin Bootstrap
 
-One-time CLI command to seed the first super admin user into both Azure AD B2C and the database.
+One-time CLI command to seed the first super admin user into both Entra External ID and the database.
+
+The seeder provisions the Entra account through the Microsoft Graph `/invitations` API:
+Entra emails an invitation with the sign-in link to the provided address, and the user
+redeems it to set up their credentials. No temporary password is involved. The app
+registration must hold the admin-consented `User.Invite.All` application permission, and
+`AzureAd:InviteRedirectUrl` must be configured (the staff app URL; wired automatically in
+Azure via Bicep, set to `http://localhost:5174` in `appsettings.Development.json`).
 
 ## Command
 
@@ -16,7 +23,7 @@ Both `--email` and `--display-name` are required.
 
 ```
 info: Herit.Application.Seeding.SuperAdminSeeder[0]
-      Super admin created: admin@example.com (ExternalId: <b2c-object-id>)
+      Super admin created: admin@example.com (ExternalId: <entra-object-id>). An invitation email with the sign-in link has been sent.
 ```
 
 Process exits with code `0`.
@@ -41,7 +48,10 @@ Process exits with code `1`.
 
 ## Verification
 
-**B2C:** In the Azure portal, navigate to the B2C tenant → Users and confirm the account exists with the email provided.
+**Email:** The invited address receives an Entra invitation email; redeeming it lands the
+user on the staff app URL configured as `AzureAd:InviteRedirectUrl`.
+
+**Entra:** In the Entra admin center, navigate to the tenant → Users and confirm the account exists with the email provided.
 
 **Database:** Run the following query against the application database:
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -127,6 +127,7 @@ module api './app/api-appservice-avm.bicep' = {
       AzureAd__Domain: '@Microsoft.KeyVault(VaultName=${keyVault.outputs.name};SecretName=entra-tenant)'
       AzureAd__TenantId: '@Microsoft.KeyVault(VaultName=${keyVault.outputs.name};SecretName=entra-tenant-id)'
       AzureAd__ClientId: '@Microsoft.KeyVault(VaultName=${keyVault.outputs.name};SecretName=entra-client-id)'
+      AzureAd__InviteRedirectUrl: staff.outputs.SERVICE_STAFF_URI
       AllowedOrigins__0: web.outputs.SERVICE_WEB_URI
       AllowedOrigins__1: staff.outputs.SERVICE_STAFF_URI
     }

--- a/src/Herit.Api/appsettings.Development.json
+++ b/src/Herit.Api/appsettings.Development.json
@@ -13,6 +13,7 @@
     "Instance": "https://heritdomain.ciamlogin.com",
     "Domain": "heritdomain.onmicrosoft.com",
     "TenantId": "72b4b7c4-cf1b-45c6-923b-771539cb809c",
-    "ClientId": "9911dbe7-a96f-4ed8-8ec4-8f458e2cd10e"
+    "ClientId": "9911dbe7-a96f-4ed8-8ec4-8f458e2cd10e",
+    "InviteRedirectUrl": "http://localhost:5174"
   }
 }

--- a/src/Herit.Api/appsettings.json
+++ b/src/Herit.Api/appsettings.json
@@ -11,14 +11,19 @@
   "AllowedHosts": "*",
   // Microsoft Entra External ID (CIAM) JWT authentication settings.
   // Required keys:
-  //   Instance  – Entra External ID authority base URL, e.g. https://<tenant>.ciamlogin.com
-  //   Domain    – Entra tenant domain, e.g. <tenant>.onmicrosoft.com
-  //   TenantId  – Entra tenant ID (GUID)
-  //   ClientId  – Application (client) ID of the API registration
+  //   Instance          – Entra External ID authority base URL, e.g. https://<tenant>.ciamlogin.com
+  //   Domain            – Entra tenant domain, e.g. <tenant>.onmicrosoft.com
+  //   TenantId          – Entra tenant ID (GUID)
+  //   ClientId          – Application (client) ID of the API registration
+  //   InviteRedirectUrl – URL the Entra invitation email redirects to after redemption
+  //                       (the staff app URL). Internal users are provisioned via the
+  //                       Graph /invitations API, which requires the app registration to
+  //                       hold the admin-consented User.Invite.All application permission.
   "AzureAd": {
     "Instance": "https://<your-tenant>.ciamlogin.com",
     "Domain": "<your-tenant>.onmicrosoft.com",
     "TenantId": "<your-tenant-id>",
-    "ClientId": "<your-client-id>"
+    "ClientId": "<your-client-id>",
+    "InviteRedirectUrl": "https://<your-staff-app-url>"
   }
 }

--- a/src/Herit.Application/Interfaces/IIdentityProviderService.cs
+++ b/src/Herit.Application/Interfaces/IIdentityProviderService.cs
@@ -2,7 +2,10 @@ namespace Herit.Application.Interfaces;
 
 public interface IIdentityProviderService
 {
-    /// <summary>Creates an external identity account and returns its object ID.</summary>
+    /// <summary>
+    /// Creates an external identity account by inviting the email address and returns its object ID.
+    /// The identity provider sends the invitation email with the sign-in link.
+    /// </summary>
     Task<string> CreateUserAsync(string email, string displayName, CancellationToken ct);
 
     /// <summary>Deletes the external identity account identified by <paramref name="externalId"/>.</summary>

--- a/src/Herit.Application/Seeding/SuperAdminSeeder.cs
+++ b/src/Herit.Application/Seeding/SuperAdminSeeder.cs
@@ -34,6 +34,9 @@ public class SuperAdminSeeder
         var user = UserEntity.Create(Guid.NewGuid(), externalId, email, displayName, UserRole.SuperAdmin);
         await _userRepository.AddAsync(user, ct);
 
-        _logger.LogInformation("Super admin created: {Email} (ExternalId: {ExternalId})", email, externalId);
+        _logger.LogInformation(
+            "Super admin created: {Email} (ExternalId: {ExternalId}). An invitation email with the sign-in link has been sent.",
+            email,
+            externalId);
     }
 }

--- a/src/Herit.Infrastructure/Services/EntraExternalIdIdentityProviderService.cs
+++ b/src/Herit.Infrastructure/Services/EntraExternalIdIdentityProviderService.cs
@@ -9,7 +9,7 @@ namespace Herit.Infrastructure.Services;
 public class EntraExternalIdIdentityProviderService : IIdentityProviderService
 {
     private readonly GraphServiceClient _graphClient;
-    private readonly string _entraTenant;
+    private readonly string _inviteRedirectUrl;
 
     public EntraExternalIdIdentityProviderService(IConfiguration configuration)
     {
@@ -19,8 +19,8 @@ public class EntraExternalIdIdentityProviderService : IIdentityProviderService
             ?? throw new InvalidOperationException("AzureAd:ClientId is not configured.");
         var clientSecret = configuration["AzureAd:ClientSecret"]
             ?? throw new InvalidOperationException("AzureAd:ClientSecret is not configured.");
-        _entraTenant = configuration["AzureAd:Domain"]
-            ?? throw new InvalidOperationException("AzureAd:Domain is not configured.");
+        _inviteRedirectUrl = configuration["AzureAd:InviteRedirectUrl"]
+            ?? throw new InvalidOperationException("AzureAd:InviteRedirectUrl is not configured.");
 
         var credential = new ClientSecretCredential(tenantId, clientId, clientSecret);
         _graphClient = new GraphServiceClient(credential);
@@ -28,32 +28,19 @@ public class EntraExternalIdIdentityProviderService : IIdentityProviderService
 
     public async Task<string> CreateUserAsync(string email, string displayName, CancellationToken ct)
     {
-        var user = new User
+        var invitation = new Invitation
         {
-            AccountEnabled = true,
-            DisplayName = displayName,
-            Identities =
-            [
-                new ObjectIdentity
-                {
-                    SignInType = "emailAddress",
-                    Issuer = _entraTenant,
-                    IssuerAssignedId = email,
-                }
-            ],
-            PasswordProfile = new PasswordProfile
-            {
-                ForceChangePasswordNextSignIn = true,
-                Password = Guid.NewGuid().ToString("N") + "Aa1!",
-            },
-            PasswordPolicies = "DisablePasswordExpiration",
+            InvitedUserEmailAddress = email,
+            InvitedUserDisplayName = displayName,
+            InviteRedirectUrl = _inviteRedirectUrl,
+            SendInvitationMessage = true,
         };
 
-        var created = await _graphClient.Users.PostAsync(user, cancellationToken: ct)
-            ?? throw new InvalidOperationException("Graph API returned null when creating user.");
+        var created = await _graphClient.Invitations.PostAsync(invitation, cancellationToken: ct)
+            ?? throw new InvalidOperationException("Graph API returned null when creating the invitation.");
 
-        return created.Id
-            ?? throw new InvalidOperationException("Graph API did not return an object ID for the created user.");
+        return created.InvitedUser?.Id
+            ?? throw new InvalidOperationException("Graph API did not return an object ID for the invited user.");
     }
 
     public async Task DeleteUserAsync(string externalId, CancellationToken ct)

--- a/tests/Herit.Infrastructure.Tests/Herit.Infrastructure.Tests.csproj
+++ b/tests/Herit.Infrastructure.Tests/Herit.Infrastructure.Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/tests/Herit.Infrastructure.Tests/Services/EntraExternalIdIdentityProviderServiceTests.cs
+++ b/tests/Herit.Infrastructure.Tests/Services/EntraExternalIdIdentityProviderServiceTests.cs
@@ -1,0 +1,46 @@
+using Herit.Infrastructure.Services;
+using Microsoft.Extensions.Configuration;
+
+namespace Herit.Infrastructure.Tests.Services;
+
+public class EntraExternalIdIdentityProviderServiceTests
+{
+    private static IConfiguration BuildConfiguration(params string[] omittedKeys)
+    {
+        var settings = new Dictionary<string, string?>
+        {
+            ["AzureAd:TenantId"] = "00000000-0000-0000-0000-000000000001",
+            ["AzureAd:ClientId"] = "00000000-0000-0000-0000-000000000002",
+            ["AzureAd:ClientSecret"] = "secret-value",
+            ["AzureAd:InviteRedirectUrl"] = "https://staff.example.com",
+        };
+
+        foreach (var key in omittedKeys)
+            settings.Remove(key);
+
+        return new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+    }
+
+    [Fact]
+    public void Constructor_WithAllRequiredSettings_Succeeds()
+    {
+        var service = new EntraExternalIdIdentityProviderService(BuildConfiguration());
+
+        Assert.NotNull(service);
+    }
+
+    [Theory]
+    [InlineData("AzureAd:TenantId")]
+    [InlineData("AzureAd:ClientId")]
+    [InlineData("AzureAd:ClientSecret")]
+    [InlineData("AzureAd:InviteRedirectUrl")]
+    public void Constructor_WithMissingSetting_Throws(string omittedKey)
+    {
+        var configuration = BuildConfiguration(omittedKey);
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => new EntraExternalIdIdentityProviderService(configuration));
+
+        Assert.Equal($"{omittedKey} is not configured.", ex.Message);
+    }
+}


### PR DESCRIPTION
## Description

A successful super-admin seed (and staff/org-admin provisioning, which share the same code path) created the Entra account with a random in-process temporary password that was never logged, returned, or emailed — leaving the new user with no way to sign in.

`EntraExternalIdIdentityProviderService.CreateUserAsync` now provisions internal users through the Microsoft Graph `/invitations` API with `SendInvitationMessage = true`, so Entra emails the sign-in invitation link itself. No temporary password is involved.

Supporting changes:
- New required config key `AzureAd:InviteRedirectUrl` (where the invitation lands after redemption): set to `http://localhost:5174` (staff app) in Development, documented placeholder in base appsettings, and wired to the deployed staff app URI in `infra/main.bicep`.
- Seeder log line and `docs/ops/super-admin-bootstrap.md` updated to describe the invitation flow, including the `User.Invite.All` application-permission requirement.
- `IIdentityProviderService` doc comment updated; E2E stub (`LocalTestIdentityProviderService`) unchanged.

## Linked Issue

Closes #314

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- Added `EntraExternalIdIdentityProviderServiceTests` covering constructor config validation for all four required `AzureAd` keys, including the new `InviteRedirectUrl`.
- Full suite: 302 tests pass (`dotnet build` / `dotnet test` in Release).
- The live Graph invitation call requires the app registration to hold admin-consented `User.Invite.All`; verify in the tenant before relying on it in a deployed environment.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [x] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)