### PR TITLE
Document both Google OAuth redirect URI forms for Entra

### DIFF
--- a/docs/ops/entra-external-id-setup.md
+++ b/docs/ops/entra-external-id-setup.md
@@ -30,7 +30,9 @@ Associate each user flow with its app registration under **User flows → \<flow
 - The signed-in principal must have the following Microsoft Graph API permissions on the tenant:
   - `Application.ReadWrite.All`
   - `IdentityProvider.ReadWrite.All`
-- A Google OAuth 2.0 client ID and secret (created in the Google Cloud Console with the Entra External ID redirect URI whitelisted: `https://<tenant>.ciamlogin.com/<tenant>.onmicrosoft.com/federation/oauth2`).
+- A Google OAuth 2.0 client ID and secret, created in the Google Cloud Console with **both** Entra External ID redirect URI forms whitelisted (Entra may send either, depending on how the authority is referenced; Google matches exactly):
+  - `https://<tenant>.ciamlogin.com/<tenant>.onmicrosoft.com/federation/oauth2`
+  - `https://<tenant>.ciamlogin.com/<tenant-id-GUID>/federation/oauth2`
 
 ---
 


### PR DESCRIPTION
## Description

Updates the Google OAuth prerequisite in `docs/ops/entra-external-id-setup.md` to whitelist **both** Entra External ID federation redirect URI forms — the `onmicrosoft.com`-domain form and the tenant-GUID form. Entra may send either depending on how the authority is referenced, and Google matches redirect URIs exactly, so listing only one causes `redirect_uri_mismatch` during Google sign-in.

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [x] Documentation
- [ ] Chore / refactor

## Testing Notes

Docs-only change; no code affected.

## Checklist

- [x] Code builds cleanly (`dotnet build`) — n/a, docs only
- [x] Tests pass (`dotnet test`) — n/a, docs only
- [x] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)