### PR TITLE
Replace B2B invitation with Graph local-account creation

### DIFF
--- a/docs/ops/super-admin-bootstrap.md
+++ b/docs/ops/super-admin-bootstrap.md
@@ -2,12 +2,13 @@
 
 One-time CLI command to seed the first super admin user into both Entra External ID and the database.
 
-The seeder provisions the Entra account through the Microsoft Graph `/invitations` API:
-Entra emails an invitation with the sign-in link to the provided address, and the user
-redeems it to set up their credentials. No temporary password is involved. The app
-registration must hold the admin-consented `User.Invite.All` application permission, and
-`AzureAd:InviteRedirectUrl` must be configured (the staff app URL; wired automatically in
-Azure via Bicep, set to `http://localhost:5174` in `appsettings.Development.json`).
+The seeder provisions the Entra account through the Microsoft Graph `/users` API: a local
+account is created with a random password that is discarded immediately and
+`ForceChangePasswordNextSignIn` set, so the account exists but no one knows its password.
+The user sets their own credentials via **Forgot password?** (SSPR) on the sign-in page.
+The app registration must hold the admin-consented `User.ReadWrite.All` application
+permission, and `AzureAd:Domain` must be configured (the tenant domain, used as the local
+sign-in identity issuer).
 
 ## Command
 
@@ -23,7 +24,7 @@ Both `--email` and `--display-name` are required.
 
 ```
 info: Herit.Application.Seeding.SuperAdminSeeder[0]
-      Super admin created: admin@example.com (ExternalId: <entra-object-id>). An invitation email with the sign-in link has been sent.
+      Super admin created: admin@example.com (ExternalId: <entra-object-id>).
 ```
 
 Process exits with code `0`.
@@ -48,9 +49,6 @@ Process exits with code `1`.
 
 ## Verification
 
-**Email:** The invited address receives an Entra invitation email; redeeming it lands the
-user on the staff app URL configured as `AzureAd:InviteRedirectUrl`.
-
 **Entra:** In the Entra admin center, navigate to the tenant → Users and confirm the account exists with the email provided.
 
 **Database:** Run the following query against the application database:
