### PR TITLE
Add IEmailService and send internal-user invitation emails

### DIFF
--- a/src/Herit.Api/Program.cs
+++ b/src/Herit.Api/Program.cs
@@ -53,7 +53,7 @@ var connectionString = (!string.IsNullOrEmpty(connectionStringKey)
     : null)
     ?? builder.Configuration.GetConnectionString("DefaultConnection")!;
 
-builder.Services.AddInfrastructure(connectionString);
+builder.Services.AddInfrastructure(connectionString, builder.Configuration);
 
 if (TestAuthentication.IsEnabled(builder.Configuration, builder.Environment))
 {
@@ -138,7 +138,7 @@ static async Task<int> RunSeedSuperAdminAsync(string[] args)
         : null)
         ?? seedBuilder.Configuration.GetConnectionString("DefaultConnection")!;
 
-    seedBuilder.Services.AddInfrastructure(seedConnectionString);
+    seedBuilder.Services.AddInfrastructure(seedConnectionString, seedBuilder.Configuration);
     seedBuilder.Services.AddScoped<SuperAdminSeeder>();
 
     if (TestAuthentication.IsEnabled(seedBuilder.Configuration, seedBuilder.Environment))

--- a/src/Herit.Api/appsettings.E2E.json
+++ b/src/Herit.Api/appsettings.E2E.json
@@ -17,7 +17,8 @@
     "Instance": "https://e2e-placeholder.ciamlogin.com",
     "Domain": "e2e-placeholder.onmicrosoft.com",
     "TenantId": "00000000-0000-0000-0000-000000000000",
-    "ClientId": "00000000-0000-0000-0000-000000000001"
+    "ClientId": "00000000-0000-0000-0000-000000000001",
+    "InviteRedirectUrl": "http://localhost:5198"
   },
   "ConnectionStrings": {
     "DefaultConnection": "Server=localhost,14330;Database=HeritE2E;User Id=sa;Password=HeritE2e!Passw0rd;TrustServerCertificate=True;Encrypt=False"

--- a/src/Herit.Api/appsettings.json
+++ b/src/Herit.Api/appsettings.json
@@ -26,5 +26,11 @@
     "TenantId": "<your-tenant-id>",
     "ClientId": "<your-client-id>",
     "InviteRedirectUrl": "https://<your-staff-app-url>"
+  },
+  // Internal-user invitation emails. When Email:AcsConnectionString is unset (the
+  // Development default), emails are logged instead of sent.
+  "Email": {
+    "AcsConnectionString": "",
+    "SenderAddress": "<your-acs-sender-address>"
   }
 }

--- a/src/Herit.Application/Features/User/Commands/CreateOrganisationAdmin/CreateOrganisationAdminCommand.cs
+++ b/src/Herit.Application/Features/User/Commands/CreateOrganisationAdmin/CreateOrganisationAdminCommand.cs
@@ -2,6 +2,7 @@ using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
 using MediatR;
+using Microsoft.Extensions.Logging;
 using UserEntity = Herit.Domain.Entities.User;
 
 namespace Herit.Application.Features.User.Commands.CreateOrganisationAdmin;
@@ -13,12 +14,21 @@ public class CreateOrganisationAdminCommandHandler : IRequestHandler<CreateOrgan
     private readonly IUserRepository _userRepository;
     private readonly IOrganisationRepository _organisationRepository;
     private readonly IIdentityProviderService _identityProviderService;
+    private readonly IEmailService _emailService;
+    private readonly ILogger<CreateOrganisationAdminCommandHandler> _logger;
 
-    public CreateOrganisationAdminCommandHandler(IUserRepository userRepository, IOrganisationRepository organisationRepository, IIdentityProviderService identityProviderService)
+    public CreateOrganisationAdminCommandHandler(
+        IUserRepository userRepository,
+        IOrganisationRepository organisationRepository,
+        IIdentityProviderService identityProviderService,
+        IEmailService emailService,
+        ILogger<CreateOrganisationAdminCommandHandler> logger)
     {
         _userRepository = userRepository;
         _organisationRepository = organisationRepository;
         _identityProviderService = identityProviderService;
+        _emailService = emailService;
+        _logger = logger;
     }
 
     public async Task<Guid> Handle(CreateOrganisationAdminCommand request, CancellationToken cancellationToken)
@@ -32,6 +42,18 @@ public class CreateOrganisationAdminCommandHandler : IRequestHandler<CreateOrgan
         var user = UserEntity.Create(Guid.NewGuid(), externalId, request.Email, request.FullName, UserRole.OrganisationAdmin, request.OrganisationId);
 
         await _userRepository.AddAsync(user, cancellationToken);
