### PR TITLE
Fix Google sign-in: bake CI client id into vite build directly

### DIFF
--- a/frontend/portal/package-lock.json
+++ b/frontend/portal/package-lock.json
@@ -28,6 +28,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.1.0",
         "@testing-library/user-event": "^14.5.2",
+        "@types/node": "^26.1.1",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
         "@vitejs/plugin-react": "^4.3.4",
@@ -2169,6 +2170,15 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -4473,6 +4483,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/frontend/portal/package.json
+++ b/frontend/portal/package.json
@@ -35,6 +35,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",
+    "@types/node": "^26.1.1",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^4.3.4",

--- a/frontend/portal/vite.config.ts
+++ b/frontend/portal/vite.config.ts
@@ -1,8 +1,20 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
+// CI/azd provides per-app values under app-specific names (VITE_PORTAL_*); the code
+// reads generic names (VITE_AZURE_CLIENT_ID). azure.yaml's `env:` blocks are NOT
+// honored by azd, so the rename must happen here. Only applied when the CI var is
+// set, so local dev via .env.local is unaffected.
+const ciDefines: Record<string, string> = {};
+if (process.env.VITE_PORTAL_AZURE_CLIENT_ID) {
+  ciDefines['import.meta.env.VITE_AZURE_CLIENT_ID'] = JSON.stringify(
+    process.env.VITE_PORTAL_AZURE_CLIENT_ID,
+  );
+}
+
 export default defineConfig({
   plugins: [react()],
+  define: ciDefines,
   test: {
     globals: true,
     environment: 'jsdom',

--- a/frontend/staff/package-lock.json
+++ b/frontend/staff/package-lock.json
@@ -21,6 +21,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.1.0",
         "@testing-library/user-event": "^14.5.2",
+        "@types/node": "^26.1.1",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
         "@vitejs/plugin-react": "^4.3.4",
@@ -1518,6 +1519,15 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -3729,6 +3739,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/frontend/staff/package.json
+++ b/frontend/staff/package.json
@@ -28,6 +28,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",
+    "@types/node": "^26.1.1",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^4.3.4",

--- a/frontend/staff/vite.config.ts
+++ b/frontend/staff/vite.config.ts
@@ -1,8 +1,25 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
+// CI/azd provides per-app values under app-specific names (VITE_STAFF_*); the code
+// reads generic names (VITE_AZURE_CLIENT_ID / VITE_REDIRECT_URI). azure.yaml's
+// `env:` blocks are NOT honored by azd, so the rename must happen here. Only applied
+// when the CI var is set, so local dev via .env.local is unaffected.
+const ciDefines: Record<string, string> = {};
+if (process.env.VITE_STAFF_AZURE_CLIENT_ID) {
+  ciDefines['import.meta.env.VITE_AZURE_CLIENT_ID'] = JSON.stringify(
+    process.env.VITE_STAFF_AZURE_CLIENT_ID,
+  );
+}
+if (process.env.VITE_STAFF_REDIRECT_URI) {
+  ciDefines['import.meta.env.VITE_REDIRECT_URI'] = JSON.stringify(
+    process.env.VITE_STAFF_REDIRECT_URI,
+  );
+}
+
 export default defineConfig({
   plugins: [react()],
+  define: ciDefines,
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Description

Root-causes and fixes the missing "Sign in with Google" button on the deployed portal login page.

`azure.yaml`'s per-app `env:` blocks (e.g. `VITE_PORTAL_AZURE_CLIENT_ID` -> `VITE_AZURE_CLIENT_ID`) are **not honored by `azd deploy`** — azd resolves `${VAR}` expressions in `azure.yaml` against its own environment store, which gets overwritten by Bicep outputs on every `azd provision` run, not the raw GitHub Actions secrets passed as process env to the deploy step. Confirmed by pulling the live deployed bundle and finding `clientId: void 0` baked into it, even after correcting the relevant GitHub secret.

Fix: each `vite.config.ts` now reads the CI-provided app-specific env var directly via `process.env` and injects it into `import.meta.env` using esbuild's `define`, bypassing azd's substitution entirely.

- `frontend/portal/vite.config.ts`: defines `VITE_AZURE_CLIENT_ID` from `VITE_PORTAL_AZURE_CLIENT_ID` when present
- `frontend/staff/vite.config.ts`: defines `VITE_AZURE_CLIENT_ID` from `VITE_STAFF_AZURE_CLIENT_ID` and `VITE_REDIRECT_URI` from `VITE_STAFF_REDIRECT_URI` when present
- Both are no-ops locally (`.env.local` still drives dev), only kick in when the CI var is set
- Added `@types/node` to both apps (required for the `process` global in `vite.config.ts`; build previously failed with `TS2580: Cannot find name 'process'`)

## Linked Issue

N/A — no tracked issue, this closes out the "Sign in with Google" investigation from this session.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Chore / refactor

## Testing Notes

- `npm run build` in both apps: passes (previously failed on `process` typing before adding `@types/node`)
- `npm run build` with `VITE_PORTAL_AZURE_CLIENT_ID` / `VITE_STAFF_AZURE_CLIENT_ID` / `VITE_STAFF_REDIRECT_URI` set: confirmed via `grep` on the built bundle that `clientId`/`redirectUri` are correctly baked in (previously `clientId:""` without the var, `clientId:"<value>"` with it)
- `npm run test:run` in both apps: portal 5/5 passed, staff 75/75 passed

## Checklist

- [x] Code builds cleanly (`dotnet build`)
- [x] Tests pass (`dotnet test`)
- [ ] Relevant documentation updated
- [x] Branch follows naming convention (`feature/`, `fix/`, `docs/`, `chore/`)