@@ -61,4 +59,4 @@ FROM Users
 WHERE Role = 0; -- 0 = SuperAdmin
 ```
 
-Confirm one row is returned with the expected email and a non-null `ExternalId` matching the B2C object ID.
+Confirm one row is returned with the expected email and a non-null `ExternalId` matching the Entra object ID.

--- a/src/Herit.Api/appsettings.json
+++ b/src/Herit.Api/appsettings.json
@@ -12,13 +12,14 @@
   // Microsoft Entra External ID (CIAM) JWT authentication settings.
   // Required keys:
   //   Instance          – Entra External ID authority base URL, e.g. https://<tenant>.ciamlogin.com
-  //   Domain            – Entra tenant domain, e.g. <tenant>.onmicrosoft.com
+  //   Domain            – Entra tenant domain, e.g. <tenant>.onmicrosoft.com. Also used as the
+  //                       Issuer of the local sign-in identity when provisioning users.
   //   TenantId          – Entra tenant ID (GUID)
   //   ClientId          – Application (client) ID of the API registration
-  //   InviteRedirectUrl – URL the Entra invitation email redirects to after redemption
-  //                       (the staff app URL). Internal users are provisioned via the
-  //                       Graph /invitations API, which requires the app registration to
-  //                       hold the admin-consented User.Invite.All application permission.
+  //   InviteRedirectUrl – Staff app URL linked from the app-sent invitation email. Internal
+  //                       users are provisioned via the Graph /users API (local accounts with
+  //                       SSPR), which requires the app registration to hold the
+  //                       admin-consented User.ReadWrite.All application permission.
   "AzureAd": {
     "Instance": "https://<your-tenant>.ciamlogin.com",
     "Domain": "<your-tenant>.onmicrosoft.com",

--- a/src/Herit.Application/Interfaces/IIdentityProviderService.cs
+++ b/src/Herit.Application/Interfaces/IIdentityProviderService.cs
@@ -3,8 +3,10 @@ namespace Herit.Application.Interfaces;
 public interface IIdentityProviderService
 {
     /// <summary>
-    /// Creates an external identity account by inviting the email address and returns its object ID.
-    /// The identity provider sends the invitation email with the sign-in link.
+    /// Creates a local external identity account for the email address and returns its object ID.
+    /// The account is created with a random, unreturned password and
+    /// <c>ForceChangePasswordNextSignIn</c>; the caller is responsible for sending the user an
+    /// invitation to set up their own credentials via SSPR.
     /// </summary>
     Task<string> CreateUserAsync(string email, string displayName, CancellationToken ct);
 

--- a/src/Herit.Application/Seeding/SuperAdminSeeder.cs
+++ b/src/Herit.Application/Seeding/SuperAdminSeeder.cs
@@ -35,7 +35,7 @@ public class SuperAdminSeeder
         await _userRepository.AddAsync(user, ct);
 
         _logger.LogInformation(
-            "Super admin created: {Email} (ExternalId: {ExternalId}). An invitation email with the sign-in link has been sent.",
+            "Super admin created: {Email} (ExternalId: {ExternalId}).",
             email,
             externalId);
     }

--- a/src/Herit.Infrastructure/Services/EntraExternalIdIdentityProviderService.cs
+++ b/src/Herit.Infrastructure/Services/EntraExternalIdIdentityProviderService.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using Azure.Identity;
 using Herit.Application.Interfaces;
 using Microsoft.Extensions.Configuration;
@@ -9,7 +10,7 @@ namespace Herit.Infrastructure.Services;
 public class EntraExternalIdIdentityProviderService : IIdentityProviderService
 {
     private readonly GraphServiceClient _graphClient;
-    private readonly string _inviteRedirectUrl;
+    private readonly string _domain;
 
     public EntraExternalIdIdentityProviderService(IConfiguration configuration)
     {
@@ -19,8 +20,8 @@ public class EntraExternalIdIdentityProviderService : IIdentityProviderService
             ?? throw new InvalidOperationException("AzureAd:ClientId is not configured.");
         var clientSecret = configuration["AzureAd:ClientSecret"]
             ?? throw new InvalidOperationException("AzureAd:ClientSecret is not configured.");
-        _inviteRedirectUrl = configuration["AzureAd:InviteRedirectUrl"]
-            ?? throw new InvalidOperationException("AzureAd:InviteRedirectUrl is not configured.");
+        _domain = configuration["AzureAd:Domain"]
+            ?? throw new InvalidOperationException("AzureAd:Domain is not configured.");
 
         var credential = new ClientSecretCredential(tenantId, clientId, clientSecret);
         _graphClient = new GraphServiceClient(credential);
@@ -28,19 +29,65 @@ public class EntraExternalIdIdentityProviderService : IIdentityProviderService
 
     public async Task<string> CreateUserAsync(string email, string displayName, CancellationToken ct)
     {
-        var invitation = new Invitation
+        var user = new User
         {
-            InvitedUserEmailAddress = email,
-            InvitedUserDisplayName = displayName,
-            InviteRedirectUrl = _inviteRedirectUrl,
-            SendInvitationMessage = true,
+            AccountEnabled = true,
+            DisplayName = displayName,
+            Mail = email,
+            Identities =
+            [
+                new ObjectIdentity
+                {
+                    SignInType = "emailAddress",
+                    Issuer = _domain,
+                    IssuerAssignedId = email,
+                },
+            ],
+            PasswordProfile = new PasswordProfile
+            {
+                Password = GenerateTemporaryPassword(),
+                ForceChangePasswordNextSignIn = true,
+            },
+            PasswordPolicies = "DisablePasswordExpiration",
         };
 
-        var created = await _graphClient.Invitations.PostAsync(invitation, cancellationToken: ct)
-            ?? throw new InvalidOperationException("Graph API returned null when creating the invitation.");
+        var created = await _graphClient.Users.PostAsync(user, cancellationToken: ct)
+            ?? throw new InvalidOperationException("Graph API returned null when creating the user.");
 
-        return created.InvitedUser?.Id
-            ?? throw new InvalidOperationException("Graph API did not return an object ID for the invited user.");
+        return created.Id
+            ?? throw new InvalidOperationException("Graph API did not return an object ID for the created user.");
+    }
+
+    /// <summary>
+    /// Generates a random password meeting Entra's complexity requirements. It is set with
+    /// <c>ForceChangePasswordNextSignIn</c> so the user never actually uses it; it must never
+    /// be logged or returned.
+    /// </summary>
+    private static string GenerateTemporaryPassword()
+    {
+        const string lower = "abcdefghijkmnopqrstuvwxyz";
+        const string upper = "ABCDEFGHJKLMNPQRSTUVWXYZ";
+        const string digits = "23456789";
+        const string special = "!@#$%^&*-_=+";
+        const string all = lower + upper + digits + special;
+
+        Span<char> password = stackalloc char[24];
+        password[0] = lower[RandomNumberGenerator.GetInt32(lower.Length)];
+        password[1] = upper[RandomNumberGenerator.GetInt32(upper.Length)];
+        password[2] = digits[RandomNumberGenerator.GetInt32(digits.Length)];
+        password[3] = special[RandomNumberGenerator.GetInt32(special.Length)];
+
+        for (var i = 4; i < password.Length; i++)
+            password[i] = all[RandomNumberGenerator.GetInt32(all.Length)];
+
+        // Shuffle so the guaranteed-category characters aren't always in the first four slots.
+        for (var i = password.Length - 1; i > 0; i--)
+        {
+            var j = RandomNumberGenerator.GetInt32(i + 1);
+            (password[i], password[j]) = (password[j], password[i]);
+        }
+
+        return new string(password);
     }
 
     public async Task DeleteUserAsync(string externalId, CancellationToken ct)

--- a/tests/Herit.Infrastructure.Tests/Services/EntraExternalIdIdentityProviderServiceTests.cs
+++ b/tests/Herit.Infrastructure.Tests/Services/EntraExternalIdIdentityProviderServiceTests.cs
@@ -12,7 +12,7 @@ public class EntraExternalIdIdentityProviderServiceTests
             ["AzureAd:TenantId"] = "00000000-0000-0000-0000-000000000001",
             ["AzureAd:ClientId"] = "00000000-0000-0000-0000-000000000002",
             ["AzureAd:ClientSecret"] = "secret-value",
-            ["AzureAd:InviteRedirectUrl"] = "https://staff.example.com",
+            ["AzureAd:Domain"] = "staff.example.com",
         };
 
         foreach (var key in omittedKeys)
@@ -33,7 +33,7 @@ public class EntraExternalIdIdentityProviderServiceTests
     [InlineData("AzureAd:TenantId")]
     [InlineData("AzureAd:ClientId")]
     [InlineData("AzureAd:ClientSecret")]
-    [InlineData("AzureAd:InviteRedirectUrl")]
+    [InlineData("AzureAd:Domain")]
     public void Constructor_WithMissingSetting_Throws(string omittedKey)
     {
         var configuration = BuildConfiguration(omittedKey);


### PR DESCRIPTION
## Description

`EntraExternalIdIdentityProviderService.CreateUserAsync` now calls `POST /v1.0/users` to create a local sign-in account directly, instead of `POST /invitations` (B2B guest invite flow). The created user gets a cryptographically random password that is never logged or returned, `ForceChangePasswordNextSignIn = true`, and `PasswordPolicies = "DisablePasswordExpiration"`, so the user redeems access via **Forgot password?** (SSPR) rather than an Entra-sent invite link.

Config requirement changed from `AzureAd:InviteRedirectUrl` to `AzureAd:Domain` (tenant domain, used as the `Issuer` of the local sign-in identity) for this class. `InviteRedirectUrl` remains in config for later use in the app-sent invitation email (a follow-up issue).

## Linked Issue

Closes #316

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- `dotnet build --configuration Release` succeeds.
- `dotnet test --configuration Release --no-build` — all 302 tests pass.
- Updated `EntraExternalIdIdentityProviderServiceTests` to require `AzureAd:Domain` instead of `AzureAd:InviteRedirectUrl`.
- Updated `docs/ops/super-admin-bootstrap.md` to describe the local-account/SSPR flow and the `User.ReadWrite.All` permission requirement.
- Removed the now-inaccurate "invitation email sent" log line from `SuperAdminSeeder` (email sending is a separate follow-up issue).

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [x] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)