+
+        try
+        {
+            await _emailService.SendInternalUserInvitationAsync(request.Email, request.FullName, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to send invitation email to {Email}. The account was created successfully; manually notify the user or re-trigger the invitation email.",
+                request.Email);
+        }
 
         return user.Id;
     }

--- a/src/Herit.Application/Features/User/Commands/CreateStaffUser/CreateStaffUserCommand.cs
+++ b/src/Herit.Application/Features/User/Commands/CreateStaffUser/CreateStaffUserCommand.cs
@@ -2,6 +2,7 @@ using Herit.Application.Exceptions;
 using Herit.Application.Interfaces;
 using Herit.Domain.Enums;
 using MediatR;
+using Microsoft.Extensions.Logging;
 using UserEntity = Herit.Domain.Entities.User;
 
 namespace Herit.Application.Features.User.Commands.CreateStaffUser;
@@ -13,12 +14,21 @@ public class CreateStaffUserCommandHandler : IRequestHandler<CreateStaffUserComm
     private readonly IUserRepository _userRepository;
     private readonly IOrganisationRepository _organisationRepository;
     private readonly IIdentityProviderService _identityProviderService;
+    private readonly IEmailService _emailService;
+    private readonly ILogger<CreateStaffUserCommandHandler> _logger;
 
-    public CreateStaffUserCommandHandler(IUserRepository userRepository, IOrganisationRepository organisationRepository, IIdentityProviderService identityProviderService)
+    public CreateStaffUserCommandHandler(
+        IUserRepository userRepository,
+        IOrganisationRepository organisationRepository,
+        IIdentityProviderService identityProviderService,
+        IEmailService emailService,
+        ILogger<CreateStaffUserCommandHandler> logger)
     {
         _userRepository = userRepository;
         _organisationRepository = organisationRepository;
         _identityProviderService = identityProviderService;
+        _emailService = emailService;
+        _logger = logger;
     }
 
     public async Task<Guid> Handle(CreateStaffUserCommand request, CancellationToken cancellationToken)
@@ -32,6 +42,18 @@ public class CreateStaffUserCommandHandler : IRequestHandler<CreateStaffUserComm
         var user = UserEntity.Create(Guid.NewGuid(), externalId, request.Email, request.FullName, UserRole.Staff, request.OrganisationId);
 
         await _userRepository.AddAsync(user, cancellationToken);
+
+        try
+        {
+            await _emailService.SendInternalUserInvitationAsync(request.Email, request.FullName, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to send invitation email to {Email}. The account was created successfully; manually notify the user or re-trigger the invitation email.",
+                request.Email);
+        }
 
         return user.Id;
     }

--- a/src/Herit.Application/Interfaces/IEmailService.cs
+++ b/src/Herit.Application/Interfaces/IEmailService.cs
@@ -1,0 +1,10 @@
+namespace Herit.Application.Interfaces;
+
+public interface IEmailService
+{
+    /// <summary>
+    /// Sends an internal user their invitation email: the account is ready, and they set their
+    /// own password via Forgot password? (SSPR) on the sign-in page.
+    /// </summary>
+    Task SendInternalUserInvitationAsync(string email, string displayName, CancellationToken ct);
+}

--- a/src/Herit.Application/Seeding/SuperAdminSeeder.cs
+++ b/src/Herit.Application/Seeding/SuperAdminSeeder.cs
@@ -9,15 +9,18 @@ public class SuperAdminSeeder
 {
     private readonly IUserRepository _userRepository;
     private readonly IIdentityProviderService _identityProviderService;
+    private readonly IEmailService _emailService;
     private readonly ILogger<SuperAdminSeeder> _logger;
 
     public SuperAdminSeeder(
         IUserRepository userRepository,
         IIdentityProviderService identityProviderService,
+        IEmailService emailService,
         ILogger<SuperAdminSeeder> logger)
     {
         _userRepository = userRepository;
         _identityProviderService = identityProviderService;
+        _emailService = emailService;
         _logger = logger;
     }
 
@@ -38,5 +41,17 @@ public class SuperAdminSeeder
             "Super admin created: {Email} (ExternalId: {ExternalId}).",
             email,
             externalId);
+
+        try
+        {
+            await _emailService.SendInternalUserInvitationAsync(email, displayName, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to send invitation email to {Email}. The account was created successfully; manually notify the user or re-trigger the invitation email.",
+                email);
+        }
     }
 }

