### PR TITLE
Pass VITE_STAFF_REDIRECT_URI and VITE_PORTAL_URL to azd deploy

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -257,6 +257,10 @@ jobs:
         env:
           VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
           VITE_REDIRECT_URI: ${{ secrets.VITE_REDIRECT_URI }}
+          # Staff app's own redirect URI + link back to the public portal
+          # (referenced by azure.yaml's staff service env block).
+          VITE_STAFF_REDIRECT_URI: ${{ secrets.VITE_STAFF_REDIRECT_URI }}
+          VITE_PORTAL_URL: ${{ secrets.VITE_PORTAL_URL }}
           VITE_AZURE_AUTHORITY: ${{ secrets.VITE_AZURE_AUTHORITY }}
           VITE_AZURE_TENANT_NAME: ${{ secrets.VITE_AZURE_TENANT_NAME }}
           # Per-app SPA client ids + the shared API client id (azd maps these to


### PR DESCRIPTION
## Description

Passes `VITE_STAFF_REDIRECT_URI` and `VITE_PORTAL_URL` secrets through to the azd deploy step so the staff app's own redirect URI and the link back to the public portal are available at build time (referenced by azure.yaml's staff service env block).

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Chore / refactor

## Testing Notes

Workflow-only change; no local build/test applicable. Will be verified by the next azd deploy run in CI.

## Checklist

- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)