--- a/src/Herit.Infrastructure/DependencyInjection.cs
+++ b/src/Herit.Infrastructure/DependencyInjection.cs
@@ -3,13 +3,14 @@ using Herit.Infrastructure.Persistence;
 using Herit.Infrastructure.Repositories;
 using Herit.Infrastructure.Services;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Herit.Infrastructure;
 
 public static class DependencyInjection
 {
-    public static IServiceCollection AddInfrastructure(this IServiceCollection services, string connectionString)
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services, string connectionString, IConfiguration configuration)
     {
         services.AddDbContext<HeritDbContext>(options =>
             options.UseSqlServer(connectionString));
@@ -21,6 +22,11 @@ public static class DependencyInjection
         services.AddScoped<IEoiRepository, EoiRepository>();
         services.AddScoped<IOrganisationRepository, OrganisationRepository>();
         services.AddScoped<IIdentityProviderService, EntraExternalIdIdentityProviderService>();
+
+        if (!string.IsNullOrEmpty(configuration["Email:AcsConnectionString"]))
+            services.AddScoped<IEmailService, AcsEmailService>();
+        else
+            services.AddScoped<IEmailService, LoggingEmailService>();
 
         return services;
     }

--- a/src/Herit.Infrastructure/Herit.Infrastructure.csproj
+++ b/src/Herit.Infrastructure/Herit.Infrastructure.csproj
@@ -5,6 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Communication.Email" Version="1.1.0" />
     <PackageReference Include="Azure.Identity" Version="1.20.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />

--- a/src/Herit.Infrastructure/Services/AcsEmailService.cs
+++ b/src/Herit.Infrastructure/Services/AcsEmailService.cs
@@ -1,0 +1,38 @@
+using Azure;
+using Azure.Communication.Email;
+using Herit.Application.Interfaces;
+using Microsoft.Extensions.Configuration;
+
+namespace Herit.Infrastructure.Services;
+
+public class AcsEmailService : IEmailService
+{
+    private readonly EmailClient _emailClient;
+    private readonly string _senderAddress;
+    private readonly string _inviteRedirectUrl;
+
+    public AcsEmailService(IConfiguration configuration)
+    {
+        var connectionString = configuration["Email:AcsConnectionString"]
+            ?? throw new InvalidOperationException("Email:AcsConnectionString is not configured.");
+        _senderAddress = configuration["Email:SenderAddress"]
+            ?? throw new InvalidOperationException("Email:SenderAddress is not configured.");
+        _inviteRedirectUrl = configuration["AzureAd:InviteRedirectUrl"]
+            ?? throw new InvalidOperationException("AzureAd:InviteRedirectUrl is not configured.");
+
+        _emailClient = new EmailClient(connectionString);
+    }
+
+    public async Task SendInternalUserInvitationAsync(string email, string displayName, CancellationToken ct)
+    {
+        var message = new EmailMessage(
+            senderAddress: _senderAddress,
+            recipientAddress: email,
+            content: new EmailContent(InternalUserInvitationEmail.Subject)
+            {
+                PlainText = InternalUserInvitationEmail.BuildBody(displayName, _inviteRedirectUrl),
+            });
+
+        await _emailClient.SendAsync(WaitUntil.Completed, message, ct);
+    }
+}

--- a/src/Herit.Infrastructure/Services/InternalUserInvitationEmail.cs
+++ b/src/Herit.Infrastructure/Services/InternalUserInvitationEmail.cs
@@ -1,0 +1,16 @@
+namespace Herit.Infrastructure.Services;
+
+/// <summary>Shared subject/body for the internal-user invitation email, used by every <see cref="Herit.Application.Interfaces.IEmailService"/> implementation.</summary>
+internal static class InternalUserInvitationEmail
+{
+    public const string Subject = "You've been invited to Herit";
+
+    public static string BuildBody(string displayName, string staffAppUrl) =>
+        $"""
+        Hi {displayName},
+
+        Your Herit account is ready. Sign in at {staffAppUrl} and click "Forgot password?" on the sign-in page to set your password.
+
+        Welcome to Herit.
+        """;
+}

--- a/src/Herit.Infrastructure/Services/LoggingEmailService.cs
+++ b/src/Herit.Infrastructure/Services/LoggingEmailService.cs
@@ -1,0 +1,35 @@
+using Herit.Application.Interfaces;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Herit.Infrastructure.Services;
+
+/// <summary>
+/// Logs the full email instead of sending it. Registered when no ACS connection string is
+/// configured (the Development default).
+/// </summary>
+public class LoggingEmailService : IEmailService
+{
+    private readonly string _inviteRedirectUrl;
+    private readonly ILogger<LoggingEmailService> _logger;
+
+    public LoggingEmailService(IConfiguration configuration, ILogger<LoggingEmailService> logger)
+    {
+        _inviteRedirectUrl = configuration["AzureAd:InviteRedirectUrl"]
+            ?? throw new InvalidOperationException("AzureAd:InviteRedirectUrl is not configured.");
+        _logger = logger;
+    }
+
+    public Task SendInternalUserInvitationAsync(string email, string displayName, CancellationToken ct)
+    {
+        var body = InternalUserInvitationEmail.BuildBody(displayName, _inviteRedirectUrl);
+
+        _logger.LogInformation(
+            "Email not sent (no ACS connection string configured). To: {Email}, Subject: {Subject}\n{Body}",
+            email,
+            InternalUserInvitationEmail.Subject,
+            body);
+
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Herit.Application.Tests/Features/User/Commands/CreateOrganisationAdminCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/User/Commands/CreateOrganisationAdminCommandHandlerTests.cs
@@ -1,6 +1,7 @@
 using Herit.Application.Exceptions;
 using Herit.Application.Features.User.Commands.CreateOrganisationAdmin;
 using Herit.Application.Interfaces;
+using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using OrganisationEntity = Herit.Domain.Entities.Organisation;
@@ -13,12 +14,18 @@ public class CreateOrganisationAdminCommandHandlerTests
     private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
     private readonly IOrganisationRepository _organisationRepository = Substitute.For<IOrganisationRepository>();
     private readonly IIdentityProviderService _identityProviderService = Substitute.For<IIdentityProviderService>();
+    private readonly IEmailService _emailService = Substitute.For<IEmailService>();
 
     private readonly CreateOrganisationAdminCommandHandler _handler;
 
     public CreateOrganisationAdminCommandHandlerTests()
     {
-        _handler = new CreateOrganisationAdminCommandHandler(_userRepository, _organisationRepository, _identityProviderService);
+        _handler = new CreateOrganisationAdminCommandHandler(
+            _userRepository,
+            _organisationRepository,
+            _identityProviderService,
+            _emailService,
+            NullLogger<CreateOrganisationAdminCommandHandler>.Instance);
     }
 
     [Fact]
@@ -51,6 +58,25 @@ public class CreateOrganisationAdminCommandHandlerTests
         await _userRepository.Received(1).AddAsync(
             Arg.Is<UserEntity>(u => u.Email == "admin@gov.eg" && u.FullName == "Organisation Admin" && u.OrganisationId == orgId),
             Arg.Any<CancellationToken>());
+        await _emailService.Received(1).SendInternalUserInvitationAsync("admin@gov.eg", "Organisation Admin", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenEmailServiceThrows_StillReturnsCreatedUserId()
+    {
+        var orgId = Guid.NewGuid();
+        var organisation = OrganisationEntity.Create(orgId, "Test Organisation");
+        _organisationRepository.GetByIdAsync(orgId, Arg.Any<CancellationToken>()).Returns(organisation);
+        _identityProviderService.CreateUserAsync("admin@gov.eg", "Organisation Admin", Arg.Any<CancellationToken>()).Returns("ext-admin-1");
+        _emailService.SendInternalUserInvitationAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("SMTP unavailable"));
+
+        var command = new CreateOrganisationAdminCommand("admin@gov.eg", "Organisation Admin", orgId);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.NotEqual(Guid.Empty, result);
+        await _userRepository.Received(1).AddAsync(Arg.Any<UserEntity>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/Herit.Application.Tests/Features/User/Commands/CreateStaffUserCommandHandlerTests.cs
+++ b/tests/Herit.Application.Tests/Features/User/Commands/CreateStaffUserCommandHandlerTests.cs
@@ -1,6 +1,7 @@
 using Herit.Application.Exceptions;
 using Herit.Application.Features.User.Commands.CreateStaffUser;
 using Herit.Application.Interfaces;
+using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using OrganisationEntity = Herit.Domain.Entities.Organisation;
@@ -13,12 +14,18 @@ public class CreateStaffUserCommandHandlerTests
     private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
     private readonly IOrganisationRepository _organisationRepository = Substitute.For<IOrganisationRepository>();
     private readonly IIdentityProviderService _identityProviderService = Substitute.For<IIdentityProviderService>();
+    private readonly IEmailService _emailService = Substitute.For<IEmailService>();
 
     private readonly CreateStaffUserCommandHandler _handler;
 
     public CreateStaffUserCommandHandlerTests()
     {
-        _handler = new CreateStaffUserCommandHandler(_userRepository, _organisationRepository, _identityProviderService);
+        _handler = new CreateStaffUserCommandHandler(
+            _userRepository,
+            _organisationRepository,
+            _identityProviderService,
+            _emailService,
+            NullLogger<CreateStaffUserCommandHandler>.Instance);
     }
 
     [Fact]
@@ -51,6 +58,25 @@ public class CreateStaffUserCommandHandlerTests
         await _userRepository.Received(1).AddAsync(
             Arg.Is<UserEntity>(u => u.Email == "staff@gov.eg" && u.FullName == "Staff Member" && u.OrganisationId == orgId),
             Arg.Any<CancellationToken>());
+        await _emailService.Received(1).SendInternalUserInvitationAsync("staff@gov.eg", "Staff Member", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenEmailServiceThrows_StillReturnsCreatedUserId()
+    {
+        var orgId = Guid.NewGuid();
+        var organisation = OrganisationEntity.Create(orgId, "Test Organisation");
+        _organisationRepository.GetByIdAsync(orgId, Arg.Any<CancellationToken>()).Returns(organisation);
+        _identityProviderService.CreateUserAsync("staff@gov.eg", "Staff Member", Arg.Any<CancellationToken>()).Returns("ext-staff-1");
+        _emailService.SendInternalUserInvitationAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("SMTP unavailable"));
+
+        var command = new CreateStaffUserCommand("staff@gov.eg", "Staff Member", orgId);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.NotEqual(Guid.Empty, result);
+        await _userRepository.Received(1).AddAsync(Arg.Any<UserEntity>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/Herit.Application.Tests/Seeding/SuperAdminSeederTests.cs
+++ b/tests/Herit.Application.Tests/Seeding/SuperAdminSeederTests.cs
@@ -3,6 +3,7 @@ using Herit.Application.Seeding;
 using Herit.Domain.Enums;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using UserEntity = Herit.Domain.Entities.User;
 
 namespace Herit.Application.Tests.Seeding;
@@ -11,11 +12,12 @@ public class SuperAdminSeederTests
 {
     private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
     private readonly IIdentityProviderService _identityProviderService = Substitute.For<IIdentityProviderService>();
+    private readonly IEmailService _emailService = Substitute.For<IEmailService>();
     private readonly SuperAdminSeeder _seeder;
 
     public SuperAdminSeederTests()
     {
-        _seeder = new SuperAdminSeeder(_userRepository, _identityProviderService, NullLogger<SuperAdminSeeder>.Instance);
+        _seeder = new SuperAdminSeeder(_userRepository, _identityProviderService, _emailService, NullLogger<SuperAdminSeeder>.Instance);
     }
 
     [Fact]
@@ -34,6 +36,23 @@ public class SuperAdminSeederTests
                 u.FullName == "Super Admin" &&
                 u.Role == UserRole.SuperAdmin &&
                 u.ExternalId == "ext-super-1"),
+            Arg.Any<CancellationToken>());
+        await _emailService.Received(1).SendInternalUserInvitationAsync("admin@example.com", "Super Admin", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SeedAsync_WhenEmailServiceThrows_StillCreatesSuperAdmin()
+    {
+        _userRepository.ListAsync(Arg.Any<CancellationToken>()).Returns([]);
+        _identityProviderService.CreateUserAsync("admin@example.com", "Super Admin", Arg.Any<CancellationToken>())
+            .Returns("ext-super-1");
+        _emailService.SendInternalUserInvitationAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("SMTP unavailable"));
+
+        await _seeder.SeedAsync("admin@example.com", "Super Admin");
+
+        await _userRepository.Received(1).AddAsync(
+            Arg.Is<UserEntity>(u => u.Email == "admin@example.com"),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/Herit.Infrastructure.Tests/Services/AcsEmailServiceTests.cs
+++ b/tests/Herit.Infrastructure.Tests/Services/AcsEmailServiceTests.cs
@@ -1,0 +1,44 @@
+using Herit.Infrastructure.Services;
+using Microsoft.Extensions.Configuration;
+
+namespace Herit.Infrastructure.Tests.Services;
+
+public class AcsEmailServiceTests
+{
+    private static IConfiguration BuildConfiguration(params string[] omittedKeys)
+    {
+        var settings = new Dictionary<string, string?>
+        {
+            ["Email:AcsConnectionString"] = "endpoint=https://example.communication.azure.com/;accesskey=key",
+            ["Email:SenderAddress"] = "no-reply@example.com",
+            ["AzureAd:InviteRedirectUrl"] = "https://staff.example.com",
+        };
+
+        foreach (var key in omittedKeys)
+            settings.Remove(key);
+
+        return new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+    }
+
+    [Fact]
+    public void Constructor_WithAllRequiredSettings_Succeeds()
+    {
+        var service = new AcsEmailService(BuildConfiguration());
+
+        Assert.NotNull(service);
+    }
+
+    [Theory]
+    [InlineData("Email:AcsConnectionString")]
+    [InlineData("Email:SenderAddress")]
+    [InlineData("AzureAd:InviteRedirectUrl")]
+    public void Constructor_WithMissingSetting_Throws(string omittedKey)
+    {
+        var configuration = BuildConfiguration(omittedKey);
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => new AcsEmailService(configuration));
+
+        Assert.Equal($"{omittedKey} is not configured.", ex.Message);
+    }
+}

--- a/tests/Herit.Infrastructure.Tests/Services/LoggingEmailServiceTests.cs
+++ b/tests/Herit.Infrastructure.Tests/Services/LoggingEmailServiceTests.cs
@@ -1,0 +1,48 @@
+using Herit.Infrastructure.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Herit.Infrastructure.Tests.Services;
+
+public class LoggingEmailServiceTests
+{
+    private static IConfiguration BuildConfiguration(params string[] omittedKeys)
+    {
+        var settings = new Dictionary<string, string?>
+        {
+            ["AzureAd:InviteRedirectUrl"] = "https://staff.example.com",
+        };
+
+        foreach (var key in omittedKeys)
+            settings.Remove(key);
+
+        return new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+    }
+
+    [Fact]
+    public void Constructor_WithAllRequiredSettings_Succeeds()
+    {
+        var service = new LoggingEmailService(BuildConfiguration(), NullLogger<LoggingEmailService>.Instance);
+
+        Assert.NotNull(service);
+    }
+
+    [Fact]
+    public void Constructor_WithMissingSetting_Throws()
+    {
+        var configuration = BuildConfiguration("AzureAd:InviteRedirectUrl");
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => new LoggingEmailService(configuration, NullLogger<LoggingEmailService>.Instance));
+
+        Assert.Equal("AzureAd:InviteRedirectUrl is not configured.", ex.Message);
+    }
+
+    [Fact]
+    public async Task SendInternalUserInvitationAsync_DoesNotThrow()
+    {
+        var service = new LoggingEmailService(BuildConfiguration(), NullLogger<LoggingEmailService>.Instance);
+
+        await service.SendInternalUserInvitationAsync("user@example.com", "Test User", CancellationToken.None);
+    }
+}


### PR DESCRIPTION
## Description

Adds `IEmailService.SendInternalUserInvitationAsync(email, displayName, ct)` in `Herit.Application`, with two `Herit.Infrastructure` implementations:

- `AcsEmailService` — sends via `Azure.Communication.Email` (config: `Email:AcsConnectionString`, `Email:SenderAddress`).
- `LoggingEmailService` — logs the full email body instead of sending; registered whenever `Email:AcsConnectionString` is not configured (the Development/E2E default).

Email content: subject "You've been invited to Herit"; body explains the account is ready, links to the staff app URL (`AzureAd:InviteRedirectUrl`), and instructs the user to use **Forgot password?** to set their password (SSPR flow from #316).

The service is invoked after successful `CreateUserAsync` in `SuperAdminSeeder`, `CreateStaffUserCommandHandler`, and `CreateOrganisationAdminCommandHandler`. Email failures are caught and logged as a warning with remediation guidance — they never roll back the already-created user account.

Also adds `AzureAd:InviteRedirectUrl` to `appsettings.E2E.json` (previously absent), since `LoggingEmailService` now requires it at startup and E2E runs would otherwise fail to boot.

## Linked Issue

Closes #317

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- `dotnet build --configuration Release` succeeds.
- `dotnet test --configuration Release --no-build` — all 312 tests pass (10 new: `AcsEmailServiceTests`, `LoggingEmailServiceTests`, plus updated handler/seeder wiring tests with a mocked `IEmailService`, including failure-isolation cases).
- Handler tests assert `AddAsync`/return value still succeed when the mocked `IEmailService` throws.

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)